### PR TITLE
style: fix yamllint violations

### DIFF
--- a/kubernetes/apps/cloudflare-tunnels/deployment.yaml
+++ b/kubernetes/apps/cloudflare-tunnels/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   selector:
     matchLabels:
       app: cloudflared
-  replicas: 2 # You could also consider elastic scaling for this deployment
+  replicas: 2  # You could also consider elastic scaling for this deployment
   template:
     metadata:
       labels:

--- a/kubernetes/clusters/production/flux-system/gotk-components.yaml
+++ b/kubernetes/clusters/production/flux-system/gotk-components.yaml
@@ -24,14 +24,14 @@ metadata:
   namespace: flux-system
 spec:
   egress:
-  - {}
+    - {}
   ingress:
-  - from:
-    - podSelector: {}
+    - from:
+        - podSelector: {}
   podSelector: {}
   policyTypes:
-  - Ingress
-  - Egress
+    - Ingress
+    - Egress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -44,14 +44,14 @@ metadata:
   namespace: flux-system
 spec:
   ingress:
-  - from:
-    - namespaceSelector: {}
-    ports:
-    - port: 8080
-      protocol: TCP
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 8080
+          protocol: TCP
   podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -64,13 +64,13 @@ metadata:
   namespace: flux-system
 spec:
   ingress:
-  - from:
-    - namespaceSelector: {}
+    - from:
+        - namespaceSelector: {}
   podSelector:
     matchLabels:
       app: notification-controller
   policyTypes:
-  - Ingress
+    - Ingress
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -86,11 +86,11 @@ spec:
     pods: "1000"
   scopeSelector:
     matchExpressions:
-    - operator: In
-      scopeName: PriorityClass
-      values:
-      - system-node-critical
-      - system-cluster-critical
+      - operator: In
+        scopeName: PriorityClass
+        values:
+          - system-node-critical
+          - system-cluster-critical
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -101,102 +101,102 @@ metadata:
     app.kubernetes.io/version: v2.8.6
   name: crd-controller-flux-system
 rules:
-- apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - kustomize.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - helm.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - notification.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - image.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - source.extensions.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - secrets
-  - configmaps
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps/status
-  verbs:
-  - get
-  - update
-  - patch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts/token
-  verbs:
-  - create
-- nonResourceURLs:
-  - /livez/ping
-  verbs:
-  - head
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - image.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - source.extensions.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+      - configmaps
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - nonResourceURLs:
+      - /livez/ping
+    verbs:
+      - head
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -209,21 +209,21 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: flux-edit-flux-system
 rules:
-- apiGroups:
-  - notification.toolkit.fluxcd.io
-  - source.toolkit.fluxcd.io
-  - source.extensions.fluxcd.io
-  - helm.toolkit.fluxcd.io
-  - image.toolkit.fluxcd.io
-  - kustomize.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - source.extensions.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -237,19 +237,19 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: flux-view-flux-system
 rules:
-- apiGroups:
-  - notification.toolkit.fluxcd.io
-  - source.toolkit.fluxcd.io
-  - source.extensions.fluxcd.io
-  - helm.toolkit.fluxcd.io
-  - image.toolkit.fluxcd.io
-  - kustomize.toolkit.fluxcd.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - source.extensions.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -264,12 +264,12 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: kustomize-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: helm-controller
-  namespace: flux-system
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: flux-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -284,27 +284,27 @@ roleRef:
   kind: ClusterRole
   name: crd-controller-flux-system
 subjects:
-- kind: ServiceAccount
-  name: kustomize-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: helm-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: source-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: notification-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: image-reflector-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: image-automation-controller
-  namespace: flux-system
-- kind: ServiceAccount
-  name: source-watcher
-  namespace: flux-system
+  - kind: ServiceAccount
+    name: kustomize-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: helm-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: source-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: notification-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: image-reflector-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: image-automation-controller
+    namespace: flux-system
+  - kind: ServiceAccount
+    name: source-watcher
+    namespace: flux-system
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -326,938 +326,237 @@ spec:
     singular: bucket
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.endpoint
-      name: Endpoint
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Bucket is the Schema for the buckets API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              BucketSpec specifies the required configuration to produce an Artifact for
-              an object storage bucket.
-            properties:
-              bucketName:
-                description: BucketName is the name of the object storage bucket.
-                type: string
-              certSecretRef:
-                description: |-
-                  CertSecretRef can be given the name of a Secret containing
-                  either or both of
-
-                  - a PEM-encoded client certificate (`tls.crt`) and private
-                  key (`tls.key`);
-                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                  and whichever are supplied, will be used for connecting to the
-                  bucket. The client cert and key are useful if you are
-                  authenticating with a certificate; the CA cert is useful if
-                  you are using a self-signed server certificate. The Secret must
-                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                  This field is only supported for the `generic` provider.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              endpoint:
-                description: Endpoint is the object storage address the BucketName
-                  is located at.
-                type: string
-              ignore:
-                description: |-
-                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                  (which is the same as .gitignore). If not provided, a default will be used,
-                  consult the documentation for your version to find out what those are.
-                type: string
-              insecure:
-                description: Insecure allows connecting to a non-TLS HTTP Endpoint.
-                type: boolean
-              interval:
-                description: |-
-                  Interval at which the Bucket Endpoint is checked for updates.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              prefix:
-                description: Prefix to use for server-side filtering of files in the
-                  Bucket.
-                type: string
-              provider:
-                default: generic
-                description: |-
-                  Provider of the object storage bucket.
-                  Defaults to 'generic', which expects an S3 (API) compatible object
-                  storage.
-                enum:
-                - generic
-                - aws
-                - gcp
-                - azure
-                type: string
-              proxySecretRef:
-                description: |-
-                  ProxySecretRef specifies the Secret containing the proxy configuration
-                  to use while communicating with the Bucket server.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              region:
-                description: Region of the Endpoint where the BucketName is located
-                  in.
-                type: string
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing authentication credentials
-                  for the Bucket.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                  the bucket. This field is only supported for the 'gcp' and 'aws' providers.
-                  For more information about workload identity:
-                  https://fluxcd.io/flux/components/source/buckets/#workload-identity
-                type: string
-              sts:
-                description: |-
-                  STS specifies the required configuration to use a Security Token
-                  Service for fetching temporary credentials to authenticate in a
-                  Bucket provider.
-
-                  This field is only supported for the `aws` and `generic` providers.
-                properties:
-                  certSecretRef:
-                    description: |-
-                      CertSecretRef can be given the name of a Secret containing
-                      either or both of
-
-                      - a PEM-encoded client certificate (`tls.crt`) and private
-                      key (`tls.key`);
-                      - a PEM-encoded CA certificate (`ca.crt`)
-
-                      and whichever are supplied, will be used for connecting to the
-                      STS endpoint. The client cert and key are useful if you are
-                      authenticating with a certificate; the CA cert is useful if
-                      you are using a self-signed server certificate. The Secret must
-                      be of type `Opaque` or `kubernetes.io/tls`.
-
-                      This field is only supported for the `ldap` provider.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  endpoint:
-                    description: |-
-                      Endpoint is the HTTP/S endpoint of the Security Token Service from
-                      where temporary credentials will be fetched.
-                    pattern: ^(http|https)://.*$
-                    type: string
-                  provider:
-                    description: Provider of the Security Token Service.
-                    enum:
-                    - aws
-                    - ldap
-                    type: string
-                  secretRef:
-                    description: |-
-                      SecretRef specifies the Secret containing authentication credentials
-                      for the STS endpoint. This Secret must contain the fields `username`
-                      and `password` and is supported only for the `ldap` provider.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                required:
-                - endpoint
-                - provider
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend the reconciliation of this
-                  Bucket.
-                type: boolean
-              timeout:
-                default: 60s
-                description: Timeout for fetch operations, defaults to 60s.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-            required:
-            - bucketName
-            - endpoint
-            - interval
-            type: object
-            x-kubernetes-validations:
-            - message: STS configuration is only supported for the 'aws' and 'generic'
-                Bucket providers
-              rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
-            - message: '''aws'' is the only supported STS provider for the ''aws''
-                Bucket provider'
-              rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider
-                == 'aws'
-            - message: '''ldap'' is the only supported STS provider for the ''generic''
-                Bucket provider'
-              rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider
-                == 'ldap'
-            - message: spec.sts.secretRef is not required for the 'aws' STS provider
-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
-            - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
-              rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
-            - message: ServiceAccountName is not supported for the 'generic' Bucket
-                provider
-              rule: self.provider != 'generic' || !has(self.serviceAccountName)
-            - message: cannot set both .spec.secretRef and .spec.serviceAccountName
-              rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
-          status:
-            default:
-              observedGeneration: -1
-            description: BucketStatus records the observed state of a Bucket.
-            properties:
-              artifact:
-                description: Artifact represents the last successful Bucket reconciliation.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the Bucket.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation of
-                  the Bucket object.
-                format: int64
-                type: integer
-              observedIgnore:
-                description: |-
-                  ObservedIgnore is the observed exclusion patterns used for constructing
-                  the source artifact.
-                type: string
-              url:
-                description: |-
-                  URL is the dynamic fetch link for the latest Artifact.
-                  It is provided on a "best effort" basis, and using the precise
-                  BucketStatus.Artifact data is recommended.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-  labels:
-    app.kubernetes.io/component: source-controller
-    app.kubernetes.io/instance: flux-system
-    app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v2.8.6
-  name: externalartifacts.source.toolkit.fluxcd.io
-spec:
-  group: source.toolkit.fluxcd.io
-  names:
-    kind: ExternalArtifact
-    listKind: ExternalArtifactList
-    plural: externalartifacts
-    singular: externalartifact
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .spec.sourceRef.name
-      name: Source
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ExternalArtifact is the Schema for the external artifacts API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ExternalArtifactSpec defines the desired state of ExternalArtifact
-            properties:
-              sourceRef:
-                description: |-
-                  SourceRef points to the Kubernetes custom resource for
-                  which the artifact is generated.
-                properties:
-                  apiVersion:
-                    description: API version of the referent, if not specified the
-                      Kubernetes preferred version will be used.
-                    type: string
-                  kind:
-                    description: Kind of the referent.
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    type: string
-                  namespace:
-                    description: Namespace of the referent, when not specified it
-                      acts as LocalObjectReference.
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-            type: object
-          status:
-            description: ExternalArtifactStatus defines the observed state of ExternalArtifact
-            properties:
-              artifact:
-                description: Artifact represents the output of an ExternalArtifact
-                  reconciliation.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the ExternalArtifact.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
-  labels:
-    app.kubernetes.io/component: source-controller
-    app.kubernetes.io/instance: flux-system
-    app.kubernetes.io/part-of: flux
-    app.kubernetes.io/version: v2.8.6
-  name: gitrepositories.source.toolkit.fluxcd.io
-spec:
-  group: source.toolkit.fluxcd.io
-  names:
-    kind: GitRepository
-    listKind: GitRepositoryList
-    plural: gitrepositories
-    shortNames:
-    - gitrepo
-    singular: gitrepository
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: GitRepository is the Schema for the gitrepositories API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              GitRepositorySpec specifies the required configuration to produce an
-              Artifact for a Git repository.
-            properties:
-              ignore:
-                description: |-
-                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                  (which is the same as .gitignore). If not provided, a default will be used,
-                  consult the documentation for your version to find out what those are.
-                type: string
-              include:
-                description: |-
-                  Include specifies a list of GitRepository resources which Artifacts
-                  should be included in the Artifact produced for this GitRepository.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.endpoint
+          name: Endpoint
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Bucket is the Schema for the buckets API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                BucketSpec specifies the required configuration to produce an Artifact for
+                an object storage bucket.
+              properties:
+                bucketName:
+                  description: BucketName is the name of the object storage bucket.
+                  type: string
+                certSecretRef:
                   description: |-
-                    GitRepositoryInclude specifies a local reference to a GitRepository which
-                    Artifact (sub-)contents must be included, and where they should be placed.
+                    CertSecretRef can be given the name of a Secret containing
+                    either or both of
+
+                    - a PEM-encoded client certificate (`tls.crt`) and private
+                    key (`tls.key`);
+                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                    and whichever are supplied, will be used for connecting to the
+                    bucket. The client cert and key are useful if you are
+                    authenticating with a certificate; the CA cert is useful if
+                    you are using a self-signed server certificate. The Secret must
+                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                    This field is only supported for the `generic` provider.
                   properties:
-                    fromPath:
-                      description: |-
-                        FromPath specifies the path to copy contents from, defaults to the root
-                        of the Artifact.
+                    name:
+                      description: Name of the referent.
                       type: string
-                    repository:
+                  required:
+                    - name
+                  type: object
+                endpoint:
+                  description: Endpoint is the object storage address the BucketName is located at.
+                  type: string
+                ignore:
+                  description: |-
+                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                    (which is the same as .gitignore). If not provided, a default will be used,
+                    consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS HTTP Endpoint.
+                  type: boolean
+                interval:
+                  description: |-
+                    Interval at which the Bucket Endpoint is checked for updates.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                prefix:
+                  description: Prefix to use for server-side filtering of files in the Bucket.
+                  type: string
+                provider:
+                  default: generic
+                  description: |-
+                    Provider of the object storage bucket.
+                    Defaults to 'generic', which expects an S3 (API) compatible object
+                    storage.
+                  enum:
+                    - generic
+                    - aws
+                    - gcp
+                    - azure
+                  type: string
+                proxySecretRef:
+                  description: |-
+                    ProxySecretRef specifies the Secret containing the proxy configuration
+                    to use while communicating with the Bucket server.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                region:
+                  description: Region of the Endpoint where the BucketName is located in.
+                  type: string
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing authentication credentials
+                    for the Bucket.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                    the bucket. This field is only supported for the 'gcp' and 'aws' providers.
+                    For more information about workload identity:
+                    https://fluxcd.io/flux/components/source/buckets/#workload-identity
+                  type: string
+                sts:
+                  description: |-
+                    STS specifies the required configuration to use a Security Token
+                    Service for fetching temporary credentials to authenticate in a
+                    Bucket provider.
+
+                    This field is only supported for the `aws` and `generic` providers.
+                  properties:
+                    certSecretRef:
                       description: |-
-                        GitRepositoryRef specifies the GitRepository which Artifact contents
-                        must be included.
+                        CertSecretRef can be given the name of a Secret containing
+                        either or both of
+
+                        - a PEM-encoded client certificate (`tls.crt`) and private
+                        key (`tls.key`);
+                        - a PEM-encoded CA certificate (`ca.crt`)
+
+                        and whichever are supplied, will be used for connecting to the
+                        STS endpoint. The client cert and key are useful if you are
+                        authenticating with a certificate; the CA cert is useful if
+                        you are using a self-signed server certificate. The Secret must
+                        be of type `Opaque` or `kubernetes.io/tls`.
+
+                        This field is only supported for the `ldap` provider.
                       properties:
                         name:
                           description: Name of the referent.
                           type: string
                       required:
-                      - name
+                        - name
                       type: object
-                    toPath:
+                    endpoint:
                       description: |-
-                        ToPath specifies the path to copy contents to, defaults to the name of
-                        the GitRepositoryRef.
+                        Endpoint is the HTTP/S endpoint of the Security Token Service from
+                        where temporary credentials will be fetched.
+                      pattern: ^(http|https)://.*$
                       type: string
-                  required:
-                  - repository
-                  type: object
-                type: array
-              interval:
-                description: |-
-                  Interval at which the GitRepository URL is checked for updates.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              provider:
-                description: |-
-                  Provider used for authentication, can be 'azure', 'github', 'generic'.
-                  When not specified, defaults to 'generic'.
-                enum:
-                - generic
-                - azure
-                - github
-                type: string
-              proxySecretRef:
-                description: |-
-                  ProxySecretRef specifies the Secret containing the proxy configuration
-                  to use while communicating with the Git server.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              recurseSubmodules:
-                description: |-
-                  RecurseSubmodules enables the initialization of all submodules within
-                  the GitRepository as cloned from the URL, using their default settings.
-                type: boolean
-              ref:
-                description: |-
-                  Reference specifies the Git reference to resolve and monitor for
-                  changes, defaults to the 'master' branch.
-                properties:
-                  branch:
-                    description: Branch to check out, defaults to 'master' if no other
-                      field is defined.
-                    type: string
-                  commit:
-                    description: |-
-                      Commit SHA to check out, takes precedence over all reference fields.
-
-                      This can be combined with Branch to shallow clone the branch, in which
-                      the commit is expected to exist.
-                    type: string
-                  name:
-                    description: |-
-                      Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
-
-                      It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
-                      Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
-                    type: string
-                  semver:
-                    description: SemVer tag expression to check out, takes precedence
-                      over Tag.
-                    type: string
-                  tag:
-                    description: Tag to check out, takes precedence over Branch.
-                    type: string
-                type: object
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing authentication credentials for
-                  the GitRepository.
-                  For HTTPS repositories the Secret must contain 'username' and 'password'
-                  fields for basic auth or 'bearerToken' field for token auth.
-                  For SSH repositories the Secret must contain 'identity'
-                  and 'known_hosts' fields.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                  authenticate to the GitRepository. This field is only supported for 'azure' provider.
-                type: string
-              sparseCheckout:
-                description: |-
-                  SparseCheckout specifies a list of directories to checkout when cloning
-                  the repository. If specified, only these directories are included in the
-                  Artifact produced for this GitRepository.
-                items:
-                  type: string
-                type: array
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend the reconciliation of this
-                  GitRepository.
-                type: boolean
-              timeout:
-                default: 60s
-                description: Timeout for Git operations like cloning, defaults to
-                  60s.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-              url:
-                description: URL specifies the Git repository URL, it can be an HTTP/S
-                  or SSH address.
-                pattern: ^(http|https|ssh)://.*$
-                type: string
-              verify:
-                description: |-
-                  Verification specifies the configuration to verify the Git commit
-                  signature(s).
-                properties:
-                  mode:
-                    default: HEAD
-                    description: |-
-                      Mode specifies which Git object(s) should be verified.
-
-                      The variants "head" and "HEAD" both imply the same thing, i.e. verify
-                      the commit that the HEAD of the Git repository points to. The variant
-                      "head" solely exists to ensure backwards compatibility.
-                    enum:
-                    - head
-                    - HEAD
-                    - Tag
-                    - TagAndHEAD
-                    type: string
-                  secretRef:
-                    description: |-
-                      SecretRef specifies the Secret containing the public keys of trusted Git
-                      authors.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                required:
-                - secretRef
-                type: object
-            required:
-            - interval
-            - url
-            type: object
-            x-kubernetes-validations:
-            - message: serviceAccountName can only be set when provider is 'azure'
-              rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider
-                == ''azure'')'
-          status:
-            default:
-              observedGeneration: -1
-            description: GitRepositoryStatus records the observed state of a Git repository.
-            properties:
-              artifact:
-                description: Artifact represents the last successful GitRepository
-                  reconciliation.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the GitRepository.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                    provider:
+                      description: Provider of the Security Token Service.
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                        - aws
+                        - ldap
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
+                    secretRef:
+                      description: |-
+                        SecretRef specifies the Secret containing authentication credentials
+                        for the STS endpoint. This Secret must contain the fields `username`
+                        and `password` and is supported only for the `ldap` provider.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - endpoint
+                    - provider
                   type: object
-                type: array
-              includedArtifacts:
-                description: |-
-                  IncludedArtifacts contains a list of the last successfully included
-                  Artifacts as instructed by GitRepositorySpec.Include.
-                items:
-                  description: Artifact represents the output of a Source reconciliation.
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend the reconciliation of this
+                    Bucket.
+                  type: boolean
+                timeout:
+                  default: 60s
+                  description: Timeout for fetch operations, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+              required:
+                - bucketName
+                - endpoint
+                - interval
+              type: object
+              x-kubernetes-validations:
+                - message: STS configuration is only supported for the 'aws' and 'generic' Bucket providers
+                  rule: self.provider == 'aws' || self.provider == 'generic' || !has(self.sts)
+                - message: '''aws'' is the only supported STS provider for the ''aws'' Bucket provider'
+                  rule: self.provider != 'aws' || !has(self.sts) || self.sts.provider == 'aws'
+                - message: '''ldap'' is the only supported STS provider for the ''generic'' Bucket provider'
+                  rule: self.provider != 'generic' || !has(self.sts) || self.sts.provider == 'ldap'
+                - message: spec.sts.secretRef is not required for the 'aws' STS provider
+                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.secretRef)'
+                - message: spec.sts.certSecretRef is not required for the 'aws' STS provider
+                  rule: '!has(self.sts) || self.sts.provider != ''aws'' || !has(self.sts.certSecretRef)'
+                - message: ServiceAccountName is not supported for the 'generic' Bucket provider
+                  rule: self.provider != 'generic' || !has(self.serviceAccountName)
+                - message: cannot set both .spec.secretRef and .spec.serviceAccountName
+                  rule: '!has(self.secretRef) || !has(self.serviceAccountName)'
+            status:
+              default:
+                observedGeneration: -1
+              description: BucketStatus records the observed state of a Bucket.
+              properties:
+                artifact:
+                  description: Artifact represents the last successful Bucket reconciliation.
                   properties:
                     digest:
-                      description: Digest is the digest of the file in the form of
-                        '<algorithm>:<checksum>'.
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
                       pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
                       type: string
                     lastUpdateTime:
@@ -1269,8 +568,7 @@ spec:
                     metadata:
                       additionalProperties:
                         type: string
-                      description: Metadata holds upstream information such as OCI
-                        annotations.
+                      description: Metadata holds upstream information such as OCI annotations.
                       type: object
                     path:
                       description: |-
@@ -1294,87 +592,765 @@ spec:
                         consumption, e.g. by another controller applying the Artifact contents.
                       type: string
                   required:
-                  - digest
-                  - lastUpdateTime
-                  - path
-                  - revision
-                  - url
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: |-
-                  ObservedGeneration is the last observed generation of the GitRepository
-                  object.
-                format: int64
-                type: integer
-              observedIgnore:
-                description: |-
-                  ObservedIgnore is the observed exclusion patterns used for constructing
-                  the source artifact.
-                type: string
-              observedInclude:
-                description: |-
-                  ObservedInclude is the observed list of GitRepository resources used to
-                  produce the current Artifact.
-                items:
+                conditions:
+                  description: Conditions holds the conditions for the Bucket.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
                   description: |-
-                    GitRepositoryInclude specifies a local reference to a GitRepository which
-                    Artifact (sub-)contents must be included, and where they should be placed.
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation of the Bucket object.
+                  format: int64
+                  type: integer
+                observedIgnore:
+                  description: |-
+                    ObservedIgnore is the observed exclusion patterns used for constructing
+                    the source artifact.
+                  type: string
+                url:
+                  description: |-
+                    URL is the dynamic fetch link for the latest Artifact.
+                    It is provided on a "best effort" basis, and using the precise
+                    BucketStatus.Artifact data is recommended.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    app.kubernetes.io/component: source-controller
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: v2.8.6
+  name: externalartifacts.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: ExternalArtifact
+    listKind: ExternalArtifactList
+    plural: externalartifacts
+    singular: externalartifact
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ExternalArtifact is the Schema for the external artifacts API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalArtifactSpec defines the desired state of ExternalArtifact
+              properties:
+                sourceRef:
+                  description: |-
+                    SourceRef points to the Kubernetes custom resource for
+                    which the artifact is generated.
                   properties:
-                    fromPath:
-                      description: |-
-                        FromPath specifies the path to copy contents from, defaults to the root
-                        of the Artifact.
+                    apiVersion:
+                      description: API version of the referent, if not specified the Kubernetes preferred version will be used.
                       type: string
-                    repository:
+                    kind:
+                      description: Kind of the referent.
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      type: string
+                    namespace:
+                      description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+              type: object
+            status:
+              description: ExternalArtifactStatus defines the observed state of ExternalArtifact
+              properties:
+                artifact:
+                  description: Artifact represents the output of an ExternalArtifact reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
                       description: |-
-                        GitRepositoryRef specifies the GitRepository which Artifact contents
-                        must be included.
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the ExternalArtifact.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    app.kubernetes.io/component: source-controller
+    app.kubernetes.io/instance: flux-system
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/version: v2.8.6
+  name: gitrepositories.source.toolkit.fluxcd.io
+spec:
+  group: source.toolkit.fluxcd.io
+  names:
+    kind: GitRepository
+    listKind: GitRepositoryList
+    plural: gitrepositories
+    shortNames:
+      - gitrepo
+    singular: gitrepository
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: GitRepository is the Schema for the gitrepositories API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                GitRepositorySpec specifies the required configuration to produce an
+                Artifact for a Git repository.
+              properties:
+                ignore:
+                  description: |-
+                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                    (which is the same as .gitignore). If not provided, a default will be used,
+                    consult the documentation for your version to find out what those are.
+                  type: string
+                include:
+                  description: |-
+                    Include specifies a list of GitRepository resources which Artifacts
+                    should be included in the Artifact produced for this GitRepository.
+                  items:
+                    description: |-
+                      GitRepositoryInclude specifies a local reference to a GitRepository which
+                      Artifact (sub-)contents must be included, and where they should be placed.
+                    properties:
+                      fromPath:
+                        description: |-
+                          FromPath specifies the path to copy contents from, defaults to the root
+                          of the Artifact.
+                        type: string
+                      repository:
+                        description: |-
+                          GitRepositoryRef specifies the GitRepository which Artifact contents
+                          must be included.
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      toPath:
+                        description: |-
+                          ToPath specifies the path to copy contents to, defaults to the name of
+                          the GitRepositoryRef.
+                        type: string
+                    required:
+                      - repository
+                    type: object
+                  type: array
+                interval:
+                  description: |-
+                    Interval at which the GitRepository URL is checked for updates.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                provider:
+                  description: |-
+                    Provider used for authentication, can be 'azure', 'github', 'generic'.
+                    When not specified, defaults to 'generic'.
+                  enum:
+                    - generic
+                    - azure
+                    - github
+                  type: string
+                proxySecretRef:
+                  description: |-
+                    ProxySecretRef specifies the Secret containing the proxy configuration
+                    to use while communicating with the Git server.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                recurseSubmodules:
+                  description: |-
+                    RecurseSubmodules enables the initialization of all submodules within
+                    the GitRepository as cloned from the URL, using their default settings.
+                  type: boolean
+                ref:
+                  description: |-
+                    Reference specifies the Git reference to resolve and monitor for
+                    changes, defaults to the 'master' branch.
+                  properties:
+                    branch:
+                      description: Branch to check out, defaults to 'master' if no other field is defined.
+                      type: string
+                    commit:
+                      description: |-
+                        Commit SHA to check out, takes precedence over all reference fields.
+
+                        This can be combined with Branch to shallow clone the branch, in which
+                        the commit is expected to exist.
+                      type: string
+                    name:
+                      description: |-
+                        Name of the reference to check out; takes precedence over Branch, Tag and SemVer.
+
+                        It must be a valid Git reference: https://git-scm.com/docs/git-check-ref-format#_description
+                        Examples: "refs/heads/main", "refs/tags/v0.1.0", "refs/pull/420/head", "refs/merge-requests/1/head"
+                      type: string
+                    semver:
+                      description: SemVer tag expression to check out, takes precedence over Tag.
+                      type: string
+                    tag:
+                      description: Tag to check out, takes precedence over Branch.
+                      type: string
+                  type: object
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing authentication credentials for
+                    the GitRepository.
+                    For HTTPS repositories the Secret must contain 'username' and 'password'
+                    fields for basic auth or 'bearerToken' field for token auth.
+                    For SSH repositories the Secret must contain 'identity'
+                    and 'known_hosts' fields.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                    authenticate to the GitRepository. This field is only supported for 'azure' provider.
+                  type: string
+                sparseCheckout:
+                  description: |-
+                    SparseCheckout specifies a list of directories to checkout when cloning
+                    the repository. If specified, only these directories are included in the
+                    Artifact produced for this GitRepository.
+                  items:
+                    type: string
+                  type: array
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend the reconciliation of this
+                    GitRepository.
+                  type: boolean
+                timeout:
+                  default: 60s
+                  description: Timeout for Git operations like cloning, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+                url:
+                  description: URL specifies the Git repository URL, it can be an HTTP/S or SSH address.
+                  pattern: ^(http|https|ssh)://.*$
+                  type: string
+                verify:
+                  description: |-
+                    Verification specifies the configuration to verify the Git commit
+                    signature(s).
+                  properties:
+                    mode:
+                      default: HEAD
+                      description: |-
+                        Mode specifies which Git object(s) should be verified.
+
+                        The variants "head" and "HEAD" both imply the same thing, i.e. verify
+                        the commit that the HEAD of the Git repository points to. The variant
+                        "head" solely exists to ensure backwards compatibility.
+                      enum:
+                        - head
+                        - HEAD
+                        - Tag
+                        - TagAndHEAD
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretRef specifies the Secret containing the public keys of trusted Git
+                        authors.
                       properties:
                         name:
                           description: Name of the referent.
                           type: string
                       required:
-                      - name
+                        - name
                       type: object
-                    toPath:
+                  required:
+                    - secretRef
+                  type: object
+              required:
+                - interval
+                - url
+              type: object
+              x-kubernetes-validations:
+                - message: serviceAccountName can only be set when provider is 'azure'
+                  rule: '!has(self.serviceAccountName) || (has(self.provider) && self.provider == ''azure'')'
+            status:
+              default:
+                observedGeneration: -1
+              description: GitRepositoryStatus records the observed state of a Git repository.
+              properties:
+                artifact:
+                  description: Artifact represents the last successful GitRepository reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
                       description: |-
-                        ToPath specifies the path to copy contents to, defaults to the name of
-                        the GitRepositoryRef.
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
                       type: string
                   required:
-                  - repository
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
                   type: object
-                type: array
-              observedRecurseSubmodules:
-                description: |-
-                  ObservedRecurseSubmodules is the observed resource submodules
-                  configuration used to produce the current Artifact.
-                type: boolean
-              observedSparseCheckout:
-                description: |-
-                  ObservedSparseCheckout is the observed list of directories used to
-                  produce the current Artifact.
-                items:
+                conditions:
+                  description: Conditions holds the conditions for the GitRepository.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                includedArtifacts:
+                  description: |-
+                    IncludedArtifacts contains a list of the last successfully included
+                    Artifacts as instructed by GitRepositorySpec.Include.
+                  items:
+                    description: Artifact represents the output of a Source reconciliation.
+                    properties:
+                      digest:
+                        description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                        pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                        type: string
+                      lastUpdateTime:
+                        description: |-
+                          LastUpdateTime is the timestamp corresponding to the last update of the
+                          Artifact.
+                        format: date-time
+                        type: string
+                      metadata:
+                        additionalProperties:
+                          type: string
+                        description: Metadata holds upstream information such as OCI annotations.
+                        type: object
+                      path:
+                        description: |-
+                          Path is the relative file path of the Artifact. It can be used to locate
+                          the file in the root of the Artifact storage on the local file system of
+                          the controller managing the Source.
+                        type: string
+                      revision:
+                        description: |-
+                          Revision is a human-readable identifier traceable in the origin source
+                          system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                        type: string
+                      size:
+                        description: Size is the number of bytes in the file.
+                        format: int64
+                        type: integer
+                      url:
+                        description: |-
+                          URL is the HTTP address of the Artifact as exposed by the controller
+                          managing the Source. It can be used to retrieve the Artifact for
+                          consumption, e.g. by another controller applying the Artifact contents.
+                        type: string
+                    required:
+                      - digest
+                      - lastUpdateTime
+                      - path
+                      - revision
+                      - url
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
                   type: string
-                type: array
-              sourceVerificationMode:
-                description: |-
-                  SourceVerificationMode is the last used verification mode indicating
-                  which Git object(s) have been verified.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the last observed generation of the GitRepository
+                    object.
+                  format: int64
+                  type: integer
+                observedIgnore:
+                  description: |-
+                    ObservedIgnore is the observed exclusion patterns used for constructing
+                    the source artifact.
+                  type: string
+                observedInclude:
+                  description: |-
+                    ObservedInclude is the observed list of GitRepository resources used to
+                    produce the current Artifact.
+                  items:
+                    description: |-
+                      GitRepositoryInclude specifies a local reference to a GitRepository which
+                      Artifact (sub-)contents must be included, and where they should be placed.
+                    properties:
+                      fromPath:
+                        description: |-
+                          FromPath specifies the path to copy contents from, defaults to the root
+                          of the Artifact.
+                        type: string
+                      repository:
+                        description: |-
+                          GitRepositoryRef specifies the GitRepository which Artifact contents
+                          must be included.
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      toPath:
+                        description: |-
+                          ToPath specifies the path to copy contents to, defaults to the name of
+                          the GitRepositoryRef.
+                        type: string
+                    required:
+                      - repository
+                    type: object
+                  type: array
+                observedRecurseSubmodules:
+                  description: |-
+                    ObservedRecurseSubmodules is the observed resource submodules
+                    configuration used to produce the current Artifact.
+                  type: boolean
+                observedSparseCheckout:
+                  description: |-
+                    ObservedSparseCheckout is the observed list of directories used to
+                    produce the current Artifact.
+                  items:
+                    type: string
+                  type: array
+                sourceVerificationMode:
+                  description: |-
+                    SourceVerificationMode is the last used verification mode indicating
+                    which Git object(s) have been verified.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1394,346 +1370,342 @@ spec:
     listKind: HelmChartList
     plural: helmcharts
     shortNames:
-    - hc
+      - hc
     singular: helmchart
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.chart
-      name: Chart
-      type: string
-    - jsonPath: .spec.version
-      name: Version
-      type: string
-    - jsonPath: .spec.sourceRef.kind
-      name: Source Kind
-      type: string
-    - jsonPath: .spec.sourceRef.name
-      name: Source Name
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: HelmChart is the Schema for the helmcharts API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HelmChartSpec specifies the desired state of a Helm chart.
-            properties:
-              chart:
-                description: |-
-                  Chart is the name or path the Helm chart is available at in the
-                  SourceRef.
-                type: string
-              ignoreMissingValuesFiles:
-                description: |-
-                  IgnoreMissingValuesFiles controls whether to silently ignore missing values
-                  files rather than failing.
-                type: boolean
-              interval:
-                description: |-
-                  Interval at which the HelmChart SourceRef is checked for updates.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              reconcileStrategy:
-                default: ChartVersion
-                description: |-
-                  ReconcileStrategy determines what enables the creation of a new artifact.
-                  Valid values are ('ChartVersion', 'Revision').
-                  See the documentation of the values for an explanation on their behavior.
-                  Defaults to ChartVersion when omitted.
-                enum:
-                - ChartVersion
-                - Revision
-                type: string
-              sourceRef:
-                description: SourceRef is the reference to the Source the chart is
-                  available at.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
-                    type: string
-                  kind:
-                    description: |-
-                      Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
-                      'Bucket').
-                    enum:
-                    - HelmRepository
-                    - GitRepository
-                    - Bucket
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend the reconciliation of this
-                  source.
-                type: boolean
-              valuesFiles:
-                description: |-
-                  ValuesFiles is an alternative list of values files to use as the chart
-                  values (values.yaml is not included by default), expected to be a
-                  relative path in the SourceRef.
-                  Values files are merged in the order of this list with the last file
-                  overriding the first. Ignored when omitted.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.chart
+          name: Chart
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.sourceRef.kind
+          name: Source Kind
+          type: string
+        - jsonPath: .spec.sourceRef.name
+          name: Source Name
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: HelmChart is the Schema for the helmcharts API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmChartSpec specifies the desired state of a Helm chart.
+              properties:
+                chart:
+                  description: |-
+                    Chart is the name or path the Helm chart is available at in the
+                    SourceRef.
                   type: string
-                type: array
-              verify:
-                description: |-
-                  Verify contains the secret name containing the trusted public keys
-                  used to verify the signature and specifies which provider to use to check
-                  whether OCI image is authentic.
-                  This field is only supported when using HelmRepository source with spec.type 'oci'.
-                  Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
-                properties:
-                  matchOIDCIdentity:
-                    description: |-
-                      MatchOIDCIdentity specifies the identity matching criteria to use
-                      while verifying an OCI artifact which was signed using Cosign keyless
-                      signing. The artifact's identity is deemed to be verified if any of the
-                      specified matchers match against the identity.
-                    items:
-                      description: |-
-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
-                        i.e. the issuer and the subject of the certificate.
-                      properties:
-                        issuer:
-                          description: |-
-                            Issuer specifies the regex pattern to match against to verify
-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
-                            valid Go regular expression.
-                          type: string
-                        subject:
-                          description: |-
-                            Subject specifies the regex pattern to match against to verify
-                            the identity subject in the Fulcio certificate. The pattern must
-                            be a valid Go regular expression.
-                          type: string
-                      required:
-                      - issuer
-                      - subject
-                      type: object
-                    type: array
-                  provider:
-                    default: cosign
-                    description: Provider specifies the technology used to sign the
-                      OCI Artifact.
-                    enum:
-                    - cosign
-                    - notation
-                    type: string
-                  secretRef:
-                    description: |-
-                      SecretRef specifies the Kubernetes Secret containing the
-                      trusted public keys.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                required:
-                - provider
-                type: object
-              version:
-                default: '*'
-                description: |-
-                  Version is the chart version semver expression, ignored for charts from
-                  GitRepository and Bucket sources. Defaults to latest when omitted.
-                type: string
-            required:
-            - chart
-            - interval
-            - sourceRef
-            type: object
-            x-kubernetes-validations:
-            - message: spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'
-              rule: '!has(self.verify) || self.sourceRef.kind == ''HelmRepository'''
-          status:
-            default:
-              observedGeneration: -1
-            description: HelmChartStatus records the observed state of the HelmChart.
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful
-                  reconciliation.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the HelmChart.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                ignoreMissingValuesFiles:
+                  description: |-
+                    IgnoreMissingValuesFiles controls whether to silently ignore missing values
+                    files rather than failing.
+                  type: boolean
+                interval:
+                  description: |-
+                    Interval at which the HelmChart SourceRef is checked for updates.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                reconcileStrategy:
+                  default: ChartVersion
+                  description: |-
+                    ReconcileStrategy determines what enables the creation of a new artifact.
+                    Valid values are ('ChartVersion', 'Revision').
+                    See the documentation of the values for an explanation on their behavior.
+                    Defaults to ChartVersion when omitted.
+                  enum:
+                    - ChartVersion
+                    - Revision
+                  type: string
+                sourceRef:
+                  description: SourceRef is the reference to the Source the chart is available at.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                    apiVersion:
+                      description: APIVersion of the referent.
                       type: string
-                    message:
+                    kind:
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                        Kind of the referent, valid values are ('HelmRepository', 'GitRepository',
+                        'Bucket').
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                        - HelmRepository
+                        - GitRepository
+                        - Bucket
                       type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - kind
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedChartName:
-                description: |-
-                  ObservedChartName is the last observed chart name as specified by the
-                  resolved chart reference.
-                type: string
-              observedGeneration:
-                description: |-
-                  ObservedGeneration is the last observed generation of the HelmChart
-                  object.
-                format: int64
-                type: integer
-              observedSourceArtifactRevision:
-                description: |-
-                  ObservedSourceArtifactRevision is the last observed Artifact.Revision
-                  of the HelmChartSpec.SourceRef.
-                type: string
-              observedValuesFiles:
-                description: |-
-                  ObservedValuesFiles are the observed value files of the last successful
-                  reconciliation.
-                  It matches the chart in the last successfully reconciled artifact.
-                items:
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend the reconciliation of this
+                    source.
+                  type: boolean
+                valuesFiles:
+                  description: |-
+                    ValuesFiles is an alternative list of values files to use as the chart
+                    values (values.yaml is not included by default), expected to be a
+                    relative path in the SourceRef.
+                    Values files are merged in the order of this list with the last file
+                    overriding the first. Ignored when omitted.
+                  items:
+                    type: string
+                  type: array
+                verify:
+                  description: |-
+                    Verify contains the secret name containing the trusted public keys
+                    used to verify the signature and specifies which provider to use to check
+                    whether OCI image is authentic.
+                    This field is only supported when using HelmRepository source with spec.type 'oci'.
+                    Chart dependencies, which are not bundled in the umbrella chart artifact, are not verified.
+                  properties:
+                    matchOIDCIdentity:
+                      description: |-
+                        MatchOIDCIdentity specifies the identity matching criteria to use
+                        while verifying an OCI artifact which was signed using Cosign keyless
+                        signing. The artifact's identity is deemed to be verified if any of the
+                        specified matchers match against the identity.
+                      items:
+                        description: |-
+                          OIDCIdentityMatch specifies options for verifying the certificate identity,
+                          i.e. the issuer and the subject of the certificate.
+                        properties:
+                          issuer:
+                            description: |-
+                              Issuer specifies the regex pattern to match against to verify
+                              the OIDC issuer in the Fulcio certificate. The pattern must be a
+                              valid Go regular expression.
+                            type: string
+                          subject:
+                            description: |-
+                              Subject specifies the regex pattern to match against to verify
+                              the identity subject in the Fulcio certificate. The pattern must
+                              be a valid Go regular expression.
+                            type: string
+                        required:
+                          - issuer
+                          - subject
+                        type: object
+                      type: array
+                    provider:
+                      default: cosign
+                      description: Provider specifies the technology used to sign the OCI Artifact.
+                      enum:
+                        - cosign
+                        - notation
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretRef specifies the Kubernetes Secret containing the
+                        trusted public keys.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - provider
+                  type: object
+                version:
+                  default: '*'
+                  description: |-
+                    Version is the chart version semver expression, ignored for charts from
+                    GitRepository and Bucket sources. Defaults to latest when omitted.
                   type: string
-                type: array
-              url:
-                description: |-
-                  URL is the dynamic fetch link for the latest Artifact.
-                  It is provided on a "best effort" basis, and using the precise
-                  BucketStatus.Artifact data is recommended.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              required:
+                - chart
+                - interval
+                - sourceRef
+              type: object
+              x-kubernetes-validations:
+                - message: spec.verify is only supported when spec.sourceRef.kind is 'HelmRepository'
+                  rule: '!has(self.verify) || self.sourceRef.kind == ''HelmRepository'''
+            status:
+              default:
+                observedGeneration: -1
+              description: HelmChartStatus records the observed state of the HelmChart.
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmChart.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedChartName:
+                  description: |-
+                    ObservedChartName is the last observed chart name as specified by the
+                    resolved chart reference.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the last observed generation of the HelmChart
+                    object.
+                  format: int64
+                  type: integer
+                observedSourceArtifactRevision:
+                  description: |-
+                    ObservedSourceArtifactRevision is the last observed Artifact.Revision
+                    of the HelmChartSpec.SourceRef.
+                  type: string
+                observedValuesFiles:
+                  description: |-
+                    ObservedValuesFiles are the observed value files of the last successful
+                    reconciliation.
+                    It matches the chart in the last successfully reconciled artifact.
+                  items:
+                    type: string
+                  type: array
+                url:
+                  description: |-
+                    URL is the dynamic fetch link for the latest Artifact.
+                    It is provided on a "best effort" basis, and using the precise
+                    BucketStatus.Artifact data is recommended.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1753,313 +1725,311 @@ spec:
     listKind: HelmRepositoryList
     plural: helmrepositories
     shortNames:
-    - helmrepo
+      - helmrepo
     singular: helmrepository
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: HelmRepository is the Schema for the helmrepositories API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              HelmRepositorySpec specifies the required configuration to produce an
-              Artifact for a Helm repository index YAML.
-            properties:
-              accessFrom:
-                description: |-
-                  AccessFrom specifies an Access Control List for allowing cross-namespace
-                  references to this object.
-                  NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
-                properties:
-                  namespaceSelectors:
-                    description: |-
-                      NamespaceSelectors is the list of namespace selectors to which this ACL applies.
-                      Items in this list are evaluated using a logical OR operation.
-                    items:
-                      description: |-
-                        NamespaceSelector selects the namespaces to which this ACL applies.
-                        An empty map of MatchLabels matches all namespaces in a cluster.
-                      properties:
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                            map is equivalent to an element of matchExpressions, whose key field is "key", the
-                            operator is "In", and the values array contains only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    type: array
-                required:
-                - namespaceSelectors
-                type: object
-              certSecretRef:
-                description: |-
-                  CertSecretRef can be given the name of a Secret containing
-                  either or both of
-
-                  - a PEM-encoded client certificate (`tls.crt`) and private
-                  key (`tls.key`);
-                  - a PEM-encoded CA certificate (`ca.crt`)
-
-                  and whichever are supplied, will be used for connecting to the
-                  registry. The client cert and key are useful if you are
-                  authenticating with a certificate; the CA cert is useful if
-                  you are using a self-signed server certificate. The Secret must
-                  be of type `Opaque` or `kubernetes.io/tls`.
-
-                  It takes precedence over the values specified in the Secret referred
-                  to by `.spec.secretRef`.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              insecure:
-                description: |-
-                  Insecure allows connecting to a non-TLS HTTP container registry.
-                  This field is only taken into account if the .spec.type field is set to 'oci'.
-                type: boolean
-              interval:
-                description: |-
-                  Interval at which the HelmRepository URL is checked for updates.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              passCredentials:
-                description: |-
-                  PassCredentials allows the credentials from the SecretRef to be passed
-                  on to a host that does not match the host as defined in URL.
-                  This may be required if the host of the advertised chart URLs in the
-                  index differ from the defined URL.
-                  Enabling this should be done with caution, as it can potentially result
-                  in credentials getting stolen in a MITM-attack.
-                type: boolean
-              provider:
-                default: generic
-                description: |-
-                  Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                  This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
-                  When not specified, defaults to 'generic'.
-                enum:
-                - generic
-                - aws
-                - azure
-                - gcp
-                type: string
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing authentication credentials
-                  for the HelmRepository.
-                  For HTTP/S basic auth the secret must contain 'username' and 'password'
-                  fields.
-                  Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
-                  keys is deprecated. Please use `.spec.certSecretRef` instead.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend the reconciliation of this
-                  HelmRepository.
-                type: boolean
-              timeout:
-                description: |-
-                  Timeout is used for the index fetch operation for an HTTPS helm repository,
-                  and for remote OCI Repository operations like pulling for an OCI helm
-                  chart by the associated HelmChart.
-                  Its default value is 60s.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-              type:
-                description: |-
-                  Type of the HelmRepository.
-                  When this field is set to  "oci", the URL field value must be prefixed with "oci://".
-                enum:
-                - default
-                - oci
-                type: string
-              url:
-                description: |-
-                  URL of the Helm repository, a valid URL contains at least a protocol and
-                  host.
-                pattern: ^(http|https|oci)://.*$
-                type: string
-            required:
-            - url
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: HelmRepositoryStatus records the observed state of the HelmRepository.
-            properties:
-              artifact:
-                description: Artifact represents the last successful HelmRepository
-                  reconciliation.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the HelmRepository.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: HelmRepository is the Schema for the helmrepositories API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                HelmRepositorySpec specifies the required configuration to produce an
+                Artifact for a Helm repository index YAML.
+              properties:
+                accessFrom:
+                  description: |-
+                    AccessFrom specifies an Access Control List for allowing cross-namespace
+                    references to this object.
+                    NOTE: Not implemented, provisional as of https://github.com/fluxcd/flux2/pull/2092
                   properties:
-                    lastTransitionTime:
+                    namespaceSelectors:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        NamespaceSelectors is the list of namespace selectors to which this ACL applies.
+                        Items in this list are evaluated using a logical OR operation.
+                      items:
+                        description: |-
+                          NamespaceSelector selects the namespaces to which this ACL applies.
+                          An empty map of MatchLabels matches all namespaces in a cluster.
+                        properties:
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
+                  required:
+                    - namespaceSelectors
+                  type: object
+                certSecretRef:
+                  description: |-
+                    CertSecretRef can be given the name of a Secret containing
+                    either or both of
+
+                    - a PEM-encoded client certificate (`tls.crt`) and private
+                    key (`tls.key`);
+                    - a PEM-encoded CA certificate (`ca.crt`)
+
+                    and whichever are supplied, will be used for connecting to the
+                    registry. The client cert and key are useful if you are
+                    authenticating with a certificate; the CA cert is useful if
+                    you are using a self-signed server certificate. The Secret must
+                    be of type `Opaque` or `kubernetes.io/tls`.
+
+                    It takes precedence over the values specified in the Secret referred
+                    to by `.spec.secretRef`.
+                  properties:
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: |-
-                  ObservedGeneration is the last observed generation of the HelmRepository
-                  object.
-                format: int64
-                type: integer
-              url:
-                description: |-
-                  URL is the dynamic fetch link for the latest Artifact.
-                  It is provided on a "best effort" basis, and using the precise
-                  HelmRepositoryStatus.Artifact data is recommended.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                insecure:
+                  description: |-
+                    Insecure allows connecting to a non-TLS HTTP container registry.
+                    This field is only taken into account if the .spec.type field is set to 'oci'.
+                  type: boolean
+                interval:
+                  description: |-
+                    Interval at which the HelmRepository URL is checked for updates.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                passCredentials:
+                  description: |-
+                    PassCredentials allows the credentials from the SecretRef to be passed
+                    on to a host that does not match the host as defined in URL.
+                    This may be required if the host of the advertised chart URLs in the
+                    index differ from the defined URL.
+                    Enabling this should be done with caution, as it can potentially result
+                    in credentials getting stolen in a MITM-attack.
+                  type: boolean
+                provider:
+                  default: generic
+                  description: |-
+                    Provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                    This field is optional, and only taken into account if the .spec.type field is set to 'oci'.
+                    When not specified, defaults to 'generic'.
+                  enum:
+                    - generic
+                    - aws
+                    - azure
+                    - gcp
+                  type: string
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing authentication credentials
+                    for the HelmRepository.
+                    For HTTP/S basic auth the secret must contain 'username' and 'password'
+                    fields.
+                    Support for TLS auth using the 'certFile' and 'keyFile', and/or 'caFile'
+                    keys is deprecated. Please use `.spec.certSecretRef` instead.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend the reconciliation of this
+                    HelmRepository.
+                  type: boolean
+                timeout:
+                  description: |-
+                    Timeout is used for the index fetch operation for an HTTPS helm repository,
+                    and for remote OCI Repository operations like pulling for an OCI helm
+                    chart by the associated HelmChart.
+                    Its default value is 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+                type:
+                  description: |-
+                    Type of the HelmRepository.
+                    When this field is set to  "oci", the URL field value must be prefixed with "oci://".
+                  enum:
+                    - default
+                    - oci
+                  type: string
+                url:
+                  description: |-
+                    URL of the Helm repository, a valid URL contains at least a protocol and
+                    host.
+                  pattern: ^(http|https|oci)://.*$
+                  type: string
+              required:
+                - url
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: HelmRepositoryStatus records the observed state of the HelmRepository.
+              properties:
+                artifact:
+                  description: Artifact represents the last successful HelmRepository reconciliation.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the HelmRepository.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the last observed generation of the HelmRepository
+                    object.
+                  format: int64
+                  type: integer
+                url:
+                  description: |-
+                    URL is the dynamic fetch link for the latest Artifact.
+                    It is provided on a "best effort" basis, and using the precise
+                    HelmRepositoryStatus.Artifact data is recommended.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2079,403 +2049,395 @@ spec:
     listKind: OCIRepositoryList
     plural: ocirepositories
     shortNames:
-    - ocirepo
+      - ocirepo
     singular: ocirepository
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.url
-      name: URL
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: OCIRepository is the Schema for the ocirepositories API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: OCIRepositorySpec defines the desired state of OCIRepository
-            properties:
-              certSecretRef:
-                description: |-
-                  CertSecretRef can be given the name of a Secret containing
-                  either or both of
+    - additionalPrinterColumns:
+        - jsonPath: .spec.url
+          name: URL
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: OCIRepository is the Schema for the ocirepositories API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OCIRepositorySpec defines the desired state of OCIRepository
+              properties:
+                certSecretRef:
+                  description: |-
+                    CertSecretRef can be given the name of a Secret containing
+                    either or both of
 
-                  - a PEM-encoded client certificate (`tls.crt`) and private
-                  key (`tls.key`);
-                  - a PEM-encoded CA certificate (`ca.crt`)
+                    - a PEM-encoded client certificate (`tls.crt`) and private
+                    key (`tls.key`);
+                    - a PEM-encoded CA certificate (`ca.crt`)
 
-                  and whichever are supplied, will be used for connecting to the
-                  registry. The client cert and key are useful if you are
-                  authenticating with a certificate; the CA cert is useful if
-                  you are using a self-signed server certificate. The Secret must
-                  be of type `Opaque` or `kubernetes.io/tls`.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              ignore:
-                description: |-
-                  Ignore overrides the set of excluded patterns in the .sourceignore format
-                  (which is the same as .gitignore). If not provided, a default will be used,
-                  consult the documentation for your version to find out what those are.
-                type: string
-              insecure:
-                description: Insecure allows connecting to a non-TLS HTTP container
-                  registry.
-                type: boolean
-              interval:
-                description: |-
-                  Interval at which the OCIRepository URL is checked for updates.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              layerSelector:
-                description: |-
-                  LayerSelector specifies which layer should be extracted from the OCI artifact.
-                  When not specified, the first layer found in the artifact is selected.
-                properties:
-                  mediaType:
-                    description: |-
-                      MediaType specifies the OCI media type of the layer
-                      which should be extracted from the OCI Artifact. The
-                      first layer matching this type is selected.
-                    type: string
-                  operation:
-                    description: |-
-                      Operation specifies how the selected layer should be processed.
-                      By default, the layer compressed content is extracted to storage.
-                      When the operation is set to 'copy', the layer compressed content
-                      is persisted to storage as it is.
-                    enum:
-                    - extract
-                    - copy
-                    type: string
-                type: object
-              provider:
-                default: generic
-                description: |-
-                  The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
-                  When not specified, defaults to 'generic'.
-                enum:
-                - generic
-                - aws
-                - azure
-                - gcp
-                type: string
-              proxySecretRef:
-                description: |-
-                  ProxySecretRef specifies the Secret containing the proxy configuration
-                  to use while communicating with the container registry.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              ref:
-                description: |-
-                  The OCI reference to pull and monitor for changes,
-                  defaults to the latest tag.
-                properties:
-                  digest:
-                    description: |-
-                      Digest is the image digest to pull, takes precedence over SemVer.
-                      The value should be in the format 'sha256:<HASH>'.
-                    type: string
-                  semver:
-                    description: |-
-                      SemVer is the range of tags to pull selecting the latest within
-                      the range, takes precedence over Tag.
-                    type: string
-                  semverFilter:
-                    description: SemverFilter is a regex pattern to filter the tags
-                      within the SemVer range.
-                    type: string
-                  tag:
-                    description: Tag is the image tag to pull, defaults to latest.
-                    type: string
-                type: object
-              secretRef:
-                description: |-
-                  SecretRef contains the secret name containing the registry login
-                  credentials to resolve image metadata.
-                  The secret must be of type kubernetes.io/dockerconfigjson.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
-                  the image pull if the service account has attached pull secrets. For more information:
-                  https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
-                type: string
-              suspend:
-                description: This flag tells the controller to suspend the reconciliation
-                  of this source.
-                type: boolean
-              timeout:
-                default: 60s
-                description: The timeout for remote OCI Repository operations like
-                  pulling, defaults to 60s.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-              url:
-                description: |-
-                  URL is a reference to an OCI artifact repository hosted
-                  on a remote container registry.
-                pattern: ^oci://.*$
-                type: string
-              verify:
-                description: |-
-                  Verify contains the secret name containing the trusted public keys
-                  used to verify the signature and specifies which provider to use to check
-                  whether OCI image is authentic.
-                properties:
-                  matchOIDCIdentity:
-                    description: |-
-                      MatchOIDCIdentity specifies the identity matching criteria to use
-                      while verifying an OCI artifact which was signed using Cosign keyless
-                      signing. The artifact's identity is deemed to be verified if any of the
-                      specified matchers match against the identity.
-                    items:
-                      description: |-
-                        OIDCIdentityMatch specifies options for verifying the certificate identity,
-                        i.e. the issuer and the subject of the certificate.
-                      properties:
-                        issuer:
-                          description: |-
-                            Issuer specifies the regex pattern to match against to verify
-                            the OIDC issuer in the Fulcio certificate. The pattern must be a
-                            valid Go regular expression.
-                          type: string
-                        subject:
-                          description: |-
-                            Subject specifies the regex pattern to match against to verify
-                            the identity subject in the Fulcio certificate. The pattern must
-                            be a valid Go regular expression.
-                          type: string
-                      required:
-                      - issuer
-                      - subject
-                      type: object
-                    type: array
-                  provider:
-                    default: cosign
-                    description: Provider specifies the technology used to sign the
-                      OCI Artifact.
-                    enum:
-                    - cosign
-                    - notation
-                    type: string
-                  secretRef:
-                    description: |-
-                      SecretRef specifies the Kubernetes Secret containing the
-                      trusted public keys.
-                    properties:
-                      name:
-                        description: Name of the referent.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                required:
-                - provider
-                type: object
-            required:
-            - interval
-            - url
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: OCIRepositoryStatus defines the observed state of OCIRepository
-            properties:
-              artifact:
-                description: Artifact represents the output of the last successful
-                  OCI Repository sync.
-                properties:
-                  digest:
-                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
-                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
-                    type: string
-                  lastUpdateTime:
-                    description: |-
-                      LastUpdateTime is the timestamp corresponding to the last update of the
-                      Artifact.
-                    format: date-time
-                    type: string
-                  metadata:
-                    additionalProperties:
-                      type: string
-                    description: Metadata holds upstream information such as OCI annotations.
-                    type: object
-                  path:
-                    description: |-
-                      Path is the relative file path of the Artifact. It can be used to locate
-                      the file in the root of the Artifact storage on the local file system of
-                      the controller managing the Source.
-                    type: string
-                  revision:
-                    description: |-
-                      Revision is a human-readable identifier traceable in the origin source
-                      system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
-                    type: string
-                  size:
-                    description: Size is the number of bytes in the file.
-                    format: int64
-                    type: integer
-                  url:
-                    description: |-
-                      URL is the HTTP address of the Artifact as exposed by the controller
-                      managing the Source. It can be used to retrieve the Artifact for
-                      consumption, e.g. by another controller applying the Artifact contents.
-                    type: string
-                required:
-                - digest
-                - lastUpdateTime
-                - path
-                - revision
-                - url
-                type: object
-              conditions:
-                description: Conditions holds the conditions for the OCIRepository.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                    and whichever are supplied, will be used for connecting to the
+                    registry. The client cert and key are useful if you are
+                    authenticating with a certificate; the CA cert is useful if
+                    you are using a self-signed server certificate. The Secret must
+                    be of type `Opaque` or `kubernetes.io/tls`.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              observedIgnore:
-                description: |-
-                  ObservedIgnore is the observed exclusion patterns used for constructing
-                  the source artifact.
-                type: string
-              observedLayerSelector:
-                description: |-
-                  ObservedLayerSelector is the observed layer selector used for constructing
-                  the source artifact.
-                properties:
-                  mediaType:
-                    description: |-
-                      MediaType specifies the OCI media type of the layer
-                      which should be extracted from the OCI Artifact. The
-                      first layer matching this type is selected.
-                    type: string
-                  operation:
-                    description: |-
-                      Operation specifies how the selected layer should be processed.
-                      By default, the layer compressed content is extracted to storage.
-                      When the operation is set to 'copy', the layer compressed content
-                      is persisted to storage as it is.
-                    enum:
-                    - extract
-                    - copy
-                    type: string
-                type: object
-              url:
-                description: URL is the download link for the artifact output of the
-                  last OCI Repository sync.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                ignore:
+                  description: |-
+                    Ignore overrides the set of excluded patterns in the .sourceignore format
+                    (which is the same as .gitignore). If not provided, a default will be used,
+                    consult the documentation for your version to find out what those are.
+                  type: string
+                insecure:
+                  description: Insecure allows connecting to a non-TLS HTTP container registry.
+                  type: boolean
+                interval:
+                  description: |-
+                    Interval at which the OCIRepository URL is checked for updates.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                layerSelector:
+                  description: |-
+                    LayerSelector specifies which layer should be extracted from the OCI artifact.
+                    When not specified, the first layer found in the artifact is selected.
+                  properties:
+                    mediaType:
+                      description: |-
+                        MediaType specifies the OCI media type of the layer
+                        which should be extracted from the OCI Artifact. The
+                        first layer matching this type is selected.
+                      type: string
+                    operation:
+                      description: |-
+                        Operation specifies how the selected layer should be processed.
+                        By default, the layer compressed content is extracted to storage.
+                        When the operation is set to 'copy', the layer compressed content
+                        is persisted to storage as it is.
+                      enum:
+                        - extract
+                        - copy
+                      type: string
+                  type: object
+                provider:
+                  default: generic
+                  description: |-
+                    The provider used for authentication, can be 'aws', 'azure', 'gcp' or 'generic'.
+                    When not specified, defaults to 'generic'.
+                  enum:
+                    - generic
+                    - aws
+                    - azure
+                    - gcp
+                  type: string
+                proxySecretRef:
+                  description: |-
+                    ProxySecretRef specifies the Secret containing the proxy configuration
+                    to use while communicating with the container registry.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                ref:
+                  description: |-
+                    The OCI reference to pull and monitor for changes,
+                    defaults to the latest tag.
+                  properties:
+                    digest:
+                      description: |-
+                        Digest is the image digest to pull, takes precedence over SemVer.
+                        The value should be in the format 'sha256:<HASH>'.
+                      type: string
+                    semver:
+                      description: |-
+                        SemVer is the range of tags to pull selecting the latest within
+                        the range, takes precedence over Tag.
+                      type: string
+                    semverFilter:
+                      description: SemverFilter is a regex pattern to filter the tags within the SemVer range.
+                      type: string
+                    tag:
+                      description: Tag is the image tag to pull, defaults to latest.
+                      type: string
+                  type: object
+                secretRef:
+                  description: |-
+                    SecretRef contains the secret name containing the registry login
+                    credentials to resolve image metadata.
+                    The secret must be of type kubernetes.io/dockerconfigjson.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to authenticate
+                    the image pull if the service account has attached pull secrets. For more information:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                  type: string
+                suspend:
+                  description: This flag tells the controller to suspend the reconciliation of this source.
+                  type: boolean
+                timeout:
+                  default: 60s
+                  description: The timeout for remote OCI Repository operations like pulling, defaults to 60s.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+                url:
+                  description: |-
+                    URL is a reference to an OCI artifact repository hosted
+                    on a remote container registry.
+                  pattern: ^oci://.*$
+                  type: string
+                verify:
+                  description: |-
+                    Verify contains the secret name containing the trusted public keys
+                    used to verify the signature and specifies which provider to use to check
+                    whether OCI image is authentic.
+                  properties:
+                    matchOIDCIdentity:
+                      description: |-
+                        MatchOIDCIdentity specifies the identity matching criteria to use
+                        while verifying an OCI artifact which was signed using Cosign keyless
+                        signing. The artifact's identity is deemed to be verified if any of the
+                        specified matchers match against the identity.
+                      items:
+                        description: |-
+                          OIDCIdentityMatch specifies options for verifying the certificate identity,
+                          i.e. the issuer and the subject of the certificate.
+                        properties:
+                          issuer:
+                            description: |-
+                              Issuer specifies the regex pattern to match against to verify
+                              the OIDC issuer in the Fulcio certificate. The pattern must be a
+                              valid Go regular expression.
+                            type: string
+                          subject:
+                            description: |-
+                              Subject specifies the regex pattern to match against to verify
+                              the identity subject in the Fulcio certificate. The pattern must
+                              be a valid Go regular expression.
+                            type: string
+                        required:
+                          - issuer
+                          - subject
+                        type: object
+                      type: array
+                    provider:
+                      default: cosign
+                      description: Provider specifies the technology used to sign the OCI Artifact.
+                      enum:
+                        - cosign
+                        - notation
+                      type: string
+                    secretRef:
+                      description: |-
+                        SecretRef specifies the Kubernetes Secret containing the
+                        trusted public keys.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - provider
+                  type: object
+              required:
+                - interval
+                - url
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: OCIRepositoryStatus defines the observed state of OCIRepository
+              properties:
+                artifact:
+                  description: Artifact represents the output of the last successful OCI Repository sync.
+                  properties:
+                    digest:
+                      description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                      pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
+                      type: string
+                    lastUpdateTime:
+                      description: |-
+                        LastUpdateTime is the timestamp corresponding to the last update of the
+                        Artifact.
+                      format: date-time
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      description: Metadata holds upstream information such as OCI annotations.
+                      type: object
+                    path:
+                      description: |-
+                        Path is the relative file path of the Artifact. It can be used to locate
+                        the file in the root of the Artifact storage on the local file system of
+                        the controller managing the Source.
+                      type: string
+                    revision:
+                      description: |-
+                        Revision is a human-readable identifier traceable in the origin source
+                        system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
+                      type: string
+                    size:
+                      description: Size is the number of bytes in the file.
+                      format: int64
+                      type: integer
+                    url:
+                      description: |-
+                        URL is the HTTP address of the Artifact as exposed by the controller
+                        managing the Source. It can be used to retrieve the Artifact for
+                        consumption, e.g. by another controller applying the Artifact contents.
+                      type: string
+                  required:
+                    - digest
+                    - lastUpdateTime
+                    - path
+                    - revision
+                    - url
+                  type: object
+                conditions:
+                  description: Conditions holds the conditions for the OCIRepository.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                observedIgnore:
+                  description: |-
+                    ObservedIgnore is the observed exclusion patterns used for constructing
+                    the source artifact.
+                  type: string
+                observedLayerSelector:
+                  description: |-
+                    ObservedLayerSelector is the observed layer selector used for constructing
+                    the source artifact.
+                  properties:
+                    mediaType:
+                      description: |-
+                        MediaType specifies the OCI media type of the layer
+                        which should be extracted from the OCI Artifact. The
+                        first layer matching this type is selected.
+                      type: string
+                    operation:
+                      description: |-
+                        Operation specifies how the selected layer should be processed.
+                        By default, the layer compressed content is extracted to storage.
+                        When the operation is set to 'copy', the layer compressed content
+                        is persisted to storage as it is.
+                      enum:
+                        - extract
+                        - copy
+                      type: string
+                  type: object
+                url:
+                  description: URL is the download link for the artifact output of the last OCI Repository sync.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -2501,10 +2463,10 @@ metadata:
   namespace: flux-system
 spec:
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: http
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
   selector:
     app: source-controller
   type: ClusterIP
@@ -2540,68 +2502,68 @@ spec:
         app.kubernetes.io/version: v2.8.6
     spec:
       containers:
-      - args:
-        - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
-        - --watch-all-namespaces=true
-        - --log-level=info
-        - --log-encoding=json
-        - --enable-leader-election
-        - --storage-path=/data
-        - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
-        env:
-        - name: RUNTIME_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: TUF_ROOT
-          value: /tmp/.sigstore
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: manager
-              resource: limits.memory
-        image: ghcr.io/fluxcd/source-controller:v1.8.3
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-        name: manager
-        ports:
-        - containerPort: 9090
-          name: http
-          protocol: TCP
-        - containerPort: 8080
-          name: http-prom
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /
-            port: http
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /data
-          name: data
-        - mountPath: /tmp
-          name: tmp
+        - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+            - --storage-path=/data
+            - --storage-adv-addr=source-controller.$(RUNTIME_NAMESPACE).svc.cluster.local.
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TUF_ROOT
+              value: /tmp/.sigstore
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: manager
+                  resource: limits.memory
+          image: ghcr.io/fluxcd/source-controller:v1.8.3
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          name: manager
+          ports:
+            - containerPort: 9090
+              name: http
+              protocol: TCP
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /data
+              name: data
+            - mountPath: /tmp
+              name: tmp
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -2610,10 +2572,10 @@ spec:
       serviceAccountName: source-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: data
-      - emptyDir: {}
-        name: tmp
+        - emptyDir: {}
+          name: data
+        - emptyDir: {}
+          name: tmp
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2633,703 +2595,678 @@ spec:
     listKind: KustomizationList
     plural: kustomizations
     shortNames:
-    - ks
+      - ks
     singular: kustomization
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Kustomization is the Schema for the kustomizations API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              KustomizationSpec defines the configuration to calculate the desired state
-              from a Source using Kustomize.
-            properties:
-              commonMetadata:
-                description: |-
-                  CommonMetadata specifies the common labels and annotations that are
-                  applied to all resources. Any existing label or annotation will be
-                  overridden if its key matches a common one.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the object's metadata.
-                    type: object
-                  labels:
-                    additionalProperties:
-                      type: string
-                    description: Labels to be added to the object's metadata.
-                    type: object
-                type: object
-              components:
-                description: Components specifies relative paths to kustomize Components.
-                items:
-                  type: string
-                type: array
-              decryption:
-                description: Decrypt Kubernetes secrets before applying them on the
-                  cluster.
-                properties:
-                  provider:
-                    description: Provider is the name of the decryption engine.
-                    enum:
-                    - sops
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Kustomization is the Schema for the kustomizations API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                KustomizationSpec defines the configuration to calculate the desired state
+                from a Source using Kustomize.
+              properties:
+                commonMetadata:
+                  description: |-
+                    CommonMetadata specifies the common labels and annotations that are
+                    applied to all resources. Any existing label or annotation will be
+                    overridden if its key matches a common one.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to be added to the object's metadata.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to be added to the object's metadata.
+                      type: object
+                  type: object
+                components:
+                  description: Components specifies relative paths to kustomize Components.
+                  items:
                     type: string
-                  secretRef:
-                    description: |-
-                      The secret name containing the private OpenPGP keys used for decryption.
-                      A static credential for a cloud provider defined inside the Secret
-                      takes priority to secret-less authentication with the ServiceAccountName
-                      field.
+                  type: array
+                decryption:
+                  description: Decrypt Kubernetes secrets before applying them on the cluster.
+                  properties:
+                    provider:
+                      description: Provider is the name of the decryption engine.
+                      enum:
+                        - sops
+                      type: string
+                    secretRef:
+                      description: |-
+                        The secret name containing the private OpenPGP keys used for decryption.
+                        A static credential for a cloud provider defined inside the Secret
+                        takes priority to secret-less authentication with the ServiceAccountName
+                        field.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    serviceAccountName:
+                      description: |-
+                        ServiceAccountName is the name of the service account used to
+                        authenticate with KMS services from cloud providers. If a
+                        static credential for a given cloud provider is defined
+                        inside the Secret referenced by SecretRef, that static
+                        credential takes priority.
+                      type: string
+                  required:
+                    - provider
+                  type: object
+                deletionPolicy:
+                  description: |-
+                    DeletionPolicy can be used to control garbage collection when this
+                    Kustomization is deleted. Valid values are ('MirrorPrune', 'Delete',
+                    'WaitForTermination', 'Orphan'). 'MirrorPrune' mirrors the Prune field
+                    (orphan if false, delete if true). Defaults to 'MirrorPrune'.
+                  enum:
+                    - MirrorPrune
+                    - Delete
+                    - WaitForTermination
+                    - Orphan
+                  type: string
+                dependsOn:
+                  description: |-
+                    DependsOn may contain a DependencyReference slice
+                    with references to Kustomization resources that must be ready before this
+                    Kustomization can be reconciled.
+                  items:
+                    description: DependencyReference defines a Kustomization dependency on another Kustomization resource.
                     properties:
                       name:
                         description: Name of the referent.
                         type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent, defaults to the namespace of the Kustomization
+                          resource object that contains the reference.
+                        type: string
+                      readyExpr:
+                        description: |-
+                          ReadyExpr is a CEL expression that can be used to assess the readiness
+                          of a dependency. When specified, the built-in readiness check
+                          is replaced by the logic defined in the CEL expression.
+                          To make the CEL expression additive to the built-in readiness check,
+                          the feature gate `AdditiveCELDependencyCheck` must be set to `true`.
+                        type: string
                     required:
-                    - name
+                      - name
                     type: object
-                  serviceAccountName:
-                    description: |-
-                      ServiceAccountName is the name of the service account used to
-                      authenticate with KMS services from cloud providers. If a
-                      static credential for a given cloud provider is defined
-                      inside the Secret referenced by SecretRef, that static
-                      credential takes priority.
-                    type: string
-                required:
-                - provider
-                type: object
-              deletionPolicy:
-                description: |-
-                  DeletionPolicy can be used to control garbage collection when this
-                  Kustomization is deleted. Valid values are ('MirrorPrune', 'Delete',
-                  'WaitForTermination', 'Orphan'). 'MirrorPrune' mirrors the Prune field
-                  (orphan if false, delete if true). Defaults to 'MirrorPrune'.
-                enum:
-                - MirrorPrune
-                - Delete
-                - WaitForTermination
-                - Orphan
-                type: string
-              dependsOn:
-                description: |-
-                  DependsOn may contain a DependencyReference slice
-                  with references to Kustomization resources that must be ready before this
-                  Kustomization can be reconciled.
-                items:
-                  description: DependencyReference defines a Kustomization dependency
-                    on another Kustomization resource.
-                  properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the Kustomization
-                        resource object that contains the reference.
-                      type: string
-                    readyExpr:
-                      description: |-
-                        ReadyExpr is a CEL expression that can be used to assess the readiness
-                        of a dependency. When specified, the built-in readiness check
-                        is replaced by the logic defined in the CEL expression.
-                        To make the CEL expression additive to the built-in readiness check,
-                        the feature gate `AdditiveCELDependencyCheck` must be set to `true`.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-              force:
-                default: false
-                description: |-
-                  Force instructs the controller to recreate resources
-                  when patching fails due to an immutable field change.
-                type: boolean
-              healthCheckExprs:
-                description: |-
-                  HealthCheckExprs is a list of healthcheck expressions for evaluating the
-                  health of custom resources using Common Expression Language (CEL).
-                  The expressions are evaluated only when Wait or HealthChecks are specified.
-                items:
-                  description: CustomHealthCheck defines the health check for custom
-                    resources.
-                  properties:
-                    apiVersion:
-                      description: APIVersion of the custom resource under evaluation.
-                      type: string
-                    current:
-                      description: |-
-                        Current is the CEL expression that determines if the status
-                        of the custom resource has reached the desired state.
-                      type: string
-                    failed:
-                      description: |-
-                        Failed is the CEL expression that determines if the status
-                        of the custom resource has failed to reach the desired state.
-                      type: string
-                    inProgress:
-                      description: |-
-                        InProgress is the CEL expression that determines if the status
-                        of the custom resource has not yet reached the desired state.
-                      type: string
-                    kind:
-                      description: Kind of the custom resource under evaluation.
-                      type: string
-                  required:
-                  - apiVersion
-                  - current
-                  - kind
-                  type: object
-                type: array
-              healthChecks:
-                description: A list of resources to be included in the health assessment.
-                items:
+                  type: array
+                force:
+                  default: false
                   description: |-
-                    NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
-                    in any namespace.
+                    Force instructs the controller to recreate resources
+                    when patching fails due to an immutable field change.
+                  type: boolean
+                healthCheckExprs:
+                  description: |-
+                    HealthCheckExprs is a list of healthcheck expressions for evaluating the
+                    health of custom resources using Common Expression Language (CEL).
+                    The expressions are evaluated only when Wait or HealthChecks are specified.
+                  items:
+                    description: CustomHealthCheck defines the health check for custom resources.
+                    properties:
+                      apiVersion:
+                        description: APIVersion of the custom resource under evaluation.
+                        type: string
+                      current:
+                        description: |-
+                          Current is the CEL expression that determines if the status
+                          of the custom resource has reached the desired state.
+                        type: string
+                      failed:
+                        description: |-
+                          Failed is the CEL expression that determines if the status
+                          of the custom resource has failed to reach the desired state.
+                        type: string
+                      inProgress:
+                        description: |-
+                          InProgress is the CEL expression that determines if the status
+                          of the custom resource has not yet reached the desired state.
+                        type: string
+                      kind:
+                        description: Kind of the custom resource under evaluation.
+                        type: string
+                    required:
+                      - apiVersion
+                      - current
+                      - kind
+                    type: object
+                  type: array
+                healthChecks:
+                  description: A list of resources to be included in the health assessment.
+                  items:
+                    description: |-
+                      NamespacedObjectKindReference contains enough information to locate the typed referenced Kubernetes resource object
+                      in any namespace.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                        type: string
+                      kind:
+                        description: Kind of the referent.
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                      namespace:
+                        description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                ignoreMissingComponents:
+                  description: |-
+                    IgnoreMissingComponents instructs the controller to ignore Components paths
+                    not found in source by removing them from the generated kustomization.yaml
+                    before running kustomize build.
+                  type: boolean
+                images:
+                  description: |-
+                    Images is a list of (image name, new name, new tag or digest)
+                    for changing image names, tags or digests. This can also be achieved with a
+                    patch, but this operator is simpler to specify.
+                  items:
+                    description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                    properties:
+                      digest:
+                        description: |-
+                          Digest is the value used to replace the original image tag.
+                          If digest is present NewTag value is ignored.
+                        type: string
+                      name:
+                        description: Name is a tag-less image name.
+                        type: string
+                      newName:
+                        description: NewName is the value used to replace the original name.
+                        type: string
+                      newTag:
+                        description: NewTag is the value used to replace the original tag.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                interval:
+                  description: |-
+                    The interval at which to reconcile the Kustomization.
+                    This interval is approximate and may be subject to jitter to ensure
+                    efficient use of resources.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                kubeConfig:
+                  description: |-
+                    The KubeConfig for reconciling the Kustomization on a remote cluster.
+                    When used in combination with KustomizationSpec.ServiceAccountName,
+                    forces the controller to act on behalf of that Service Account at the
+                    target cluster.
+                    If the --default-service-account flag is set, its value will be used as
+                    a controller level fallback for when KustomizationSpec.ServiceAccountName
+                    is empty.
+                  properties:
+                    configMapRef:
+                      description: |-
+                        ConfigMapRef holds an optional name of a ConfigMap that contains
+                        the following keys:
+
+                        - `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or
+                           `generic`. Required.
+                        - `cluster`: the fully qualified resource name of the Kubernetes
+                           cluster in the cloud provider API. Not used by the `generic`
+                           provider. Required when one of `address` or `ca.crt` is not set.
+                        - `address`: the address of the Kubernetes API server. Required
+                           for `generic`. For the other providers, if not specified, the
+                           first address in the cluster resource will be used, and if
+                           specified, it must match one of the addresses in the cluster
+                           resource.
+                           If audiences is not set, will be used as the audience for the
+                           `generic` provider.
+                        - `ca.crt`: the optional PEM-encoded CA certificate for the
+                           Kubernetes API server. If not set, the controller will use the
+                           CA certificate from the cluster resource.
+                        - `audiences`: the optional audiences as a list of
+                           line-break-separated strings for the Kubernetes ServiceAccount
+                           token. Defaults to the `address` for the `generic` provider, or
+                           to specific values for the other providers depending on the
+                           provider.
+                        -  `serviceAccountName`: the optional name of the Kubernetes
+                           ServiceAccount in the same namespace that should be used
+                           for authentication. If not specified, the controller
+                           ServiceAccount will be used.
+
+                        Mutually exclusive with SecretRef.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    secretRef:
+                      description: |-
+                        SecretRef holds an optional name of a secret that contains a key with
+                        the kubeconfig file as the value. If no key is set, the key will default
+                        to 'value'. Mutually exclusive with ConfigMapRef.
+                        It is recommended that the kubeconfig is self-contained, and the secret
+                        is regularly updated if credentials such as a cloud-access-token expire.
+                        Cloud specific `cmd-path` auth helpers will not function without adding
+                        binaries and credentials to the Pod that is responsible for reconciling
+                        Kubernetes resources. Supported only for the generic provider.
+                      properties:
+                        key:
+                          description: Key in the Secret, when not specified an implementation-specific default key is used.
+                          type: string
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified
+                      rule: has(self.configMapRef) || has(self.secretRef)
+                    - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified
+                      rule: '!has(self.configMapRef) || !has(self.secretRef)'
+                namePrefix:
+                  description: NamePrefix will prefix the names of all managed resources.
+                  maxLength: 200
+                  minLength: 1
+                  type: string
+                nameSuffix:
+                  description: NameSuffix will suffix the names of all managed resources.
+                  maxLength: 200
+                  minLength: 1
+                  type: string
+                patches:
+                  description: |-
+                    Strategic merge and JSON patches, defined as inline YAML objects,
+                    capable of targeting objects based on kind, label and annotation selectors.
+                  items:
+                    description: |-
+                      Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                      be applied to.
+                    properties:
+                      patch:
+                        description: |-
+                          Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                          an array of operation objects.
+                        type: string
+                      target:
+                        description: Target points to the resources that the patch document should be applied to.
+                        properties:
+                          annotationSelector:
+                            description: |-
+                              AnnotationSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource annotations.
+                            type: string
+                          group:
+                            description: |-
+                              Group is the API group to select resources from.
+                              Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the API Group to select resources from.
+                              Together with Group and Version it is capable of unambiguously
+                              identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                          labelSelector:
+                            description: |-
+                              LabelSelector is a string that follows the label selection expression
+                              https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                              It matches with the resource labels.
+                            type: string
+                          name:
+                            description: Name to match resources with.
+                            type: string
+                          namespace:
+                            description: Namespace to select resources from.
+                            type: string
+                          version:
+                            description: |-
+                              Version of the API Group to select resources from.
+                              Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                              https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                            type: string
+                        type: object
+                    required:
+                      - patch
+                    type: object
+                  type: array
+                path:
+                  description: |-
+                    Path to the directory containing the kustomization.yaml file, or the
+                    set of plain YAMLs a kustomization.yaml should be generated for.
+                    Defaults to 'None', which translates to the root path of the SourceRef.
+                  type: string
+                postBuild:
+                  description: |-
+                    PostBuild describes which actions to perform on the YAML manifest
+                    generated by building the kustomize overlay.
+                  properties:
+                    substitute:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Substitute holds a map of key/value pairs.
+                        The variables defined in your YAML manifests that match any of the keys
+                        defined in the map will be substituted with the set value.
+                        Includes support for bash string replacement functions
+                        e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
+                      type: object
+                    substituteFrom:
+                      description: |-
+                        SubstituteFrom holds references to ConfigMaps and Secrets containing
+                        the variables and their values to be substituted in the YAML manifests.
+                        The ConfigMap and the Secret data keys represent the var names, and they
+                        must match the vars declared in the manifests for the substitution to
+                        happen.
+                      items:
+                        description: |-
+                          SubstituteReference contains a reference to a resource containing
+                          the variables name and value.
+                        properties:
+                          kind:
+                            description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
+                            enum:
+                              - Secret
+                              - ConfigMap
+                            type: string
+                          name:
+                            description: |-
+                              Name of the values referent. Should reside in the same namespace as the
+                              referring resource.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          optional:
+                            default: false
+                            description: |-
+                              Optional indicates whether the referenced resource must exist, or whether to
+                              tolerate its absence. If true and the referenced resource is absent, proceed
+                              as if the resource was present but empty, without any variables defined.
+                            type: boolean
+                        required:
+                          - kind
+                          - name
+                        type: object
+                      type: array
+                  type: object
+                prune:
+                  description: Prune enables garbage collection.
+                  type: boolean
+                retryInterval:
+                  description: |-
+                    The interval at which to retry a previously failed reconciliation.
+                    When not specified, the controller uses the KustomizationSpec.Interval
+                    value to retry failures.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                serviceAccountName:
+                  description: |-
+                    The name of the Kubernetes service account to impersonate
+                    when reconciling this Kustomization.
+                  type: string
+                sourceRef:
+                  description: Reference of the source where the kustomization file is.
                   properties:
                     apiVersion:
-                      description: API version of the referent, if not specified the
-                        Kubernetes preferred version will be used.
+                      description: API version of the referent.
                       type: string
                     kind:
                       description: Kind of the referent.
+                      enum:
+                        - OCIRepository
+                        - GitRepository
+                        - Bucket
+                        - ExternalArtifact
                       type: string
                     name:
                       description: Name of the referent.
                       type: string
                     namespace:
-                      description: Namespace of the referent, when not specified it
-                        acts as LocalObjectReference.
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              ignoreMissingComponents:
-                description: |-
-                  IgnoreMissingComponents instructs the controller to ignore Components paths
-                  not found in source by removing them from the generated kustomization.yaml
-                  before running kustomize build.
-                type: boolean
-              images:
-                description: |-
-                  Images is a list of (image name, new name, new tag or digest)
-                  for changing image names, tags or digests. This can also be achieved with a
-                  patch, but this operator is simpler to specify.
-                items:
-                  description: Image contains an image name, a new name, a new tag
-                    or digest, which will replace the original name and tag.
-                  properties:
-                    digest:
                       description: |-
-                        Digest is the value used to replace the original image tag.
-                        If digest is present NewTag value is ignored.
-                      type: string
-                    name:
-                      description: Name is a tag-less image name.
-                      type: string
-                    newName:
-                      description: NewName is the value used to replace the original
-                        name.
-                      type: string
-                    newTag:
-                      description: NewTag is the value used to replace the original
-                        tag.
+                        Namespace of the referent, defaults to the namespace of the Kubernetes
+                        resource object that contains the reference.
                       type: string
                   required:
-                  - name
+                    - kind
+                    - name
                   type: object
-                type: array
-              interval:
-                description: |-
-                  The interval at which to reconcile the Kustomization.
-                  This interval is approximate and may be subject to jitter to ensure
-                  efficient use of resources.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              kubeConfig:
-                description: |-
-                  The KubeConfig for reconciling the Kustomization on a remote cluster.
-                  When used in combination with KustomizationSpec.ServiceAccountName,
-                  forces the controller to act on behalf of that Service Account at the
-                  target cluster.
-                  If the --default-service-account flag is set, its value will be used as
-                  a controller level fallback for when KustomizationSpec.ServiceAccountName
-                  is empty.
-                properties:
-                  configMapRef:
-                    description: |-
-                      ConfigMapRef holds an optional name of a ConfigMap that contains
-                      the following keys:
-
-                      - `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or
-                         `generic`. Required.
-                      - `cluster`: the fully qualified resource name of the Kubernetes
-                         cluster in the cloud provider API. Not used by the `generic`
-                         provider. Required when one of `address` or `ca.crt` is not set.
-                      - `address`: the address of the Kubernetes API server. Required
-                         for `generic`. For the other providers, if not specified, the
-                         first address in the cluster resource will be used, and if
-                         specified, it must match one of the addresses in the cluster
-                         resource.
-                         If audiences is not set, will be used as the audience for the
-                         `generic` provider.
-                      - `ca.crt`: the optional PEM-encoded CA certificate for the
-                         Kubernetes API server. If not set, the controller will use the
-                         CA certificate from the cluster resource.
-                      - `audiences`: the optional audiences as a list of
-                         line-break-separated strings for the Kubernetes ServiceAccount
-                         token. Defaults to the `address` for the `generic` provider, or
-                         to specific values for the other providers depending on the
-                         provider.
-                      -  `serviceAccountName`: the optional name of the Kubernetes
-                         ServiceAccount in the same namespace that should be used
-                         for authentication. If not specified, the controller
-                         ServiceAccount will be used.
-
-                      Mutually exclusive with SecretRef.
+                suspend:
+                  description: |-
+                    This flag tells the controller to suspend subsequent kustomize executions,
+                    it does not apply to already started executions. Defaults to false.
+                  type: boolean
+                targetNamespace:
+                  description: |-
+                    TargetNamespace sets or overrides the namespace in the
+                    kustomization.yaml file.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                timeout:
+                  description: |-
+                    Timeout for validation, apply and health checking operations.
+                    Defaults to 'Interval' duration.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                wait:
+                  description: |-
+                    Wait instructs the controller to check the health of all the reconciled
+                    resources. When enabled, the HealthChecks are ignored. Defaults to false.
+                  type: boolean
+              required:
+                - interval
+                - prune
+                - sourceRef
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: KustomizationStatus defines the observed state of a kustomization.
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
-                      name:
-                        description: Name of the referent.
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
                     required:
-                    - name
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
                     type: object
-                  secretRef:
+                  type: array
+                history:
+                  description: |-
+                    History contains a set of snapshots of the last reconciliation attempts
+                    tracking the revision, the state and the duration of each attempt.
+                  items:
                     description: |-
-                      SecretRef holds an optional name of a secret that contains a key with
-                      the kubeconfig file as the value. If no key is set, the key will default
-                      to 'value'. Mutually exclusive with ConfigMapRef.
-                      It is recommended that the kubeconfig is self-contained, and the secret
-                      is regularly updated if credentials such as a cloud-access-token expire.
-                      Cloud specific `cmd-path` auth helpers will not function without adding
-                      binaries and credentials to the Pod that is responsible for reconciling
-                      Kubernetes resources. Supported only for the generic provider.
+                      Snapshot represents a point-in-time record of a group of resources reconciliation,
+                      including timing information, status, and a unique digest identifier.
                     properties:
-                      key:
-                        description: Key in the Secret, when not specified an implementation-specific
-                          default key is used.
+                      digest:
+                        description: Digest is the checksum in the format `<algo>:<hex>` of the resources in this snapshot.
                         type: string
-                      name:
-                        description: Name of the Secret.
+                      firstReconciled:
+                        description: FirstReconciled is the time when this revision was first reconciled to the cluster.
+                        format: date-time
                         type: string
+                      lastReconciled:
+                        description: LastReconciled is the time when this revision was last reconciled to the cluster.
+                        format: date-time
+                        type: string
+                      lastReconciledDuration:
+                        description: LastReconciledDuration is time it took to reconcile the resources in this revision.
+                        type: string
+                      lastReconciledStatus:
+                        description: LastReconciledStatus is the status of the last reconciliation.
+                        type: string
+                      metadata:
+                        additionalProperties:
+                          type: string
+                        description: Metadata contains additional information about the snapshot.
+                        type: object
+                      totalReconciliations:
+                        description: TotalReconciliations is the total number of reconciliations that have occurred for this snapshot.
+                        format: int64
+                        type: integer
                     required:
-                    - name
+                      - digest
+                      - firstReconciled
+                      - lastReconciled
+                      - lastReconciledDuration
+                      - lastReconciledStatus
+                      - totalReconciliations
                     type: object
-                type: object
-                x-kubernetes-validations:
-                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
-                    must be specified
-                  rule: has(self.configMapRef) || has(self.secretRef)
-                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
-                    must be specified
-                  rule: '!has(self.configMapRef) || !has(self.secretRef)'
-              namePrefix:
-                description: NamePrefix will prefix the names of all managed resources.
-                maxLength: 200
-                minLength: 1
-                type: string
-              nameSuffix:
-                description: NameSuffix will suffix the names of all managed resources.
-                maxLength: 200
-                minLength: 1
-                type: string
-              patches:
-                description: |-
-                  Strategic merge and JSON patches, defined as inline YAML objects,
-                  capable of targeting objects based on kind, label and annotation selectors.
-                items:
+                  type: array
+                inventory:
                   description: |-
-                    Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                    be applied to.
+                    Inventory contains the list of Kubernetes resource object references that
+                    have been successfully applied.
                   properties:
-                    patch:
-                      description: |-
-                        Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                        an array of operation objects.
-                      type: string
-                    target:
-                      description: Target points to the resources that the patch document
-                        should be applied to.
-                      properties:
-                        annotationSelector:
-                          description: |-
-                            AnnotationSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource annotations.
-                          type: string
-                        group:
-                          description: |-
-                            Group is the API group to select resources from.
-                            Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        kind:
-                          description: |-
-                            Kind of the API Group to select resources from.
-                            Together with Group and Version it is capable of unambiguously
-                            identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                        labelSelector:
-                          description: |-
-                            LabelSelector is a string that follows the label selection expression
-                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                            It matches with the resource labels.
-                          type: string
-                        name:
-                          description: Name to match resources with.
-                          type: string
-                        namespace:
-                          description: Namespace to select resources from.
-                          type: string
-                        version:
-                          description: |-
-                            Version of the API Group to select resources from.
-                            Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                            https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                          type: string
-                      type: object
+                    entries:
+                      description: Entries of Kubernetes resource object references.
+                      items:
+                        description: ResourceRef contains the information necessary to locate a resource within a cluster.
+                        properties:
+                          id:
+                            description: |-
+                              ID is the string representation of the Kubernetes resource object's metadata,
+                              in the format '<namespace>_<name>_<group>_<kind>'.
+                            type: string
+                          v:
+                            description: Version is the API version of the Kubernetes resource object's kind.
+                            type: string
+                        required:
+                          - id
+                          - v
+                        type: object
+                      type: array
                   required:
-                  - patch
+                    - entries
                   type: object
-                type: array
-              path:
-                description: |-
-                  Path to the directory containing the kustomization.yaml file, or the
-                  set of plain YAMLs a kustomization.yaml should be generated for.
-                  Defaults to 'None', which translates to the root path of the SourceRef.
-                type: string
-              postBuild:
-                description: |-
-                  PostBuild describes which actions to perform on the YAML manifest
-                  generated by building the kustomize overlay.
-                properties:
-                  substitute:
-                    additionalProperties:
-                      type: string
-                    description: |-
-                      Substitute holds a map of key/value pairs.
-                      The variables defined in your YAML manifests that match any of the keys
-                      defined in the map will be substituted with the set value.
-                      Includes support for bash string replacement functions
-                      e.g. ${var:=default}, ${var:position} and ${var/substring/replacement}.
-                    type: object
-                  substituteFrom:
-                    description: |-
-                      SubstituteFrom holds references to ConfigMaps and Secrets containing
-                      the variables and their values to be substituted in the YAML manifests.
-                      The ConfigMap and the Secret data keys represent the var names, and they
-                      must match the vars declared in the manifests for the substitution to
-                      happen.
-                    items:
-                      description: |-
-                        SubstituteReference contains a reference to a resource containing
-                        the variables name and value.
-                      properties:
-                        kind:
-                          description: Kind of the values referent, valid values are
-                            ('Secret', 'ConfigMap').
-                          enum:
-                          - Secret
-                          - ConfigMap
-                          type: string
-                        name:
-                          description: |-
-                            Name of the values referent. Should reside in the same namespace as the
-                            referring resource.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        optional:
-                          default: false
-                          description: |-
-                            Optional indicates whether the referenced resource must exist, or whether to
-                            tolerate its absence. If true and the referenced resource is absent, proceed
-                            as if the resource was present but empty, without any variables defined.
-                          type: boolean
-                      required:
-                      - kind
-                      - name
-                      type: object
-                    type: array
-                type: object
-              prune:
-                description: Prune enables garbage collection.
-                type: boolean
-              retryInterval:
-                description: |-
-                  The interval at which to retry a previously failed reconciliation.
-                  When not specified, the controller uses the KustomizationSpec.Interval
-                  value to retry failures.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              serviceAccountName:
-                description: |-
-                  The name of the Kubernetes service account to impersonate
-                  when reconciling this Kustomization.
-                type: string
-              sourceRef:
-                description: Reference of the source where the kustomization file
-                  is.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  kind:
-                    description: Kind of the referent.
-                    enum:
-                    - OCIRepository
-                    - GitRepository
-                    - Bucket
-                    - ExternalArtifact
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent, defaults to the namespace of the Kubernetes
-                      resource object that contains the reference.
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              suspend:
-                description: |-
-                  This flag tells the controller to suspend subsequent kustomize executions,
-                  it does not apply to already started executions. Defaults to false.
-                type: boolean
-              targetNamespace:
-                description: |-
-                  TargetNamespace sets or overrides the namespace in the
-                  kustomization.yaml file.
-                maxLength: 63
-                minLength: 1
-                type: string
-              timeout:
-                description: |-
-                  Timeout for validation, apply and health checking operations.
-                  Defaults to 'Interval' duration.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              wait:
-                description: |-
-                  Wait instructs the controller to check the health of all the reconciled
-                  resources. When enabled, the HealthChecks are ignored. Defaults to false.
-                type: boolean
-            required:
-            - interval
-            - prune
-            - sourceRef
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: KustomizationStatus defines the observed state of a kustomization.
-            properties:
-              conditions:
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              history:
-                description: |-
-                  History contains a set of snapshots of the last reconciliation attempts
-                  tracking the revision, the state and the duration of each attempt.
-                items:
+                lastAppliedOriginRevision:
                   description: |-
-                    Snapshot represents a point-in-time record of a group of resources reconciliation,
-                    including timing information, status, and a unique digest identifier.
-                  properties:
-                    digest:
-                      description: Digest is the checksum in the format `<algo>:<hex>`
-                        of the resources in this snapshot.
-                      type: string
-                    firstReconciled:
-                      description: FirstReconciled is the time when this revision
-                        was first reconciled to the cluster.
-                      format: date-time
-                      type: string
-                    lastReconciled:
-                      description: LastReconciled is the time when this revision was
-                        last reconciled to the cluster.
-                      format: date-time
-                      type: string
-                    lastReconciledDuration:
-                      description: LastReconciledDuration is time it took to reconcile
-                        the resources in this revision.
-                      type: string
-                    lastReconciledStatus:
-                      description: LastReconciledStatus is the status of the last
-                        reconciliation.
-                      type: string
-                    metadata:
-                      additionalProperties:
-                        type: string
-                      description: Metadata contains additional information about
-                        the snapshot.
-                      type: object
-                    totalReconciliations:
-                      description: TotalReconciliations is the total number of reconciliations
-                        that have occurred for this snapshot.
-                      format: int64
-                      type: integer
-                  required:
-                  - digest
-                  - firstReconciled
-                  - lastReconciled
-                  - lastReconciledDuration
-                  - lastReconciledStatus
-                  - totalReconciliations
-                  type: object
-                type: array
-              inventory:
-                description: |-
-                  Inventory contains the list of Kubernetes resource object references that
-                  have been successfully applied.
-                properties:
-                  entries:
-                    description: Entries of Kubernetes resource object references.
-                    items:
-                      description: ResourceRef contains the information necessary
-                        to locate a resource within a cluster.
-                      properties:
-                        id:
-                          description: |-
-                            ID is the string representation of the Kubernetes resource object's metadata,
-                            in the format '<namespace>_<name>_<group>_<kind>'.
-                          type: string
-                        v:
-                          description: Version is the API version of the Kubernetes
-                            resource object's kind.
-                          type: string
-                      required:
-                      - id
-                      - v
-                      type: object
-                    type: array
-                required:
-                - entries
-                type: object
-              lastAppliedOriginRevision:
-                description: |-
-                  The last successfully applied origin revision.
-                  Equals the origin revision of the applied Artifact from the referenced Source.
-                  Usually present on the Metadata of the applied Artifact and depends on the
-                  Source type, e.g. for OCI it's the value associated with the key
-                  "org.opencontainers.image.revision".
-                type: string
-              lastAppliedRevision:
-                description: |-
-                  The last successfully applied revision.
-                  Equals the Revision of the applied Artifact from the referenced Source.
-                type: string
-              lastAttemptedRevision:
-                description: LastAttemptedRevision is the revision of the last reconciliation
-                  attempt.
-                type: string
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last reconciled generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    The last successfully applied origin revision.
+                    Equals the origin revision of the applied Artifact from the referenced Source.
+                    Usually present on the Metadata of the applied Artifact and depends on the
+                    Source type, e.g. for OCI it's the value associated with the key
+                    "org.opencontainers.image.revision".
+                  type: string
+                lastAppliedRevision:
+                  description: |-
+                    The last successfully applied revision.
+                    Equals the Revision of the applied Artifact from the referenced Source.
+                  type: string
+                lastAttemptedRevision:
+                  description: LastAttemptedRevision is the revision of the last reconciliation attempt.
+                  type: string
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last reconciled generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -3371,59 +3308,59 @@ spec:
         app.kubernetes.io/version: v2.8.6
     spec:
       containers:
-      - args:
-        - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
-        - --watch-all-namespaces=true
-        - --log-level=info
-        - --log-encoding=json
-        - --enable-leader-election
-        env:
-        - name: RUNTIME_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: manager
-              resource: limits.memory
-        image: ghcr.io/fluxcd/kustomize-controller:v1.8.4
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-        name: manager
-        ports:
-        - containerPort: 8080
-          name: http-prom
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp
-          name: temp
+        - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: manager
+                  resource: limits.memory
+          image: ghcr.io/fluxcd/kustomize-controller:v1.8.4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -3432,8 +3369,8 @@ spec:
       serviceAccountName: kustomize-controller
       terminationGracePeriodSeconds: 60
       volumes:
-      - emptyDir: {}
-        name: temp
+        - emptyDir: {}
+          name: temp
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3453,1439 +3390,1397 @@ spec:
     listKind: HelmReleaseList
     plural: helmreleases
     shortNames:
-    - hr
+      - hr
     singular: helmrelease
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v2
-    schema:
-      openAPIV3Schema:
-        description: HelmRelease is the Schema for the helmreleases API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HelmReleaseSpec defines the desired state of a Helm release.
-            properties:
-              chart:
-                description: |-
-                  Chart defines the template of the v1.HelmChart that should be created
-                  for this HelmRelease.
-                properties:
-                  metadata:
-                    description: ObjectMeta holds the template for metadata like labels
-                      and annotations.
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-                        type: object
-                      labels:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-                        type: object
-                    type: object
-                  spec:
-                    description: Spec holds the template for the v1.HelmChartSpec
-                      for this HelmRelease.
-                    properties:
-                      chart:
-                        description: The name or path the Helm chart is available
-                          at in the SourceRef.
-                        maxLength: 2048
-                        minLength: 1
-                        type: string
-                      ignoreMissingValuesFiles:
-                        description: IgnoreMissingValuesFiles controls whether to
-                          silently ignore missing values files rather than failing.
-                        type: boolean
-                      interval:
-                        description: |-
-                          Interval at which to check the v1.Source for updates. Defaults to
-                          'HelmReleaseSpec.Interval'.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                        type: string
-                      reconcileStrategy:
-                        default: ChartVersion
-                        description: |-
-                          Determines what enables the creation of a new artifact. Valid values are
-                          ('ChartVersion', 'Revision').
-                          See the documentation of the values for an explanation on their behavior.
-                          Defaults to ChartVersion when omitted.
-                        enum:
-                        - ChartVersion
-                        - Revision
-                        type: string
-                      sourceRef:
-                        description: The name and namespace of the v1.Source the chart
-                          is available at.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referent.
-                            type: string
-                          kind:
-                            description: Kind of the referent.
-                            enum:
-                            - HelmRepository
-                            - GitRepository
-                            - Bucket
-                            type: string
-                          name:
-                            description: Name of the referent.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: Namespace of the referent.
-                            maxLength: 63
-                            minLength: 1
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                      valuesFiles:
-                        description: |-
-                          Alternative list of values files to use as the chart values (values.yaml
-                          is not included by default), expected to be a relative path in the SourceRef.
-                          Values files are merged in the order of this list with the last file overriding
-                          the first. Ignored when omitted.
-                        items:
-                          type: string
-                        type: array
-                      verify:
-                        description: |-
-                          Verify contains the secret name containing the trusted public keys
-                          used to verify the signature and specifies which provider to use to check
-                          whether OCI image is authentic.
-                          This field is only supported for OCI sources.
-                          Chart dependencies, which are not bundled in the umbrella chart artifact,
-                          are not verified.
-                        properties:
-                          provider:
-                            default: cosign
-                            description: Provider specifies the technology used to
-                              sign the OCI Helm chart.
-                            enum:
-                            - cosign
-                            - notation
-                            type: string
-                          secretRef:
-                            description: |-
-                              SecretRef specifies the Kubernetes Secret containing the
-                              trusted public keys.
-                            properties:
-                              name:
-                                description: Name of the referent.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                        required:
-                        - provider
-                        type: object
-                      version:
-                        default: '*'
-                        description: |-
-                          Version semver expression, ignored for charts from v1.GitRepository and
-                          v1beta2.Bucket sources. Defaults to latest when omitted.
-                        type: string
-                    required:
-                    - chart
-                    - sourceRef
-                    type: object
-                required:
-                - spec
-                type: object
-              chartRef:
-                description: |-
-                  ChartRef holds a reference to a source controller resource containing the
-                  Helm chart artifact.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referent.
-                    type: string
-                  kind:
-                    description: Kind of the referent.
-                    enum:
-                    - OCIRepository
-                    - HelmChart
-                    - ExternalArtifact
-                    type: string
-                  name:
-                    description: Name of the referent.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  namespace:
-                    description: |-
-                      Namespace of the referent, defaults to the namespace of the Kubernetes
-                      resource object that contains the reference.
-                    maxLength: 63
-                    minLength: 1
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-              commonMetadata:
-                description: |-
-                  CommonMetadata specifies the common labels and annotations that are
-                  applied to all resources. Any existing label or annotation will be
-                  overridden if its key matches a common one.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations to be added to the object's metadata.
-                    type: object
-                  labels:
-                    additionalProperties:
-                      type: string
-                    description: Labels to be added to the object's metadata.
-                    type: object
-                type: object
-              dependsOn:
-                description: |-
-                  DependsOn may contain a DependencyReference slice with
-                  references to HelmRelease resources that must be ready before this HelmRelease
-                  can be reconciled.
-                items:
-                  description: DependencyReference defines a HelmRelease dependency
-                    on another HelmRelease resource.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v2
+      schema:
+        openAPIV3Schema:
+          description: HelmRelease is the Schema for the helmreleases API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HelmReleaseSpec defines the desired state of a Helm release.
+              properties:
+                chart:
+                  description: |-
+                    Chart defines the template of the v1.HelmChart that should be created
+                    for this HelmRelease.
                   properties:
-                    name:
-                      description: Name of the referent.
-                      type: string
-                    namespace:
-                      description: |-
-                        Namespace of the referent, defaults to the namespace of the HelmRelease
-                        resource object that contains the reference.
-                      type: string
-                    readyExpr:
-                      description: |-
-                        ReadyExpr is a CEL expression that can be used to assess the readiness
-                        of a dependency. When specified, the built-in readiness check
-                        is replaced by the logic defined in the CEL expression.
-                        To make the CEL expression additive to the built-in readiness check,
-                        the feature gate `AdditiveCELDependencyCheck` must be set to `true`.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-              driftDetection:
-                description: |-
-                  DriftDetection holds the configuration for detecting and handling
-                  differences between the manifest in the Helm storage and the resources
-                  currently existing in the cluster.
-                properties:
-                  ignore:
-                    description: |-
-                      Ignore contains a list of rules for specifying which changes to ignore
-                      during diffing.
-                    items:
-                      description: |-
-                        IgnoreRule defines a rule to selectively disregard specific changes during
-                        the drift detection process.
+                    metadata:
+                      description: ObjectMeta holds the template for metadata like labels and annotations.
                       properties:
-                        paths:
+                        annotations:
+                          additionalProperties:
+                            type: string
                           description: |-
-                            Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
-                            consideration in a Kubernetes object.
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                          type: object
+                      type: object
+                    spec:
+                      description: Spec holds the template for the v1.HelmChartSpec for this HelmRelease.
+                      properties:
+                        chart:
+                          description: The name or path the Helm chart is available at in the SourceRef.
+                          maxLength: 2048
+                          minLength: 1
+                          type: string
+                        ignoreMissingValuesFiles:
+                          description: IgnoreMissingValuesFiles controls whether to silently ignore missing values files rather than failing.
+                          type: boolean
+                        interval:
+                          description: |-
+                            Interval at which to check the v1.Source for updates. Defaults to
+                            'HelmReleaseSpec.Interval'.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                        reconcileStrategy:
+                          default: ChartVersion
+                          description: |-
+                            Determines what enables the creation of a new artifact. Valid values are
+                            ('ChartVersion', 'Revision').
+                            See the documentation of the values for an explanation on their behavior.
+                            Defaults to ChartVersion when omitted.
+                          enum:
+                            - ChartVersion
+                            - Revision
+                          type: string
+                        sourceRef:
+                          description: The name and namespace of the v1.Source the chart is available at.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the referent.
+                              type: string
+                            kind:
+                              description: Kind of the referent.
+                              enum:
+                                - HelmRepository
+                                - GitRepository
+                                - Bucket
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: Namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        valuesFiles:
+                          description: |-
+                            Alternative list of values files to use as the chart values (values.yaml
+                            is not included by default), expected to be a relative path in the SourceRef.
+                            Values files are merged in the order of this list with the last file overriding
+                            the first. Ignored when omitted.
                           items:
                             type: string
                           type: array
-                        target:
+                        verify:
                           description: |-
-                            Target is a selector for specifying Kubernetes objects to which this
-                            rule applies.
-                            If Target is not set, the Paths will be ignored for all Kubernetes
-                            objects within the manifest of the Helm release.
+                            Verify contains the secret name containing the trusted public keys
+                            used to verify the signature and specifies which provider to use to check
+                            whether OCI image is authentic.
+                            This field is only supported for OCI sources.
+                            Chart dependencies, which are not bundled in the umbrella chart artifact,
+                            are not verified.
                           properties:
-                            annotationSelector:
+                            provider:
+                              default: cosign
+                              description: Provider specifies the technology used to sign the OCI Helm chart.
+                              enum:
+                                - cosign
+                                - notation
+                              type: string
+                            secretRef:
                               description: |-
-                                AnnotationSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource annotations.
-                              type: string
-                            group:
-                              description: |-
-                                Group is the API group to select resources from.
-                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                            kind:
-                              description: |-
-                                Kind of the API Group to select resources from.
-                                Together with Group and Version it is capable of unambiguously
-                                identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
-                            labelSelector:
-                              description: |-
-                                LabelSelector is a string that follows the label selection expression
-                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                It matches with the resource labels.
-                              type: string
-                            name:
-                              description: Name to match resources with.
-                              type: string
-                            namespace:
-                              description: Namespace to select resources from.
-                              type: string
-                            version:
-                              description: |-
-                                Version of the API Group to select resources from.
-                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                              type: string
+                                SecretRef specifies the Kubernetes Secret containing the
+                                trusted public keys.
+                              properties:
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - provider
                           type: object
+                        version:
+                          default: '*'
+                          description: |-
+                            Version semver expression, ignored for charts from v1.GitRepository and
+                            v1beta2.Bucket sources. Defaults to latest when omitted.
+                          type: string
                       required:
-                      - paths
+                        - chart
+                        - sourceRef
                       type: object
-                    type: array
-                  mode:
-                    description: |-
-                      Mode defines how differences should be handled between the Helm manifest
-                      and the manifest currently applied to the cluster.
-                      If not explicitly set, it defaults to DiffModeDisabled.
-                    enum:
-                    - enabled
-                    - warn
-                    - disabled
-                    type: string
-                type: object
-              healthCheckExprs:
-                description: |-
-                  HealthCheckExprs is a list of healthcheck expressions for evaluating the
-                  health of custom resources using Common Expression Language (CEL).
-                  The expressions are evaluated only when the specific Helm action
-                  taking place has wait enabled, i.e. DisableWait is false, and the
-                  'poller' WaitStrategy is used.
-                items:
-                  description: CustomHealthCheck defines the health check for custom
-                    resources.
+                  required:
+                    - spec
+                  type: object
+                chartRef:
+                  description: |-
+                    ChartRef holds a reference to a source controller resource containing the
+                    Helm chart artifact.
                   properties:
                     apiVersion:
-                      description: APIVersion of the custom resource under evaluation.
-                      type: string
-                    current:
-                      description: |-
-                        Current is the CEL expression that determines if the status
-                        of the custom resource has reached the desired state.
-                      type: string
-                    failed:
-                      description: |-
-                        Failed is the CEL expression that determines if the status
-                        of the custom resource has failed to reach the desired state.
-                      type: string
-                    inProgress:
-                      description: |-
-                        InProgress is the CEL expression that determines if the status
-                        of the custom resource has not yet reached the desired state.
+                      description: APIVersion of the referent.
                       type: string
                     kind:
-                      description: Kind of the custom resource under evaluation.
+                      description: Kind of the referent.
+                      enum:
+                        - OCIRepository
+                        - HelmChart
+                        - ExternalArtifact
+                      type: string
+                    name:
+                      description: Name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent, defaults to the namespace of the Kubernetes
+                        resource object that contains the reference.
+                      maxLength: 63
+                      minLength: 1
                       type: string
                   required:
-                  - apiVersion
-                  - current
-                  - kind
-                  type: object
-                type: array
-              install:
-                description: Install holds the configuration for Helm install actions
-                  for this HelmRelease.
-                properties:
-                  crds:
-                    description: |-
-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
-                      `Create` or `CreateReplace`. Default is `Create` and if omitted
-                      CRDs are installed but not updated.
-
-                      Skip: do neither install nor replace (update) any CRDs.
-
-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-
-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                      but not deleted.
-
-                      By default, CRDs are applied (installed) during Helm install action.
-                      With this option users can opt in to CRD replace existing CRDs on Helm
-                      install actions, which is not (yet) natively supported by Helm.
-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                    enum:
-                    - Skip
-                    - Create
-                    - CreateReplace
-                    type: string
-                  createNamespace:
-                    description: |-
-                      CreateNamespace tells the Helm install action to create the
-                      HelmReleaseSpec.TargetNamespace if it does not exist yet.
-                      On uninstall, the namespace will not be garbage collected.
-                    type: boolean
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the
-                      Helm install action.
-                    type: boolean
-                  disableOpenAPIValidation:
-                    description: |-
-                      DisableOpenAPIValidation prevents the Helm install action from validating
-                      rendered templates against the Kubernetes OpenAPI Schema.
-                    type: boolean
-                  disableSchemaValidation:
-                    description: |-
-                      DisableSchemaValidation prevents the Helm install action from validating
-                      the values against the JSON Schema.
-                    type: boolean
-                  disableTakeOwnership:
-                    description: |-
-                      DisableTakeOwnership disables taking ownership of existing resources
-                      during the Helm install action. Defaults to false.
-                    type: boolean
-                  disableWait:
-                    description: |-
-                      DisableWait disables the waiting for resources to be ready after a Helm
-                      install has been performed.
-                    type: boolean
-                  disableWaitForJobs:
-                    description: |-
-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                      install has been performed.
-                    type: boolean
-                  remediation:
-                    description: |-
-                      Remediation holds the remediation configuration for when the Helm install
-                      action for the HelmRelease fails. The default is to not perform any action.
-                    properties:
-                      ignoreTestFailures:
-                        description: |-
-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
-                          tests are run after an install action but fail. Defaults to
-                          'Test.IgnoreFailures'.
-                        type: boolean
-                      remediateLastFailure:
-                        description: |-
-                          RemediateLastFailure tells the controller to remediate the last failure, when
-                          no retries remain. Defaults to 'false'.
-                        type: boolean
-                      retries:
-                        description: |-
-                          Retries is the number of retries that should be attempted on failures before
-                          bailing. Remediation, using an uninstall, is performed between each attempt.
-                          Defaults to '0', a negative integer equals to unlimited retries.
-                        type: integer
-                    type: object
-                  replace:
-                    description: |-
-                      Replace tells the Helm install action to re-use the 'ReleaseName', but only
-                      if that name is a deleted release which remains in the history.
-                    type: boolean
-                  serverSideApply:
-                    description: |-
-                      ServerSideApply enables server-side apply for resources during install.
-                      Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
-                    type: boolean
-                  skipCRDs:
-                    description: |-
-                      SkipCRDs tells the Helm install action to not install any CRDs. By default,
-                      CRDs are installed if not already present.
-
-                      Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
-                    type: boolean
-                  strategy:
-                    description: |-
-                      Strategy defines the install strategy to use for this HelmRelease.
-                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
-                      DefaultToRetryOnFailure feature gate is enabled.
-                    properties:
-                      name:
-                        description: Name of the install strategy.
-                        enum:
-                        - RemediateOnFailure
-                        - RetryOnFailure
-                        type: string
-                      retryInterval:
-                        description: |-
-                          RetryInterval is the interval at which to retry a failed install.
-                          Can be used only when Name is set to RetryOnFailure.
-                          Defaults to '5m'.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                        type: string
-                    required:
+                    - kind
                     - name
-                    type: object
-                    x-kubernetes-validations:
-                    - message: .retryInterval cannot be set when .name is 'RemediateOnFailure'
-                      rule: '!has(self.retryInterval) || self.name != ''RemediateOnFailure'''
-                  timeout:
-                    description: |-
-                      Timeout is the time to wait for any individual Kubernetes operation (like
-                      Jobs for hooks) during the performance of a Helm install action. Defaults to
-                      'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                    type: string
-                type: object
-              interval:
-                description: Interval at which to reconcile the Helm release.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              kubeConfig:
-                description: |-
-                  KubeConfig for reconciling the HelmRelease on a remote cluster.
-                  When used in combination with HelmReleaseSpec.ServiceAccountName,
-                  forces the controller to act on behalf of that Service Account at the
-                  target cluster.
-                  If the --default-service-account flag is set, its value will be used as
-                  a controller level fallback for when HelmReleaseSpec.ServiceAccountName
-                  is empty.
-                properties:
-                  configMapRef:
-                    description: |-
-                      ConfigMapRef holds an optional name of a ConfigMap that contains
-                      the following keys:
-
-                      - `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or
-                         `generic`. Required.
-                      - `cluster`: the fully qualified resource name of the Kubernetes
-                         cluster in the cloud provider API. Not used by the `generic`
-                         provider. Required when one of `address` or `ca.crt` is not set.
-                      - `address`: the address of the Kubernetes API server. Required
-                         for `generic`. For the other providers, if not specified, the
-                         first address in the cluster resource will be used, and if
-                         specified, it must match one of the addresses in the cluster
-                         resource.
-                         If audiences is not set, will be used as the audience for the
-                         `generic` provider.
-                      - `ca.crt`: the optional PEM-encoded CA certificate for the
-                         Kubernetes API server. If not set, the controller will use the
-                         CA certificate from the cluster resource.
-                      - `audiences`: the optional audiences as a list of
-                         line-break-separated strings for the Kubernetes ServiceAccount
-                         token. Defaults to the `address` for the `generic` provider, or
-                         to specific values for the other providers depending on the
-                         provider.
-                      -  `serviceAccountName`: the optional name of the Kubernetes
-                         ServiceAccount in the same namespace that should be used
-                         for authentication. If not specified, the controller
-                         ServiceAccount will be used.
-
-                      Mutually exclusive with SecretRef.
+                  type: object
+                commonMetadata:
+                  description: |-
+                    CommonMetadata specifies the common labels and annotations that are
+                    applied to all resources. Any existing label or annotation will be
+                    overridden if its key matches a common one.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to be added to the object's metadata.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels to be added to the object's metadata.
+                      type: object
+                  type: object
+                dependsOn:
+                  description: |-
+                    DependsOn may contain a DependencyReference slice with
+                    references to HelmRelease resources that must be ready before this HelmRelease
+                    can be reconciled.
+                  items:
+                    description: DependencyReference defines a HelmRelease dependency on another HelmRelease resource.
                     properties:
                       name:
                         description: Name of the referent.
                         type: string
-                    required:
-                    - name
-                    type: object
-                  secretRef:
-                    description: |-
-                      SecretRef holds an optional name of a secret that contains a key with
-                      the kubeconfig file as the value. If no key is set, the key will default
-                      to 'value'. Mutually exclusive with ConfigMapRef.
-                      It is recommended that the kubeconfig is self-contained, and the secret
-                      is regularly updated if credentials such as a cloud-access-token expire.
-                      Cloud specific `cmd-path` auth helpers will not function without adding
-                      binaries and credentials to the Pod that is responsible for reconciling
-                      Kubernetes resources. Supported only for the generic provider.
-                    properties:
-                      key:
-                        description: Key in the Secret, when not specified an implementation-specific
-                          default key is used.
+                      namespace:
+                        description: |-
+                          Namespace of the referent, defaults to the namespace of the HelmRelease
+                          resource object that contains the reference.
                         type: string
-                      name:
-                        description: Name of the Secret.
+                      readyExpr:
+                        description: |-
+                          ReadyExpr is a CEL expression that can be used to assess the readiness
+                          of a dependency. When specified, the built-in readiness check
+                          is replaced by the logic defined in the CEL expression.
+                          To make the CEL expression additive to the built-in readiness check,
+                          the feature gate `AdditiveCELDependencyCheck` must be set to `true`.
                         type: string
                     required:
-                    - name
+                      - name
                     type: object
-                type: object
-                x-kubernetes-validations:
-                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
-                    must be specified
-                  rule: has(self.configMapRef) || has(self.secretRef)
-                - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef
-                    must be specified
-                  rule: '!has(self.configMapRef) || !has(self.secretRef)'
-              maxHistory:
-                description: |-
-                  MaxHistory is the number of revisions saved by Helm for this HelmRelease.
-                  Use '0' for an unlimited number of revisions; defaults to '5'.
-                type: integer
-              persistentClient:
-                description: |-
-                  PersistentClient tells the controller to use a persistent Kubernetes
-                  client for this release. When enabled, the client will be reused for the
-                  duration of the reconciliation, instead of being created and destroyed
-                  for each (step of a) Helm action.
-
-                  This can improve performance, but may cause issues with some Helm charts
-                  that for example do create Custom Resource Definitions during installation
-                  outside Helm's CRD lifecycle hooks, which are then not observed to be
-                  available by e.g. post-install hooks.
-
-                  If not set, it defaults to true.
-                type: boolean
-              postRenderers:
-                description: |-
-                  PostRenderers holds an array of Helm PostRenderers, which will be applied in order
-                  of their definition.
-                items:
-                  description: PostRenderer contains a Helm PostRenderer specification.
+                  type: array
+                driftDetection:
+                  description: |-
+                    DriftDetection holds the configuration for detecting and handling
+                    differences between the manifest in the Helm storage and the resources
+                    currently existing in the cluster.
                   properties:
-                    kustomize:
-                      description: Kustomization to apply as PostRenderer.
-                      properties:
-                        images:
-                          description: |-
-                            Images is a list of (image name, new name, new tag or digest)
-                            for changing image names, tags or digests. This can also be achieved with a
-                            patch, but this operator is simpler to specify.
-                          items:
-                            description: Image contains an image name, a new name,
-                              a new tag or digest, which will replace the original
-                              name and tag.
+                    ignore:
+                      description: |-
+                        Ignore contains a list of rules for specifying which changes to ignore
+                        during diffing.
+                      items:
+                        description: |-
+                          IgnoreRule defines a rule to selectively disregard specific changes during
+                          the drift detection process.
+                        properties:
+                          paths:
+                            description: |-
+                              Paths is a list of JSON Pointer (RFC 6901) paths to be excluded from
+                              consideration in a Kubernetes object.
+                            items:
+                              type: string
+                            type: array
+                          target:
+                            description: |-
+                              Target is a selector for specifying Kubernetes objects to which this
+                              rule applies.
+                              If Target is not set, the Paths will be ignored for all Kubernetes
+                              objects within the manifest of the Helm release.
                             properties:
-                              digest:
+                              annotationSelector:
                                 description: |-
-                                  Digest is the value used to replace the original image tag.
-                                  If digest is present NewTag value is ignored.
+                                  AnnotationSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource annotations.
+                                type: string
+                              group:
+                                description: |-
+                                  Group is the API group to select resources from.
+                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the API Group to select resources from.
+                                  Together with Group and Version it is capable of unambiguously
+                                  identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                type: string
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource labels.
                                 type: string
                               name:
-                                description: Name is a tag-less image name.
+                                description: Name to match resources with.
                                 type: string
-                              newName:
-                                description: NewName is the value used to replace
-                                  the original name.
+                              namespace:
+                                description: Namespace to select resources from.
                                 type: string
-                              newTag:
-                                description: NewTag is the value used to replace the
-                                  original tag.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        patches:
-                          description: |-
-                            Strategic merge and JSON patches, defined as inline YAML objects,
-                            capable of targeting objects based on kind, label and annotation selectors.
-                          items:
-                            description: |-
-                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
-                              be applied to.
-                            properties:
-                              patch:
+                              version:
                                 description: |-
-                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
-                                  an array of operation objects.
+                                  Version of the API Group to select resources from.
+                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                 type: string
-                              target:
-                                description: Target points to the resources that the
-                                  patch document should be applied to.
-                                properties:
-                                  annotationSelector:
-                                    description: |-
-                                      AnnotationSelector is a string that follows the label selection expression
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                      It matches with the resource annotations.
-                                    type: string
-                                  group:
-                                    description: |-
-                                      Group is the API group to select resources from.
-                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                    type: string
-                                  kind:
-                                    description: |-
-                                      Kind of the API Group to select resources from.
-                                      Together with Group and Version it is capable of unambiguously
-                                      identifying and/or selecting resources.
-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                    type: string
-                                  labelSelector:
-                                    description: |-
-                                      LabelSelector is a string that follows the label selection expression
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
-                                      It matches with the resource labels.
-                                    type: string
-                                  name:
-                                    description: Name to match resources with.
-                                    type: string
-                                  namespace:
-                                    description: Namespace to select resources from.
-                                    type: string
-                                  version:
-                                    description: |-
-                                      Version of the API Group to select resources from.
-                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
-                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
-                                    type: string
-                                type: object
-                            required:
-                            - patch
                             type: object
-                          type: array
-                      type: object
+                        required:
+                          - paths
+                        type: object
+                      type: array
+                    mode:
+                      description: |-
+                        Mode defines how differences should be handled between the Helm manifest
+                        and the manifest currently applied to the cluster.
+                        If not explicitly set, it defaults to DiffModeDisabled.
+                      enum:
+                        - enabled
+                        - warn
+                        - disabled
+                      type: string
                   type: object
-                type: array
-              releaseName:
-                description: |-
-                  ReleaseName used for the Helm release. Defaults to a composition of
-                  '[TargetNamespace-]Name'.
-                maxLength: 53
-                minLength: 1
-                type: string
-              rollback:
-                description: Rollback holds the configuration for Helm rollback actions
-                  for this HelmRelease.
-                properties:
-                  cleanupOnFail:
-                    description: |-
-                      CleanupOnFail allows deletion of new resources created during the Helm
-                      rollback action when it fails.
-                    type: boolean
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the
-                      Helm rollback action.
-                    type: boolean
-                  disableWait:
-                    description: |-
-                      DisableWait disables the waiting for resources to be ready after a Helm
-                      rollback has been performed.
-                    type: boolean
-                  disableWaitForJobs:
-                    description: |-
-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                      rollback has been performed.
-                    type: boolean
-                  force:
-                    description: |-
-                      Force forces resource updates through a replacement strategy
-                      that avoids 3-way merge conflicts on client-side apply.
-                      This field is ignored for server-side apply (which always
-                      forces conflicts with other field managers).
-                    type: boolean
-                  recreate:
-                    description: |-
-                      Recreate performs pod restarts for any managed workloads.
-
-                      Deprecated: This behavior was deprecated in Helm 3:
-                        - Deprecation: https://github.com/helm/helm/pull/6463
-                        - Removal: https://github.com/helm/helm/pull/31023
-                      After helm-controller was upgraded to the Helm 4 SDK,
-                      this field is no longer functional and will print a
-                      warning if set to true. It will also be removed in a
-                      future release.
-                    type: boolean
-                  serverSideApply:
-                    description: |-
-                      ServerSideApply enables server-side apply for resources during rollback.
-                      Can be "enabled", "disabled", or "auto".
-                      When "auto", server-side apply usage will be based on the release's previous usage.
-                      Defaults to "auto".
-                    enum:
-                    - enabled
-                    - disabled
-                    - auto
-                    type: string
-                  timeout:
-                    description: |-
-                      Timeout is the time to wait for any individual Kubernetes operation (like
-                      Jobs for hooks) during the performance of a Helm rollback action. Defaults to
-                      'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                    type: string
-                type: object
-              serviceAccountName:
-                description: |-
-                  The name of the Kubernetes service account to impersonate
-                  when reconciling this HelmRelease.
-                maxLength: 253
-                minLength: 1
-                type: string
-              storageNamespace:
-                description: |-
-                  StorageNamespace used for the Helm storage.
-                  Defaults to the namespace of the HelmRelease.
-                maxLength: 63
-                minLength: 1
-                type: string
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend reconciliation for this HelmRelease,
-                  it does not apply to already started reconciliations. Defaults to false.
-                type: boolean
-              targetNamespace:
-                description: |-
-                  TargetNamespace to target when performing operations for the HelmRelease.
-                  Defaults to the namespace of the HelmRelease.
-                maxLength: 63
-                minLength: 1
-                type: string
-              test:
-                description: Test holds the configuration for Helm test actions for
-                  this HelmRelease.
-                properties:
-                  enable:
-                    description: |-
-                      Enable enables Helm test actions for this HelmRelease after an Helm install
-                      or upgrade action has been performed.
-                    type: boolean
-                  filters:
-                    description: Filters is a list of tests to run or exclude from
-                      running.
-                    items:
-                      description: Filter holds the configuration for individual Helm
-                        test filters.
-                      properties:
-                        exclude:
-                          description: Exclude specifies whether the named test should
-                            be excluded.
-                          type: boolean
-                        name:
-                          description: Name is the name of the test.
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  ignoreFailures:
-                    description: |-
-                      IgnoreFailures tells the controller to skip remediation when the Helm tests
-                      are run but fail. Can be overwritten for tests run after install or upgrade
-                      actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
-                    type: boolean
-                  timeout:
-                    description: |-
-                      Timeout is the time to wait for any individual Kubernetes operation during
-                      the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                    type: string
-                type: object
-              timeout:
-                description: |-
-                  Timeout is the time to wait for any individual Kubernetes operation (like Jobs
-                  for hooks) during the performance of a Helm action. Defaults to '5m0s'.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              uninstall:
-                description: Uninstall holds the configuration for Helm uninstall
-                  actions for this HelmRelease.
-                properties:
-                  deletionPropagation:
-                    default: background
-                    description: |-
-                      DeletionPropagation specifies the deletion propagation policy when
-                      a Helm uninstall is performed.
-                    enum:
-                    - background
-                    - foreground
-                    - orphan
-                    type: string
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the
-                      Helm rollback action.
-                    type: boolean
-                  disableWait:
-                    description: |-
-                      DisableWait disables waiting for all the resources to be deleted after
-                      a Helm uninstall is performed.
-                    type: boolean
-                  keepHistory:
-                    description: |-
-                      KeepHistory tells Helm to remove all associated resources and mark the
-                      release as deleted, but retain the release history.
-                    type: boolean
-                  timeout:
-                    description: |-
-                      Timeout is the time to wait for any individual Kubernetes operation (like
-                      Jobs for hooks) during the performance of a Helm uninstall action. Defaults
-                      to 'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                    type: string
-                type: object
-              upgrade:
-                description: Upgrade holds the configuration for Helm upgrade actions
-                  for this HelmRelease.
-                properties:
-                  cleanupOnFail:
-                    description: |-
-                      CleanupOnFail allows deletion of new resources created during the Helm
-                      upgrade action when it fails.
-                    type: boolean
-                  crds:
-                    description: |-
-                      CRDs upgrade CRDs from the Helm Chart's crds directory according
-                      to the CRD upgrade policy provided here. Valid values are `Skip`,
-                      `Create` or `CreateReplace`. Default is `Skip` and if omitted
-                      CRDs are neither installed nor upgraded.
-
-                      Skip: do neither install nor replace (update) any CRDs.
-
-                      Create: new CRDs are created, existing CRDs are neither updated nor deleted.
-
-                      CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
-                      but not deleted.
-
-                      By default, CRDs are not applied during Helm upgrade action. With this
-                      option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
-                      https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
-                    enum:
-                    - Skip
-                    - Create
-                    - CreateReplace
-                    type: string
-                  disableHooks:
-                    description: DisableHooks prevents hooks from running during the
-                      Helm upgrade action.
-                    type: boolean
-                  disableOpenAPIValidation:
-                    description: |-
-                      DisableOpenAPIValidation prevents the Helm upgrade action from validating
-                      rendered templates against the Kubernetes OpenAPI Schema.
-                    type: boolean
-                  disableSchemaValidation:
-                    description: |-
-                      DisableSchemaValidation prevents the Helm upgrade action from validating
-                      the values against the JSON Schema.
-                    type: boolean
-                  disableTakeOwnership:
-                    description: |-
-                      DisableTakeOwnership disables taking ownership of existing resources
-                      during the Helm upgrade action. Defaults to false.
-                    type: boolean
-                  disableWait:
-                    description: |-
-                      DisableWait disables the waiting for resources to be ready after a Helm
-                      upgrade has been performed.
-                    type: boolean
-                  disableWaitForJobs:
-                    description: |-
-                      DisableWaitForJobs disables waiting for jobs to complete after a Helm
-                      upgrade has been performed.
-                    type: boolean
-                  force:
-                    description: |-
-                      Force forces resource updates through a replacement strategy
-                      that avoids 3-way merge conflicts on client-side apply.
-                      This field is ignored for server-side apply (which always
-                      forces conflicts with other field managers).
-                    type: boolean
-                  preserveValues:
-                    description: |-
-                      PreserveValues will make Helm reuse the last release's values and merge in
-                      overrides from 'Values'. Setting this flag makes the HelmRelease
-                      non-declarative.
-                    type: boolean
-                  remediation:
-                    description: |-
-                      Remediation holds the remediation configuration for when the Helm upgrade
-                      action for the HelmRelease fails. The default is to not perform any action.
+                healthCheckExprs:
+                  description: |-
+                    HealthCheckExprs is a list of healthcheck expressions for evaluating the
+                    health of custom resources using Common Expression Language (CEL).
+                    The expressions are evaluated only when the specific Helm action
+                    taking place has wait enabled, i.e. DisableWait is false, and the
+                    'poller' WaitStrategy is used.
+                  items:
+                    description: CustomHealthCheck defines the health check for custom resources.
                     properties:
-                      ignoreTestFailures:
-                        description: |-
-                          IgnoreTestFailures tells the controller to skip remediation when the Helm
-                          tests are run after an upgrade action but fail.
-                          Defaults to 'Test.IgnoreFailures'.
-                        type: boolean
-                      remediateLastFailure:
-                        description: |-
-                          RemediateLastFailure tells the controller to remediate the last failure, when
-                          no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
-                        type: boolean
-                      retries:
-                        description: |-
-                          Retries is the number of retries that should be attempted on failures before
-                          bailing. Remediation, using 'Strategy', is performed between each attempt.
-                          Defaults to '0', a negative integer equals to unlimited retries.
-                        type: integer
-                      strategy:
-                        description: Strategy to use for failure remediation. Defaults
-                          to 'rollback'.
-                        enum:
-                        - rollback
-                        - uninstall
+                      apiVersion:
+                        description: APIVersion of the custom resource under evaluation.
                         type: string
-                    type: object
-                  serverSideApply:
-                    description: |-
-                      ServerSideApply enables server-side apply for resources during upgrade.
-                      Can be "enabled", "disabled", or "auto".
-                      When "auto", server-side apply usage will be based on the release's previous usage.
-                      Defaults to "auto".
-                    enum:
-                    - enabled
-                    - disabled
-                    - auto
-                    type: string
-                  strategy:
-                    description: |-
-                      Strategy defines the upgrade strategy to use for this HelmRelease.
-                      Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
-                      DefaultToRetryOnFailure feature gate is enabled.
-                    properties:
-                      name:
-                        description: Name of the upgrade strategy.
-                        enum:
-                        - RemediateOnFailure
-                        - RetryOnFailure
-                        type: string
-                      retryInterval:
+                      current:
                         description: |-
-                          RetryInterval is the interval at which to retry a failed upgrade.
-                          Can be used only when Name is set to RetryOnFailure.
-                          Defaults to '5m'.
-                        pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          Current is the CEL expression that determines if the status
+                          of the custom resource has reached the desired state.
+                        type: string
+                      failed:
+                        description: |-
+                          Failed is the CEL expression that determines if the status
+                          of the custom resource has failed to reach the desired state.
+                        type: string
+                      inProgress:
+                        description: |-
+                          InProgress is the CEL expression that determines if the status
+                          of the custom resource has not yet reached the desired state.
+                        type: string
+                      kind:
+                        description: Kind of the custom resource under evaluation.
                         type: string
                     required:
-                    - name
+                      - apiVersion
+                      - current
+                      - kind
                     type: object
-                    x-kubernetes-validations:
-                    - message: .retryInterval can only be set when .name is 'RetryOnFailure'
-                      rule: '!has(self.retryInterval) || self.name == ''RetryOnFailure'''
-                  timeout:
-                    description: |-
-                      Timeout is the time to wait for any individual Kubernetes operation (like
-                      Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
-                      'HelmReleaseSpec.Timeout'.
-                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                    type: string
-                type: object
-              values:
-                description: Values holds the values for this Helm release.
-                x-kubernetes-preserve-unknown-fields: true
-              valuesFrom:
-                description: |-
-                  ValuesFrom holds references to resources containing Helm values for this HelmRelease,
-                  and information about how they should be merged.
-                items:
-                  description: |-
-                    ValuesReference contains a reference to a resource containing Helm values,
-                    and optionally the key they can be found at.
+                  type: array
+                install:
+                  description: Install holds the configuration for Helm install actions for this HelmRelease.
                   properties:
-                    kind:
-                      description: Kind of the values referent, valid values are ('Secret',
-                        'ConfigMap').
+                    crds:
+                      description: |-
+                        CRDs upgrade CRDs from the Helm Chart's crds directory according
+                        to the CRD upgrade policy provided here. Valid values are `Skip`,
+                        `Create` or `CreateReplace`. Default is `Create` and if omitted
+                        CRDs are installed but not updated.
+
+                        Skip: do neither install nor replace (update) any CRDs.
+
+                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                        but not deleted.
+
+                        By default, CRDs are applied (installed) during Helm install action.
+                        With this option users can opt in to CRD replace existing CRDs on Helm
+                        install actions, which is not (yet) natively supported by Helm.
+                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
                       enum:
-                      - Secret
-                      - ConfigMap
+                        - Skip
+                        - Create
+                        - CreateReplace
                       type: string
-                    name:
+                    createNamespace:
                       description: |-
-                        Name of the values referent. Should reside in the same namespace as the
-                        referring resource.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    optional:
-                      description: |-
-                        Optional marks this ValuesReference as optional. When set, a not found error
-                        for the values reference is ignored, but any ValuesKey, TargetPath or
-                        transient error will still result in a reconciliation failure.
+                        CreateNamespace tells the Helm install action to create the
+                        HelmReleaseSpec.TargetNamespace if it does not exist yet.
+                        On uninstall, the namespace will not be garbage collected.
                       type: boolean
-                    targetPath:
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm install action.
+                      type: boolean
+                    disableOpenAPIValidation:
                       description: |-
-                        TargetPath is the YAML dot notation path the value should be merged at. When
-                        set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
-                        which results in the values getting merged at the root.
-                      maxLength: 250
-                      pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
-                      type: string
-                    valuesKey:
+                        DisableOpenAPIValidation prevents the Helm install action from validating
+                        rendered templates against the Kubernetes OpenAPI Schema.
+                      type: boolean
+                    disableSchemaValidation:
                       description: |-
-                        ValuesKey is the data key where the values.yaml or a specific value can be
-                        found at. Defaults to 'values.yaml'.
-                      maxLength: 253
-                      pattern: ^[\-._a-zA-Z0-9]+$
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              waitStrategy:
-                description: |-
-                  WaitStrategy defines Helm's wait strategy for waiting for applied
-                  resources to become ready.
-                properties:
-                  name:
-                    description: |-
-                      Name is Helm's wait strategy for waiting for applied resources to
-                      become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
-                      kstatus to poll resource statuses, while the 'legacy' strategy uses
-                      Helm v3's waiting logic.
-                      Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
-                      gate is enabled.
-                    enum:
-                    - poller
-                    - legacy
-                    type: string
-                required:
-                - name
-                type: object
-            required:
-            - interval
-            type: object
-            x-kubernetes-validations:
-            - message: either chart or chartRef must be set
-              rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart)
-                && has(self.chartRef))
-          status:
-            default:
-              observedGeneration: -1
-            description: HelmReleaseStatus defines the observed state of a HelmRelease.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the HelmRelease.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
+                        DisableSchemaValidation prevents the Helm install action from validating
+                        the values against the JSON Schema.
+                      type: boolean
+                    disableTakeOwnership:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
+                        DisableTakeOwnership disables taking ownership of existing resources
+                        during the Helm install action. Defaults to false.
+                      type: boolean
+                    disableWait:
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
+                        DisableWait disables the waiting for resources to be ready after a Helm
+                        install has been performed.
+                      type: boolean
+                    disableWaitForJobs:
                       description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
+                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                        install has been performed.
+                      type: boolean
+                    remediation:
                       description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              failures:
-                description: |-
-                  Failures is the reconciliation failure count against the latest desired
-                  state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-              helmChart:
-                description: |-
-                  HelmChart is the namespaced name of the HelmChart resource created by
-                  the controller for the HelmRelease.
-                type: string
-              history:
-                description: |-
-                  History holds the history of Helm releases performed for this HelmRelease
-                  up to the last successfully completed release.
-                items:
-                  description: |-
-                    Snapshot captures a point-in-time copy of the status information for a Helm release,
-                    as managed by the controller.
-                  properties:
-                    action:
-                      description: Action is the action that resulted in this snapshot
-                        being created.
-                      type: string
-                    apiVersion:
-                      description: |-
-                        APIVersion is the API version of the Snapshot.
-                        When the calculation method of the Digest field is changed, this
-                        field will be used to distinguish between the old and new methods.
-                      type: string
-                    appVersion:
-                      description: AppVersion is the chart app version of the release
-                        object in storage.
-                      type: string
-                    chartName:
-                      description: ChartName is the chart name of the release object
-                        in storage.
-                      type: string
-                    chartVersion:
-                      description: |-
-                        ChartVersion is the chart version of the release object in
-                        storage.
-                      type: string
-                    configDigest:
-                      description: |-
-                        ConfigDigest is the checksum of the config (better known as
-                        "values") of the release object in storage.
-                        It has the format of `<algo>:<checksum>`.
-                      type: string
-                    deleted:
-                      description: Deleted is when the release was deleted.
-                      format: date-time
-                      type: string
-                    digest:
-                      description: |-
-                        Digest is the checksum of the release object in storage.
-                        It has the format of `<algo>:<checksum>`.
-                      type: string
-                    firstDeployed:
-                      description: FirstDeployed is when the release was first deployed.
-                      format: date-time
-                      type: string
-                    lastDeployed:
-                      description: LastDeployed is when the release was last deployed.
-                      format: date-time
-                      type: string
-                    name:
-                      description: Name is the name of the release.
-                      type: string
-                    namespace:
-                      description: Namespace is the namespace the release is deployed
-                        to.
-                      type: string
-                    ociDigest:
-                      description: OCIDigest is the digest of the OCI artifact associated
-                        with the release.
-                      type: string
-                    status:
-                      description: Status is the current state of the release.
-                      type: string
-                    testHooks:
-                      additionalProperties:
-                        description: |-
-                          TestHookStatus holds the status information for a test hook as observed
-                          to be run by the controller.
-                        properties:
-                          lastCompleted:
-                            description: LastCompleted is the time the test hook last
-                              completed.
-                            format: date-time
-                            type: string
-                          lastStarted:
-                            description: LastStarted is the time the test hook was
-                              last started.
-                            format: date-time
-                            type: string
-                          phase:
-                            description: Phase the test hook was observed to be in.
-                            type: string
-                        type: object
-                      description: |-
-                        TestHooks is the list of test hooks for the release as observed to be
-                        run by the controller.
-                      type: object
-                    version:
-                      description: Version is the version of the release object in
-                        storage.
-                      type: integer
-                  required:
-                  - chartName
-                  - chartVersion
-                  - configDigest
-                  - digest
-                  - firstDeployed
-                  - lastDeployed
-                  - name
-                  - namespace
-                  - status
-                  - version
-                  type: object
-                type: array
-              installFailures:
-                description: |-
-                  InstallFailures is the install failure count against the latest desired
-                  state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-              inventory:
-                description: |-
-                  Inventory contains the list of Kubernetes resource object references
-                  that have been applied for this release.
-                properties:
-                  entries:
-                    description: Entries of Kubernetes resource object references.
-                    items:
-                      description: ResourceRef contains the information necessary
-                        to locate a resource within a cluster.
+                        Remediation holds the remediation configuration for when the Helm install
+                        action for the HelmRelease fails. The default is to not perform any action.
                       properties:
-                        id:
+                        ignoreTestFailures:
                           description: |-
-                            ID is the string representation of the Kubernetes resource object's metadata,
-                            in the format '<namespace>_<name>_<group>_<kind>'.
+                            IgnoreTestFailures tells the controller to skip remediation when the Helm
+                            tests are run after an install action but fail. Defaults to
+                            'Test.IgnoreFailures'.
+                          type: boolean
+                        remediateLastFailure:
+                          description: |-
+                            RemediateLastFailure tells the controller to remediate the last failure, when
+                            no retries remain. Defaults to 'false'.
+                          type: boolean
+                        retries:
+                          description: |-
+                            Retries is the number of retries that should be attempted on failures before
+                            bailing. Remediation, using an uninstall, is performed between each attempt.
+                            Defaults to '0', a negative integer equals to unlimited retries.
+                          type: integer
+                      type: object
+                    replace:
+                      description: |-
+                        Replace tells the Helm install action to re-use the 'ReleaseName', but only
+                        if that name is a deleted release which remains in the history.
+                      type: boolean
+                    serverSideApply:
+                      description: |-
+                        ServerSideApply enables server-side apply for resources during install.
+                        Defaults to true (or false when UseHelm3Defaults feature gate is enabled).
+                      type: boolean
+                    skipCRDs:
+                      description: |-
+                        SkipCRDs tells the Helm install action to not install any CRDs. By default,
+                        CRDs are installed if not already present.
+
+                        Deprecated use CRD policy (`crds`) attribute with value `Skip` instead.
+                      type: boolean
+                    strategy:
+                      description: |-
+                        Strategy defines the install strategy to use for this HelmRelease.
+                        Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                        DefaultToRetryOnFailure feature gate is enabled.
+                      properties:
+                        name:
+                          description: Name of the install strategy.
+                          enum:
+                            - RemediateOnFailure
+                            - RetryOnFailure
                           type: string
-                        v:
-                          description: Version is the API version of the Kubernetes
-                            resource object's kind.
+                        retryInterval:
+                          description: |-
+                            RetryInterval is the interval at which to retry a failed install.
+                            Can be used only when Name is set to RetryOnFailure.
+                            Defaults to '5m'.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                           type: string
                       required:
-                      - id
-                      - v
+                        - name
                       type: object
-                    type: array
-                required:
-                - entries
-                type: object
-              lastAttemptedConfigDigest:
-                description: |-
-                  LastAttemptedConfigDigest is the digest for the config (better known as
-                  "values") of the last reconciliation attempt.
-                type: string
-              lastAttemptedGeneration:
-                description: |-
-                  LastAttemptedGeneration is the last generation the controller attempted
-                  to reconcile.
-                format: int64
-                type: integer
-              lastAttemptedReleaseAction:
-                description: |-
-                  LastAttemptedReleaseAction is the last release action performed for this
-                  HelmRelease. It is used to determine the active retry or remediation
-                  strategy.
-                enum:
-                - install
-                - upgrade
-                type: string
-              lastAttemptedReleaseActionDuration:
-                description: |-
-                  LastAttemptedReleaseActionDuration is the duration of the last
-                  release action performed for this HelmRelease.
-                type: string
-              lastAttemptedRevision:
-                description: |-
-                  LastAttemptedRevision is the Source revision of the last reconciliation
-                  attempt. For OCIRepository  sources, the 12 first characters of the digest are
-                  appended to the chart version e.g. "1.2.3+1234567890ab".
-                type: string
-              lastAttemptedRevisionDigest:
-                description: |-
-                  LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
-                  This is only set for OCIRepository sources.
-                type: string
-              lastAttemptedValuesChecksum:
-                description: |-
-                  LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
-                  reconciliation attempt.
+                      x-kubernetes-validations:
+                        - message: .retryInterval cannot be set when .name is 'RemediateOnFailure'
+                          rule: '!has(self.retryInterval) || self.name != ''RemediateOnFailure'''
+                    timeout:
+                      description: |-
+                        Timeout is the time to wait for any individual Kubernetes operation (like
+                        Jobs for hooks) during the performance of a Helm install action. Defaults to
+                        'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  type: object
+                interval:
+                  description: Interval at which to reconcile the Helm release.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                kubeConfig:
+                  description: |-
+                    KubeConfig for reconciling the HelmRelease on a remote cluster.
+                    When used in combination with HelmReleaseSpec.ServiceAccountName,
+                    forces the controller to act on behalf of that Service Account at the
+                    target cluster.
+                    If the --default-service-account flag is set, its value will be used as
+                    a controller level fallback for when HelmReleaseSpec.ServiceAccountName
+                    is empty.
+                  properties:
+                    configMapRef:
+                      description: |-
+                        ConfigMapRef holds an optional name of a ConfigMap that contains
+                        the following keys:
 
-                  Deprecated: Use LastAttemptedConfigDigest instead.
-                type: string
-              lastHandledForceAt:
-                description: |-
-                  LastHandledForceAt holds the value of the most recent
-                  force request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              lastHandledResetAt:
-                description: |-
-                  LastHandledResetAt holds the value of the most recent reset request
-                  value, so a change of the annotation value can be detected.
-                type: string
-              lastReleaseRevision:
-                description: |-
-                  LastReleaseRevision is the revision of the last successful Helm release.
+                        - `provider`: the provider to use. One of `aws`, `azure`, `gcp`, or
+                           `generic`. Required.
+                        - `cluster`: the fully qualified resource name of the Kubernetes
+                           cluster in the cloud provider API. Not used by the `generic`
+                           provider. Required when one of `address` or `ca.crt` is not set.
+                        - `address`: the address of the Kubernetes API server. Required
+                           for `generic`. For the other providers, if not specified, the
+                           first address in the cluster resource will be used, and if
+                           specified, it must match one of the addresses in the cluster
+                           resource.
+                           If audiences is not set, will be used as the audience for the
+                           `generic` provider.
+                        - `ca.crt`: the optional PEM-encoded CA certificate for the
+                           Kubernetes API server. If not set, the controller will use the
+                           CA certificate from the cluster resource.
+                        - `audiences`: the optional audiences as a list of
+                           line-break-separated strings for the Kubernetes ServiceAccount
+                           token. Defaults to the `address` for the `generic` provider, or
+                           to specific values for the other providers depending on the
+                           provider.
+                        -  `serviceAccountName`: the optional name of the Kubernetes
+                           ServiceAccount in the same namespace that should be used
+                           for authentication. If not specified, the controller
+                           ServiceAccount will be used.
 
-                  Deprecated: Use History instead.
-                type: integer
-              observedCommonMetadataDigest:
-                description: |-
-                  ObservedCommonMetadataDigest is the digest for the common metadata of
-                  the last successful reconciliation attempt.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-              observedPostRenderersDigest:
-                description: |-
-                  ObservedPostRenderersDigest is the digest for the post-renderers of
-                  the last successful reconciliation attempt.
-                type: string
-              storageNamespace:
-                description: |-
-                  StorageNamespace is the namespace of the Helm release storage for the
-                  current release.
-                maxLength: 63
-                minLength: 1
-                type: string
-              upgradeFailures:
-                description: |-
-                  UpgradeFailures is the upgrade failure count against the latest desired
-                  state. It is reset after a successful reconciliation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                        Mutually exclusive with SecretRef.
+                      properties:
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    secretRef:
+                      description: |-
+                        SecretRef holds an optional name of a secret that contains a key with
+                        the kubeconfig file as the value. If no key is set, the key will default
+                        to 'value'. Mutually exclusive with ConfigMapRef.
+                        It is recommended that the kubeconfig is self-contained, and the secret
+                        is regularly updated if credentials such as a cloud-access-token expire.
+                        Cloud specific `cmd-path` auth helpers will not function without adding
+                        binaries and credentials to the Pod that is responsible for reconciling
+                        Kubernetes resources. Supported only for the generic provider.
+                      properties:
+                        key:
+                          description: Key in the Secret, when not specified an implementation-specific default key is used.
+                          type: string
+                        name:
+                          description: Name of the Secret.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified
+                      rule: has(self.configMapRef) || has(self.secretRef)
+                    - message: exactly one of spec.kubeConfig.configMapRef or spec.kubeConfig.secretRef must be specified
+                      rule: '!has(self.configMapRef) || !has(self.secretRef)'
+                maxHistory:
+                  description: |-
+                    MaxHistory is the number of revisions saved by Helm for this HelmRelease.
+                    Use '0' for an unlimited number of revisions; defaults to '5'.
+                  type: integer
+                persistentClient:
+                  description: |-
+                    PersistentClient tells the controller to use a persistent Kubernetes
+                    client for this release. When enabled, the client will be reused for the
+                    duration of the reconciliation, instead of being created and destroyed
+                    for each (step of a) Helm action.
+
+                    This can improve performance, but may cause issues with some Helm charts
+                    that for example do create Custom Resource Definitions during installation
+                    outside Helm's CRD lifecycle hooks, which are then not observed to be
+                    available by e.g. post-install hooks.
+
+                    If not set, it defaults to true.
+                  type: boolean
+                postRenderers:
+                  description: |-
+                    PostRenderers holds an array of Helm PostRenderers, which will be applied in order
+                    of their definition.
+                  items:
+                    description: PostRenderer contains a Helm PostRenderer specification.
+                    properties:
+                      kustomize:
+                        description: Kustomization to apply as PostRenderer.
+                        properties:
+                          images:
+                            description: |-
+                              Images is a list of (image name, new name, new tag or digest)
+                              for changing image names, tags or digests. This can also be achieved with a
+                              patch, but this operator is simpler to specify.
+                            items:
+                              description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                              properties:
+                                digest:
+                                  description: |-
+                                    Digest is the value used to replace the original image tag.
+                                    If digest is present NewTag value is ignored.
+                                  type: string
+                                name:
+                                  description: Name is a tag-less image name.
+                                  type: string
+                                newName:
+                                  description: NewName is the value used to replace the original name.
+                                  type: string
+                                newTag:
+                                  description: NewTag is the value used to replace the original tag.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          patches:
+                            description: |-
+                              Strategic merge and JSON patches, defined as inline YAML objects,
+                              capable of targeting objects based on kind, label and annotation selectors.
+                            items:
+                              description: |-
+                                Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                                be applied to.
+                              properties:
+                                patch:
+                                  description: |-
+                                    Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                    an array of operation objects.
+                                  type: string
+                                target:
+                                  description: Target points to the resources that the patch document should be applied to.
+                                  properties:
+                                    annotationSelector:
+                                      description: |-
+                                        AnnotationSelector is a string that follows the label selection expression
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                        It matches with the resource annotations.
+                                      type: string
+                                    group:
+                                      description: |-
+                                        Group is the API group to select resources from.
+                                        Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the API Group to select resources from.
+                                        Together with Group and Version it is capable of unambiguously
+                                        identifying and/or selecting resources.
+                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                      type: string
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is a string that follows the label selection expression
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                        It matches with the resource labels.
+                                      type: string
+                                    name:
+                                      description: Name to match resources with.
+                                      type: string
+                                    namespace:
+                                      description: Namespace to select resources from.
+                                      type: string
+                                    version:
+                                      description: |-
+                                        Version of the API Group to select resources from.
+                                        Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                        https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
+                                      type: string
+                                  type: object
+                              required:
+                                - patch
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+                releaseName:
+                  description: |-
+                    ReleaseName used for the Helm release. Defaults to a composition of
+                    '[TargetNamespace-]Name'.
+                  maxLength: 53
+                  minLength: 1
+                  type: string
+                rollback:
+                  description: Rollback holds the configuration for Helm rollback actions for this HelmRelease.
+                  properties:
+                    cleanupOnFail:
+                      description: |-
+                        CleanupOnFail allows deletion of new resources created during the Helm
+                        rollback action when it fails.
+                      type: boolean
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm rollback action.
+                      type: boolean
+                    disableWait:
+                      description: |-
+                        DisableWait disables the waiting for resources to be ready after a Helm
+                        rollback has been performed.
+                      type: boolean
+                    disableWaitForJobs:
+                      description: |-
+                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                        rollback has been performed.
+                      type: boolean
+                    force:
+                      description: |-
+                        Force forces resource updates through a replacement strategy
+                        that avoids 3-way merge conflicts on client-side apply.
+                        This field is ignored for server-side apply (which always
+                        forces conflicts with other field managers).
+                      type: boolean
+                    recreate:
+                      description: |-
+                        Recreate performs pod restarts for any managed workloads.
+
+                        Deprecated: This behavior was deprecated in Helm 3:
+                          - Deprecation: https://github.com/helm/helm/pull/6463
+                          - Removal: https://github.com/helm/helm/pull/31023
+                        After helm-controller was upgraded to the Helm 4 SDK,
+                        this field is no longer functional and will print a
+                        warning if set to true. It will also be removed in a
+                        future release.
+                      type: boolean
+                    serverSideApply:
+                      description: |-
+                        ServerSideApply enables server-side apply for resources during rollback.
+                        Can be "enabled", "disabled", or "auto".
+                        When "auto", server-side apply usage will be based on the release's previous usage.
+                        Defaults to "auto".
+                      enum:
+                        - enabled
+                        - disabled
+                        - auto
+                      type: string
+                    timeout:
+                      description: |-
+                        Timeout is the time to wait for any individual Kubernetes operation (like
+                        Jobs for hooks) during the performance of a Helm rollback action. Defaults to
+                        'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    The name of the Kubernetes service account to impersonate
+                    when reconciling this HelmRelease.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                storageNamespace:
+                  description: |-
+                    StorageNamespace used for the Helm storage.
+                    Defaults to the namespace of the HelmRelease.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend reconciliation for this HelmRelease,
+                    it does not apply to already started reconciliations. Defaults to false.
+                  type: boolean
+                targetNamespace:
+                  description: |-
+                    TargetNamespace to target when performing operations for the HelmRelease.
+                    Defaults to the namespace of the HelmRelease.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                test:
+                  description: Test holds the configuration for Helm test actions for this HelmRelease.
+                  properties:
+                    enable:
+                      description: |-
+                        Enable enables Helm test actions for this HelmRelease after an Helm install
+                        or upgrade action has been performed.
+                      type: boolean
+                    filters:
+                      description: Filters is a list of tests to run or exclude from running.
+                      items:
+                        description: Filter holds the configuration for individual Helm test filters.
+                        properties:
+                          exclude:
+                            description: Exclude specifies whether the named test should be excluded.
+                            type: boolean
+                          name:
+                            description: Name is the name of the test.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    ignoreFailures:
+                      description: |-
+                        IgnoreFailures tells the controller to skip remediation when the Helm tests
+                        are run but fail. Can be overwritten for tests run after install or upgrade
+                        actions in 'Install.IgnoreTestFailures' and 'Upgrade.IgnoreTestFailures'.
+                      type: boolean
+                    timeout:
+                      description: |-
+                        Timeout is the time to wait for any individual Kubernetes operation during
+                        the performance of a Helm test action. Defaults to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  type: object
+                timeout:
+                  description: |-
+                    Timeout is the time to wait for any individual Kubernetes operation (like Jobs
+                    for hooks) during the performance of a Helm action. Defaults to '5m0s'.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                uninstall:
+                  description: Uninstall holds the configuration for Helm uninstall actions for this HelmRelease.
+                  properties:
+                    deletionPropagation:
+                      default: background
+                      description: |-
+                        DeletionPropagation specifies the deletion propagation policy when
+                        a Helm uninstall is performed.
+                      enum:
+                        - background
+                        - foreground
+                        - orphan
+                      type: string
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm rollback action.
+                      type: boolean
+                    disableWait:
+                      description: |-
+                        DisableWait disables waiting for all the resources to be deleted after
+                        a Helm uninstall is performed.
+                      type: boolean
+                    keepHistory:
+                      description: |-
+                        KeepHistory tells Helm to remove all associated resources and mark the
+                        release as deleted, but retain the release history.
+                      type: boolean
+                    timeout:
+                      description: |-
+                        Timeout is the time to wait for any individual Kubernetes operation (like
+                        Jobs for hooks) during the performance of a Helm uninstall action. Defaults
+                        to 'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  type: object
+                upgrade:
+                  description: Upgrade holds the configuration for Helm upgrade actions for this HelmRelease.
+                  properties:
+                    cleanupOnFail:
+                      description: |-
+                        CleanupOnFail allows deletion of new resources created during the Helm
+                        upgrade action when it fails.
+                      type: boolean
+                    crds:
+                      description: |-
+                        CRDs upgrade CRDs from the Helm Chart's crds directory according
+                        to the CRD upgrade policy provided here. Valid values are `Skip`,
+                        `Create` or `CreateReplace`. Default is `Skip` and if omitted
+                        CRDs are neither installed nor upgraded.
+
+                        Skip: do neither install nor replace (update) any CRDs.
+
+                        Create: new CRDs are created, existing CRDs are neither updated nor deleted.
+
+                        CreateReplace: new CRDs are created, existing CRDs are updated (replaced)
+                        but not deleted.
+
+                        By default, CRDs are not applied during Helm upgrade action. With this
+                        option users can opt-in to CRD upgrade, which is not (yet) natively supported by Helm.
+                        https://helm.sh/docs/chart_best_practices/custom_resource_definitions.
+                      enum:
+                        - Skip
+                        - Create
+                        - CreateReplace
+                      type: string
+                    disableHooks:
+                      description: DisableHooks prevents hooks from running during the Helm upgrade action.
+                      type: boolean
+                    disableOpenAPIValidation:
+                      description: |-
+                        DisableOpenAPIValidation prevents the Helm upgrade action from validating
+                        rendered templates against the Kubernetes OpenAPI Schema.
+                      type: boolean
+                    disableSchemaValidation:
+                      description: |-
+                        DisableSchemaValidation prevents the Helm upgrade action from validating
+                        the values against the JSON Schema.
+                      type: boolean
+                    disableTakeOwnership:
+                      description: |-
+                        DisableTakeOwnership disables taking ownership of existing resources
+                        during the Helm upgrade action. Defaults to false.
+                      type: boolean
+                    disableWait:
+                      description: |-
+                        DisableWait disables the waiting for resources to be ready after a Helm
+                        upgrade has been performed.
+                      type: boolean
+                    disableWaitForJobs:
+                      description: |-
+                        DisableWaitForJobs disables waiting for jobs to complete after a Helm
+                        upgrade has been performed.
+                      type: boolean
+                    force:
+                      description: |-
+                        Force forces resource updates through a replacement strategy
+                        that avoids 3-way merge conflicts on client-side apply.
+                        This field is ignored for server-side apply (which always
+                        forces conflicts with other field managers).
+                      type: boolean
+                    preserveValues:
+                      description: |-
+                        PreserveValues will make Helm reuse the last release's values and merge in
+                        overrides from 'Values'. Setting this flag makes the HelmRelease
+                        non-declarative.
+                      type: boolean
+                    remediation:
+                      description: |-
+                        Remediation holds the remediation configuration for when the Helm upgrade
+                        action for the HelmRelease fails. The default is to not perform any action.
+                      properties:
+                        ignoreTestFailures:
+                          description: |-
+                            IgnoreTestFailures tells the controller to skip remediation when the Helm
+                            tests are run after an upgrade action but fail.
+                            Defaults to 'Test.IgnoreFailures'.
+                          type: boolean
+                        remediateLastFailure:
+                          description: |-
+                            RemediateLastFailure tells the controller to remediate the last failure, when
+                            no retries remain. Defaults to 'false' unless 'Retries' is greater than 0.
+                          type: boolean
+                        retries:
+                          description: |-
+                            Retries is the number of retries that should be attempted on failures before
+                            bailing. Remediation, using 'Strategy', is performed between each attempt.
+                            Defaults to '0', a negative integer equals to unlimited retries.
+                          type: integer
+                        strategy:
+                          description: Strategy to use for failure remediation. Defaults to 'rollback'.
+                          enum:
+                            - rollback
+                            - uninstall
+                          type: string
+                      type: object
+                    serverSideApply:
+                      description: |-
+                        ServerSideApply enables server-side apply for resources during upgrade.
+                        Can be "enabled", "disabled", or "auto".
+                        When "auto", server-side apply usage will be based on the release's previous usage.
+                        Defaults to "auto".
+                      enum:
+                        - enabled
+                        - disabled
+                        - auto
+                      type: string
+                    strategy:
+                      description: |-
+                        Strategy defines the upgrade strategy to use for this HelmRelease.
+                        Defaults to 'RemediateOnFailure', or 'RetryOnFailure' when the
+                        DefaultToRetryOnFailure feature gate is enabled.
+                      properties:
+                        name:
+                          description: Name of the upgrade strategy.
+                          enum:
+                            - RemediateOnFailure
+                            - RetryOnFailure
+                          type: string
+                        retryInterval:
+                          description: |-
+                            RetryInterval is the interval at which to retry a failed upgrade.
+                            Can be used only when Name is set to RetryOnFailure.
+                            Defaults to '5m'.
+                          pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                          type: string
+                      required:
+                        - name
+                      type: object
+                      x-kubernetes-validations:
+                        - message: .retryInterval can only be set when .name is 'RetryOnFailure'
+                          rule: '!has(self.retryInterval) || self.name == ''RetryOnFailure'''
+                    timeout:
+                      description: |-
+                        Timeout is the time to wait for any individual Kubernetes operation (like
+                        Jobs for hooks) during the performance of a Helm upgrade action. Defaults to
+                        'HelmReleaseSpec.Timeout'.
+                      pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                      type: string
+                  type: object
+                values:
+                  description: Values holds the values for this Helm release.
+                  x-kubernetes-preserve-unknown-fields: true
+                valuesFrom:
+                  description: |-
+                    ValuesFrom holds references to resources containing Helm values for this HelmRelease,
+                    and information about how they should be merged.
+                  items:
+                    description: |-
+                      ValuesReference contains a reference to a resource containing Helm values,
+                      and optionally the key they can be found at.
+                    properties:
+                      kind:
+                        description: Kind of the values referent, valid values are ('Secret', 'ConfigMap').
+                        enum:
+                          - Secret
+                          - ConfigMap
+                        type: string
+                      name:
+                        description: |-
+                          Name of the values referent. Should reside in the same namespace as the
+                          referring resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      optional:
+                        description: |-
+                          Optional marks this ValuesReference as optional. When set, a not found error
+                          for the values reference is ignored, but any ValuesKey, TargetPath or
+                          transient error will still result in a reconciliation failure.
+                        type: boolean
+                      targetPath:
+                        description: |-
+                          TargetPath is the YAML dot notation path the value should be merged at. When
+                          set, the ValuesKey is expected to be a single flat value. Defaults to 'None',
+                          which results in the values getting merged at the root.
+                        maxLength: 250
+                        pattern: ^([a-zA-Z0-9_\-.\\\/]|\[[0-9]{1,5}\])+$
+                        type: string
+                      valuesKey:
+                        description: |-
+                          ValuesKey is the data key where the values.yaml or a specific value can be
+                          found at. Defaults to 'values.yaml'.
+                        maxLength: 253
+                        pattern: ^[\-._a-zA-Z0-9]+$
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                waitStrategy:
+                  description: |-
+                    WaitStrategy defines Helm's wait strategy for waiting for applied
+                    resources to become ready.
+                  properties:
+                    name:
+                      description: |-
+                        Name is Helm's wait strategy for waiting for applied resources to
+                        become ready. One of 'poller' or 'legacy'. The 'poller' strategy uses
+                        kstatus to poll resource statuses, while the 'legacy' strategy uses
+                        Helm v3's waiting logic.
+                        Defaults to 'poller', or to 'legacy' when UseHelm3Defaults feature
+                        gate is enabled.
+                      enum:
+                        - poller
+                        - legacy
+                      type: string
+                  required:
+                    - name
+                  type: object
+              required:
+                - interval
+              type: object
+              x-kubernetes-validations:
+                - message: either chart or chartRef must be set
+                  rule: (has(self.chart) && !has(self.chartRef)) || (!has(self.chart) && has(self.chartRef))
+            status:
+              default:
+                observedGeneration: -1
+              description: HelmReleaseStatus defines the observed state of a HelmRelease.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the HelmRelease.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                failures:
+                  description: |-
+                    Failures is the reconciliation failure count against the latest desired
+                    state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+                helmChart:
+                  description: |-
+                    HelmChart is the namespaced name of the HelmChart resource created by
+                    the controller for the HelmRelease.
+                  type: string
+                history:
+                  description: |-
+                    History holds the history of Helm releases performed for this HelmRelease
+                    up to the last successfully completed release.
+                  items:
+                    description: |-
+                      Snapshot captures a point-in-time copy of the status information for a Helm release,
+                      as managed by the controller.
+                    properties:
+                      action:
+                        description: Action is the action that resulted in this snapshot being created.
+                        type: string
+                      apiVersion:
+                        description: |-
+                          APIVersion is the API version of the Snapshot.
+                          When the calculation method of the Digest field is changed, this
+                          field will be used to distinguish between the old and new methods.
+                        type: string
+                      appVersion:
+                        description: AppVersion is the chart app version of the release object in storage.
+                        type: string
+                      chartName:
+                        description: ChartName is the chart name of the release object in storage.
+                        type: string
+                      chartVersion:
+                        description: |-
+                          ChartVersion is the chart version of the release object in
+                          storage.
+                        type: string
+                      configDigest:
+                        description: |-
+                          ConfigDigest is the checksum of the config (better known as
+                          "values") of the release object in storage.
+                          It has the format of `<algo>:<checksum>`.
+                        type: string
+                      deleted:
+                        description: Deleted is when the release was deleted.
+                        format: date-time
+                        type: string
+                      digest:
+                        description: |-
+                          Digest is the checksum of the release object in storage.
+                          It has the format of `<algo>:<checksum>`.
+                        type: string
+                      firstDeployed:
+                        description: FirstDeployed is when the release was first deployed.
+                        format: date-time
+                        type: string
+                      lastDeployed:
+                        description: LastDeployed is when the release was last deployed.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the release.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace the release is deployed to.
+                        type: string
+                      ociDigest:
+                        description: OCIDigest is the digest of the OCI artifact associated with the release.
+                        type: string
+                      status:
+                        description: Status is the current state of the release.
+                        type: string
+                      testHooks:
+                        additionalProperties:
+                          description: |-
+                            TestHookStatus holds the status information for a test hook as observed
+                            to be run by the controller.
+                          properties:
+                            lastCompleted:
+                              description: LastCompleted is the time the test hook last completed.
+                              format: date-time
+                              type: string
+                            lastStarted:
+                              description: LastStarted is the time the test hook was last started.
+                              format: date-time
+                              type: string
+                            phase:
+                              description: Phase the test hook was observed to be in.
+                              type: string
+                          type: object
+                        description: |-
+                          TestHooks is the list of test hooks for the release as observed to be
+                          run by the controller.
+                        type: object
+                      version:
+                        description: Version is the version of the release object in storage.
+                        type: integer
+                    required:
+                      - chartName
+                      - chartVersion
+                      - configDigest
+                      - digest
+                      - firstDeployed
+                      - lastDeployed
+                      - name
+                      - namespace
+                      - status
+                      - version
+                    type: object
+                  type: array
+                installFailures:
+                  description: |-
+                    InstallFailures is the install failure count against the latest desired
+                    state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+                inventory:
+                  description: |-
+                    Inventory contains the list of Kubernetes resource object references
+                    that have been applied for this release.
+                  properties:
+                    entries:
+                      description: Entries of Kubernetes resource object references.
+                      items:
+                        description: ResourceRef contains the information necessary to locate a resource within a cluster.
+                        properties:
+                          id:
+                            description: |-
+                              ID is the string representation of the Kubernetes resource object's metadata,
+                              in the format '<namespace>_<name>_<group>_<kind>'.
+                            type: string
+                          v:
+                            description: Version is the API version of the Kubernetes resource object's kind.
+                            type: string
+                        required:
+                          - id
+                          - v
+                        type: object
+                      type: array
+                  required:
+                    - entries
+                  type: object
+                lastAttemptedConfigDigest:
+                  description: |-
+                    LastAttemptedConfigDigest is the digest for the config (better known as
+                    "values") of the last reconciliation attempt.
+                  type: string
+                lastAttemptedGeneration:
+                  description: |-
+                    LastAttemptedGeneration is the last generation the controller attempted
+                    to reconcile.
+                  format: int64
+                  type: integer
+                lastAttemptedReleaseAction:
+                  description: |-
+                    LastAttemptedReleaseAction is the last release action performed for this
+                    HelmRelease. It is used to determine the active retry or remediation
+                    strategy.
+                  enum:
+                    - install
+                    - upgrade
+                  type: string
+                lastAttemptedReleaseActionDuration:
+                  description: |-
+                    LastAttemptedReleaseActionDuration is the duration of the last
+                    release action performed for this HelmRelease.
+                  type: string
+                lastAttemptedRevision:
+                  description: |-
+                    LastAttemptedRevision is the Source revision of the last reconciliation
+                    attempt. For OCIRepository  sources, the 12 first characters of the digest are
+                    appended to the chart version e.g. "1.2.3+1234567890ab".
+                  type: string
+                lastAttemptedRevisionDigest:
+                  description: |-
+                    LastAttemptedRevisionDigest is the digest of the last reconciliation attempt.
+                    This is only set for OCIRepository sources.
+                  type: string
+                lastAttemptedValuesChecksum:
+                  description: |-
+                    LastAttemptedValuesChecksum is the SHA1 checksum for the values of the last
+                    reconciliation attempt.
+
+                    Deprecated: Use LastAttemptedConfigDigest instead.
+                  type: string
+                lastHandledForceAt:
+                  description: |-
+                    LastHandledForceAt holds the value of the most recent
+                    force request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                lastHandledResetAt:
+                  description: |-
+                    LastHandledResetAt holds the value of the most recent reset request
+                    value, so a change of the annotation value can be detected.
+                  type: string
+                lastReleaseRevision:
+                  description: |-
+                    LastReleaseRevision is the revision of the last successful Helm release.
+
+                    Deprecated: Use History instead.
+                  type: integer
+                observedCommonMetadataDigest:
+                  description: |-
+                    ObservedCommonMetadataDigest is the digest for the common metadata of
+                    the last successful reconciliation attempt.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+                observedPostRenderersDigest:
+                  description: |-
+                    ObservedPostRenderersDigest is the digest for the post-renderers of
+                    the last successful reconciliation attempt.
+                  type: string
+                storageNamespace:
+                  description: |-
+                    StorageNamespace is the namespace of the Helm release storage for the
+                    current release.
+                  maxLength: 63
+                  minLength: 1
+                  type: string
+                upgradeFailures:
+                  description: |-
+                    UpgradeFailures is the upgrade failure count against the latest desired
+                    state. It is reset after a successful reconciliation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -4927,59 +4822,59 @@ spec:
         app.kubernetes.io/version: v2.8.6
     spec:
       containers:
-      - args:
-        - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
-        - --watch-all-namespaces=true
-        - --log-level=info
-        - --log-encoding=json
-        - --enable-leader-election
-        env:
-        - name: RUNTIME_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: manager
-              resource: limits.memory
-        image: ghcr.io/fluxcd/helm-controller:v1.5.4
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-        name: manager
-        ports:
-        - containerPort: 8080
-          name: http-prom
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp
-          name: temp
+        - args:
+            - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: manager
+                  resource: limits.memory
+          image: ghcr.io/fluxcd/helm-controller:v1.5.4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          name: manager
+          ports:
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
@@ -4988,8 +4883,8 @@ spec:
       serviceAccountName: helm-controller
       terminationGracePeriodSeconds: 600
       volumes:
-      - emptyDir: {}
-        name: temp
+        - emptyDir: {}
+          name: temp
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5011,379 +4906,373 @@ spec:
     singular: alert
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    deprecated: true
-    deprecationWarning: v1beta2 Alert is deprecated, upgrade to v1beta3
-    name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: Alert is the Schema for the alerts API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AlertSpec defines an alerting rule for events involving a
-              list of objects.
-            properties:
-              eventMetadata:
-                additionalProperties:
-                  type: string
-                description: |-
-                  EventMetadata is an optional field for adding metadata to events dispatched by the
-                  controller. This can be used for enhancing the context of the event. If a field
-                  would override one already present on the original event as generated by the emitter,
-                  then the override doesn't happen, i.e. the original value is preserved, and an info
-                  log is printed.
-                type: object
-              eventSeverity:
-                default: info
-                description: |-
-                  EventSeverity specifies how to filter events based on severity.
-                  If set to 'info' no events will be filtered.
-                enum:
-                - info
-                - error
-                type: string
-              eventSources:
-                description: |-
-                  EventSources specifies how to filter events based
-                  on the involved object kind, name and namespace.
-                items:
-                  description: |-
-                    CrossNamespaceObjectReference contains enough information to let you locate the
-                    typed referenced object at cluster level
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      - ImageRepository
-                      - ImagePolicy
-                      - ImageUpdateAutomation
-                      - OCIRepository
-                      - ArtifactGenerator
-                      - ExternalArtifact
-                      type: string
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        MatchLabels requires the name to be set to `*`.
-                      type: object
-                    name:
-                      description: |-
-                        Name of the referent
-                        If multiple resources are targeted `*` may be set.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              exclusionList:
-                description: |-
-                  ExclusionList specifies a list of Golang regular expressions
-                  to be used for excluding messages.
-                items:
-                  type: string
-                type: array
-              inclusionList:
-                description: |-
-                  InclusionList specifies a list of Golang regular expressions
-                  to be used for including messages.
-                items:
-                  type: string
-                type: array
-              providerRef:
-                description: ProviderRef specifies which Provider this Alert should
-                  use.
-                properties:
-                  name:
-                    description: Name of the referent.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      deprecated: true
+      deprecationWarning: v1beta2 Alert is deprecated, upgrade to v1beta3
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Alert is the Schema for the alerts API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlertSpec defines an alerting rule for events involving a list of objects.
+              properties:
+                eventMetadata:
+                  additionalProperties:
                     type: string
-                required:
-                - name
-                type: object
-              summary:
-                description: Summary holds a short description of the impact and affected
-                  cluster.
-                maxLength: 255
-                type: string
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this Alert.
-                type: boolean
-            required:
-            - eventSources
-            - providerRef
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: AlertStatus defines the observed state of the Alert.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the Alert.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta3
-    schema:
-      openAPIV3Schema:
-        description: Alert is the Schema for the alerts API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AlertSpec defines an alerting rule for events involving a
-              list of objects.
-            properties:
-              eventMetadata:
-                additionalProperties:
-                  type: string
-                description: |-
-                  EventMetadata is an optional field for adding metadata to events dispatched by the
-                  controller. This can be used for enhancing the context of the event. If a field
-                  would override one already present on the original event as generated by the emitter,
-                  then the override doesn't happen, i.e. the original value is preserved, and an info
-                  log is printed.
-                type: object
-              eventSeverity:
-                default: info
-                description: |-
-                  EventSeverity specifies how to filter events based on severity.
-                  If set to 'info' no events will be filtered.
-                enum:
-                - info
-                - error
-                type: string
-              eventSources:
-                description: |-
-                  EventSources specifies how to filter events based
-                  on the involved object kind, name and namespace.
-                items:
                   description: |-
-                    CrossNamespaceObjectReference contains enough information to let you locate the
-                    typed referenced object at cluster level
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      - ImageRepository
-                      - ImagePolicy
-                      - ImageUpdateAutomation
-                      - OCIRepository
-                      - ArtifactGenerator
-                      - ExternalArtifact
-                      type: string
-                    matchLabels:
-                      additionalProperties:
+                    EventMetadata is an optional field for adding metadata to events dispatched by the
+                    controller. This can be used for enhancing the context of the event. If a field
+                    would override one already present on the original event as generated by the emitter,
+                    then the override doesn't happen, i.e. the original value is preserved, and an info
+                    log is printed.
+                  type: object
+                eventSeverity:
+                  default: info
+                  description: |-
+                    EventSeverity specifies how to filter events based on severity.
+                    If set to 'info' no events will be filtered.
+                  enum:
+                    - info
+                    - error
+                  type: string
+                eventSources:
+                  description: |-
+                    EventSources specifies how to filter events based
+                    on the involved object kind, name and namespace.
+                  items:
+                    description: |-
+                      CrossNamespaceObjectReference contains enough information to let you locate the
+                      typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
                         type: string
-                      description: |-
-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        MatchLabels requires the name to be set to `*`.
-                      type: object
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                          - OCIRepository
+                          - ArtifactGenerator
+                          - ExternalArtifact
+                        type: string
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          MatchLabels requires the name to be set to `*`.
+                        type: object
+                      name:
+                        description: |-
+                          Name of the referent
+                          If multiple resources are targeted `*` may be set.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                exclusionList:
+                  description: |-
+                    ExclusionList specifies a list of Golang regular expressions
+                    to be used for excluding messages.
+                  items:
+                    type: string
+                  type: array
+                inclusionList:
+                  description: |-
+                    InclusionList specifies a list of Golang regular expressions
+                    to be used for including messages.
+                  items:
+                    type: string
+                  type: array
+                providerRef:
+                  description: ProviderRef specifies which Provider this Alert should use.
+                  properties:
                     name:
-                      description: |-
-                        Name of the referent
-                        If multiple resources are targeted `*` may be set.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 253
-                      minLength: 1
+                      description: Name of the referent.
                       type: string
                   required:
-                  - kind
-                  - name
+                    - name
                   type: object
-                type: array
-              exclusionList:
-                description: |-
-                  ExclusionList specifies a list of Golang regular expressions
-                  to be used for excluding messages.
-                items:
+                summary:
+                  description: Summary holds a short description of the impact and affected cluster.
+                  maxLength: 255
                   type: string
-                type: array
-              inclusionList:
-                description: |-
-                  InclusionList specifies a list of Golang regular expressions
-                  to be used for including messages.
-                items:
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this Alert.
+                  type: boolean
+              required:
+                - eventSources
+                - providerRef
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: AlertStatus defines the observed state of the Alert.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the Alert.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
                   type: string
-                type: array
-              providerRef:
-                description: ProviderRef specifies which Provider this Alert should
-                  use.
-                properties:
-                  name:
-                    description: Name of the referent.
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta3
+      schema:
+        openAPIV3Schema:
+          description: Alert is the Schema for the alerts API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AlertSpec defines an alerting rule for events involving a list of objects.
+              properties:
+                eventMetadata:
+                  additionalProperties:
                     type: string
-                required:
-                - name
-                type: object
-              summary:
-                description: |-
-                  Summary holds a short description of the impact and affected cluster.
-                  Deprecated: Use EventMetadata instead.
-                maxLength: 255
-                type: string
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this Alert.
-                type: boolean
-            required:
-            - eventSources
-            - providerRef
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                  description: |-
+                    EventMetadata is an optional field for adding metadata to events dispatched by the
+                    controller. This can be used for enhancing the context of the event. If a field
+                    would override one already present on the original event as generated by the emitter,
+                    then the override doesn't happen, i.e. the original value is preserved, and an info
+                    log is printed.
+                  type: object
+                eventSeverity:
+                  default: info
+                  description: |-
+                    EventSeverity specifies how to filter events based on severity.
+                    If set to 'info' no events will be filtered.
+                  enum:
+                    - info
+                    - error
+                  type: string
+                eventSources:
+                  description: |-
+                    EventSources specifies how to filter events based
+                    on the involved object kind, name and namespace.
+                  items:
+                    description: |-
+                      CrossNamespaceObjectReference contains enough information to let you locate the
+                      typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                          - OCIRepository
+                          - ArtifactGenerator
+                          - ExternalArtifact
+                        type: string
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          MatchLabels requires the name to be set to `*`.
+                        type: object
+                      name:
+                        description: |-
+                          Name of the referent
+                          If multiple resources are targeted `*` may be set.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                exclusionList:
+                  description: |-
+                    ExclusionList specifies a list of Golang regular expressions
+                    to be used for excluding messages.
+                  items:
+                    type: string
+                  type: array
+                inclusionList:
+                  description: |-
+                    InclusionList specifies a list of Golang regular expressions
+                    to be used for including messages.
+                  items:
+                    type: string
+                  type: array
+                providerRef:
+                  description: ProviderRef specifies which Provider this Alert should use.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                summary:
+                  description: |-
+                    Summary holds a short description of the impact and affected cluster.
+                    Deprecated: Use EventMetadata instead.
+                  maxLength: 255
+                  type: string
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this Alert.
+                  type: boolean
+              required:
+                - eventSources
+                - providerRef
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5405,400 +5294,393 @@ spec:
     singular: provider
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    deprecated: true
-    deprecationWarning: v1beta2 Provider is deprecated, upgrade to v1beta3
-    name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: Provider is the Schema for the providers API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProviderSpec defines the desired state of the Provider.
-            properties:
-              address:
-                description: |-
-                  Address specifies the endpoint, in a generic sense, to where alerts are sent.
-                  What kind of endpoint depends on the specific Provider type being used.
-                  For the generic Provider, for example, this is an HTTP/S address.
-                  For other Provider types this could be a project ID or a namespace.
-                maxLength: 2048
-                type: string
-              certSecretRef:
-                description: |-
-                  CertSecretRef specifies the Secret containing
-                  a PEM-encoded CA certificate (in the `ca.crt` key).
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      deprecated: true
+      deprecationWarning: v1beta2 Provider is deprecated, upgrade to v1beta3
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Provider is the Schema for the providers API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderSpec defines the desired state of the Provider.
+              properties:
+                address:
+                  description: |-
+                    Address specifies the endpoint, in a generic sense, to where alerts are sent.
+                    What kind of endpoint depends on the specific Provider type being used.
+                    For the generic Provider, for example, this is an HTTP/S address.
+                    For other Provider types this could be a project ID or a namespace.
+                  maxLength: 2048
+                  type: string
+                certSecretRef:
+                  description: |-
+                    CertSecretRef specifies the Secret containing
+                    a PEM-encoded CA certificate (in the `ca.crt` key).
 
-                  Note: Support for the `caFile` key has
-                  been deprecated.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              channel:
-                description: Channel specifies the destination channel where events
-                  should be posted.
-                maxLength: 2048
-                type: string
-              interval:
-                description: Interval at which to reconcile the Provider with its
-                  Secret references.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              proxy:
-                description: Proxy the HTTP/S address of the proxy server.
-                maxLength: 2048
-                pattern: ^(http|https)://.*$
-                type: string
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing the authentication
-                  credentials for this Provider.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this Provider.
-                type: boolean
-              timeout:
-                description: Timeout for sending alerts to the Provider.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-              type:
-                description: Type specifies which Provider implementation to use.
-                enum:
-                - slack
-                - discord
-                - msteams
-                - rocket
-                - generic
-                - generic-hmac
-                - github
-                - gitlab
-                - gitea
-                - bitbucketserver
-                - bitbucket
-                - azuredevops
-                - googlechat
-                - googlepubsub
-                - webex
-                - sentry
-                - azureeventhub
-                - telegram
-                - lark
-                - matrix
-                - opsgenie
-                - alertmanager
-                - grafana
-                - githubdispatch
-                - pagerduty
-                - datadog
-                type: string
-              username:
-                description: Username specifies the name under which events are posted.
-                maxLength: 2048
-                type: string
-            required:
-            - type
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: ProviderStatus defines the observed state of the Provider.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the Provider.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                    Note: Support for the `caFile` key has
+                    been deprecated.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last reconciled generation.
-                format: int64
-                type: integer
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta3
-    schema:
-      openAPIV3Schema:
-        description: Provider is the Schema for the providers API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProviderSpec defines the desired state of the Provider.
-            properties:
-              address:
-                description: |-
-                  Address specifies the endpoint, in a generic sense, to where alerts are sent.
-                  What kind of endpoint depends on the specific Provider type being used.
-                  For the generic Provider, for example, this is an HTTP/S address.
-                  For other Provider types this could be a project ID or a namespace.
-                maxLength: 2048
-                type: string
-              certSecretRef:
-                description: |-
-                  CertSecretRef specifies the Secret containing TLS certificates
-                  for secure communication.
+                channel:
+                  description: Channel specifies the destination channel where events should be posted.
+                  maxLength: 2048
+                  type: string
+                interval:
+                  description: Interval at which to reconcile the Provider with its Secret references.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                proxy:
+                  description: Proxy the HTTP/S address of the proxy server.
+                  maxLength: 2048
+                  pattern: ^(http|https)://.*$
+                  type: string
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing the authentication
+                    credentials for this Provider.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this Provider.
+                  type: boolean
+                timeout:
+                  description: Timeout for sending alerts to the Provider.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+                type:
+                  description: Type specifies which Provider implementation to use.
+                  enum:
+                    - slack
+                    - discord
+                    - msteams
+                    - rocket
+                    - generic
+                    - generic-hmac
+                    - github
+                    - gitlab
+                    - gitea
+                    - bitbucketserver
+                    - bitbucket
+                    - azuredevops
+                    - googlechat
+                    - googlepubsub
+                    - webex
+                    - sentry
+                    - azureeventhub
+                    - telegram
+                    - lark
+                    - matrix
+                    - opsgenie
+                    - alertmanager
+                    - grafana
+                    - githubdispatch
+                    - pagerduty
+                    - datadog
+                  type: string
+                username:
+                  description: Username specifies the name under which events are posted.
+                  maxLength: 2048
+                  type: string
+              required:
+                - type
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: ProviderStatus defines the observed state of the Provider.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the Provider.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last reconciled generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta3
+      schema:
+        openAPIV3Schema:
+          description: Provider is the Schema for the providers API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProviderSpec defines the desired state of the Provider.
+              properties:
+                address:
+                  description: |-
+                    Address specifies the endpoint, in a generic sense, to where alerts are sent.
+                    What kind of endpoint depends on the specific Provider type being used.
+                    For the generic Provider, for example, this is an HTTP/S address.
+                    For other Provider types this could be a project ID or a namespace.
+                  maxLength: 2048
+                  type: string
+                certSecretRef:
+                  description: |-
+                    CertSecretRef specifies the Secret containing TLS certificates
+                    for secure communication.
 
-                  Supported configurations:
-                  - CA-only: Server authentication (provide ca.crt only)
-                  - mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
-                  - Client-only: Client authentication with system CA (provide tls.crt + tls.key only)
+                    Supported configurations:
+                    - CA-only: Server authentication (provide ca.crt only)
+                    - mTLS: Mutual authentication (provide ca.crt + tls.crt + tls.key)
+                    - Client-only: Client authentication with system CA (provide tls.crt + tls.key only)
 
-                  Legacy keys "caFile", "certFile", "keyFile" are supported but deprecated. Use "ca.crt", "tls.crt", "tls.key" instead.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              channel:
-                description: Channel specifies the destination channel where events
-                  should be posted.
-                maxLength: 2048
-                type: string
-              commitStatusExpr:
-                description: |-
-                  CommitStatusExpr is a CEL expression that evaluates to a string value
-                  that can be used to generate a custom commit status message for use
-                  with eligible Provider types (github, gitlab, gitea, bitbucketserver,
-                  bitbucket, azuredevops). Supported variables are: event, provider,
-                  and alert.
-                type: string
-              interval:
-                description: |-
-                  Interval at which to reconcile the Provider with its Secret references.
-                  Deprecated and not used in v1beta3.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              proxy:
-                description: |-
-                  Proxy the HTTP/S address of the proxy server.
-                  Deprecated: Use ProxySecretRef instead. Will be removed in v1.
-                maxLength: 2048
-                pattern: ^(http|https)://.*$
-                type: string
-              proxySecretRef:
-                description: |-
-                  ProxySecretRef specifies the Secret containing the proxy configuration
-                  for this Provider. The Secret should contain an 'address' key with the
-                  HTTP/S address of the proxy server. Optional 'username' and 'password'
-                  keys can be provided for proxy authentication.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing the authentication
-                  credentials for this Provider.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the name of the Kubernetes ServiceAccount used to
-                  authenticate with cloud provider services through workload identity.
-                  This enables multi-tenant authentication without storing static credentials.
+                    Legacy keys "caFile", "certFile", "keyFile" are supported but deprecated. Use "ca.crt", "tls.crt", "tls.key" instead.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                channel:
+                  description: Channel specifies the destination channel where events should be posted.
+                  maxLength: 2048
+                  type: string
+                commitStatusExpr:
+                  description: |-
+                    CommitStatusExpr is a CEL expression that evaluates to a string value
+                    that can be used to generate a custom commit status message for use
+                    with eligible Provider types (github, gitlab, gitea, bitbucketserver,
+                    bitbucket, azuredevops). Supported variables are: event, provider,
+                    and alert.
+                  type: string
+                interval:
+                  description: |-
+                    Interval at which to reconcile the Provider with its Secret references.
+                    Deprecated and not used in v1beta3.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                proxy:
+                  description: |-
+                    Proxy the HTTP/S address of the proxy server.
+                    Deprecated: Use ProxySecretRef instead. Will be removed in v1.
+                  maxLength: 2048
+                  pattern: ^(http|https)://.*$
+                  type: string
+                proxySecretRef:
+                  description: |-
+                    ProxySecretRef specifies the Secret containing the proxy configuration
+                    for this Provider. The Secret should contain an 'address' key with the
+                    HTTP/S address of the proxy server. Optional 'username' and 'password'
+                    keys can be provided for proxy authentication.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing the authentication
+                    credentials for this Provider.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount used to
+                    authenticate with cloud provider services through workload identity.
+                    This enables multi-tenant authentication without storing static credentials.
 
-                  Supported provider types: azureeventhub, azuredevops, googlepubsub
+                    Supported provider types: azureeventhub, azuredevops, googlepubsub
 
-                  When specified, the controller will:
-                  1. Create an OIDC token for the specified ServiceAccount
-                  2. Exchange it for cloud provider credentials via STS
-                  3. Use the obtained credentials for API authentication
+                    When specified, the controller will:
+                    1. Create an OIDC token for the specified ServiceAccount
+                    2. Exchange it for cloud provider credentials via STS
+                    3. Use the obtained credentials for API authentication
 
-                  When unspecified, controller-level authentication is used (single-tenant).
+                    When unspecified, controller-level authentication is used (single-tenant).
 
-                  An error is thrown if static credentials are also defined in SecretRef.
-                  This field requires the ObjectLevelWorkloadIdentity feature gate to be enabled.
-                type: string
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this Provider.
-                type: boolean
-              timeout:
-                description: Timeout for sending alerts to the Provider.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
-                type: string
-              type:
-                description: Type specifies which Provider implementation to use.
-                enum:
-                - slack
-                - discord
-                - msteams
-                - rocket
-                - generic
-                - generic-hmac
-                - github
-                - gitlab
-                - gitea
-                - giteapullrequestcomment
-                - bitbucketserver
-                - bitbucket
-                - azuredevops
-                - googlechat
-                - googlepubsub
-                - webex
-                - sentry
-                - azureeventhub
-                - telegram
-                - lark
-                - matrix
-                - opsgenie
-                - alertmanager
-                - grafana
-                - githubdispatch
-                - githubpullrequestcomment
-                - gitlabmergerequestcomment
-                - pagerduty
-                - datadog
-                - nats
-                - zulip
-                - otel
-                type: string
-              username:
-                description: Username specifies the name under which events are posted.
-                maxLength: 2048
-                type: string
-            required:
-            - type
-            type: object
-            x-kubernetes-validations:
-            - message: spec.commitStatusExpr is only supported for the 'github', 'gitlab',
-                'gitea', 'bitbucketserver', 'bitbucket', 'azuredevops' provider types
-              rule: self.type == 'github' || self.type == 'gitlab' || self.type ==
-                'gitea' || self.type == 'bitbucketserver' || self.type == 'bitbucket'
-                || self.type == 'azuredevops' || !has(self.commitStatusExpr)
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                    An error is thrown if static credentials are also defined in SecretRef.
+                    This field requires the ObjectLevelWorkloadIdentity feature gate to be enabled.
+                  type: string
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this Provider.
+                  type: boolean
+                timeout:
+                  description: Timeout for sending alerts to the Provider.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m))+$
+                  type: string
+                type:
+                  description: Type specifies which Provider implementation to use.
+                  enum:
+                    - slack
+                    - discord
+                    - msteams
+                    - rocket
+                    - generic
+                    - generic-hmac
+                    - github
+                    - gitlab
+                    - gitea
+                    - giteapullrequestcomment
+                    - bitbucketserver
+                    - bitbucket
+                    - azuredevops
+                    - googlechat
+                    - googlepubsub
+                    - webex
+                    - sentry
+                    - azureeventhub
+                    - telegram
+                    - lark
+                    - matrix
+                    - opsgenie
+                    - alertmanager
+                    - grafana
+                    - githubdispatch
+                    - githubpullrequestcomment
+                    - gitlabmergerequestcomment
+                    - pagerduty
+                    - datadog
+                    - nats
+                    - zulip
+                    - otel
+                  type: string
+                username:
+                  description: Username specifies the name under which events are posted.
+                  maxLength: 2048
+                  type: string
+              required:
+                - type
+              type: object
+              x-kubernetes-validations:
+                - message: spec.commitStatusExpr is only supported for the 'github', 'gitlab', 'gitea', 'bitbucketserver', 'bitbucket', 'azuredevops' provider types
+                  rule: self.type == 'github' || self.type == 'gitlab' || self.type == 'gitea' || self.type == 'bitbucketserver' || self.type == 'bitbucket' || self.type == 'azuredevops' || !has(self.commitStatusExpr)
+          type: object
+      served: true
+      storage: true
+      subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5820,471 +5702,465 @@ spec:
     singular: receiver
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Receiver is the Schema for the receivers API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ReceiverSpec defines the desired state of the Receiver.
-            properties:
-              events:
-                description: |-
-                  Events specifies the list of event types to handle,
-                  e.g. 'push' for GitHub or 'Push Hook' for GitLab.
-                items:
-                  type: string
-                type: array
-              interval:
-                default: 10m
-                description: Interval at which to reconcile the Receiver with its
-                  Secret references.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              resourceFilter:
-                description: |-
-                  ResourceFilter is a CEL expression expected to return a boolean that is
-                  evaluated for each resource referenced in the Resources field when a
-                  webhook is received. If the expression returns false then the controller
-                  will not request a reconciliation for the resource.
-                  When the expression is specified the controller will parse it and mark
-                  the object as terminally failed if the expression is invalid or does not
-                  return a boolean.
-                type: string
-              resources:
-                description: A list of resources to be notified about changes.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Receiver is the Schema for the receivers API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReceiverSpec defines the desired state of the Receiver.
+              properties:
+                events:
                   description: |-
-                    CrossNamespaceObjectReference contains enough information to let you locate the
-                    typed referenced object at cluster level
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      - ImageRepository
-                      - ImagePolicy
-                      - ImageUpdateAutomation
-                      - OCIRepository
-                      - ArtifactGenerator
-                      - ExternalArtifact
-                      type: string
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: |-
-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        MatchLabels requires the name to be set to `*`.
-                      type: object
-                    name:
-                      description: |-
-                        Name of the referent
-                        If multiple resources are targeted `*` may be set.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing the token used
-                  to validate the payload authenticity. The Secret must contain a 'token'
-                  key. For GCR receivers, the Secret must also contain an 'email' key
-                  with the IAM service account email configured on the Pub/Sub push
-                  subscription, and an 'audience' key with the expected OIDC token audience.
-                properties:
-                  name:
-                    description: Name of the referent.
+                    Events specifies the list of event types to handle,
+                    e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+                  items:
                     type: string
-                required:
-                - name
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this receiver.
-                type: boolean
-              type:
-                description: |-
-                  Type of webhook sender, used to determine
-                  the validation procedure and payload deserialization.
-                enum:
-                - generic
-                - generic-hmac
-                - github
-                - gitlab
-                - bitbucket
-                - harbor
-                - dockerhub
-                - quay
-                - gcr
-                - nexus
-                - acr
-                - cdevents
-                type: string
-            required:
-            - resources
-            - secretRef
-            - type
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: ReceiverStatus defines the observed state of the Receiver.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the Receiver.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation of
-                  the Receiver object.
-                format: int64
-                type: integer
-              webhookPath:
-                description: |-
-                  WebhookPath is the generated incoming webhook address in the format
-                  of '/hook/sha256sum(token+name+namespace)'.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      type: string
-    deprecated: true
-    deprecationWarning: v1beta2 Receiver is deprecated, upgrade to v1
-    name: v1beta2
-    schema:
-      openAPIV3Schema:
-        description: Receiver is the Schema for the receivers API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ReceiverSpec defines the desired state of the Receiver.
-            properties:
-              events:
-                description: |-
-                  Events specifies the list of event types to handle,
-                  e.g. 'push' for GitHub or 'Push Hook' for GitLab.
-                items:
+                  type: array
+                interval:
+                  default: 10m
+                  description: Interval at which to reconcile the Receiver with its Secret references.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                   type: string
-                type: array
-              interval:
-                description: Interval at which to reconcile the Receiver with its
-                  Secret references.
-                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
-                type: string
-              resources:
-                description: A list of resources to be notified about changes.
-                items:
+                resourceFilter:
                   description: |-
-                    CrossNamespaceObjectReference contains enough information to let you locate the
-                    typed referenced object at cluster level
-                  properties:
-                    apiVersion:
-                      description: API version of the referent
-                      type: string
-                    kind:
-                      description: Kind of the referent
-                      enum:
-                      - Bucket
-                      - GitRepository
-                      - Kustomization
-                      - HelmRelease
-                      - HelmChart
-                      - HelmRepository
-                      - ImageRepository
-                      - ImagePolicy
-                      - ImageUpdateAutomation
-                      - OCIRepository
-                      - ArtifactGenerator
-                      - ExternalArtifact
-                      type: string
-                    matchLabels:
-                      additionalProperties:
+                    ResourceFilter is a CEL expression expected to return a boolean that is
+                    evaluated for each resource referenced in the Resources field when a
+                    webhook is received. If the expression returns false then the controller
+                    will not request a reconciliation for the resource.
+                    When the expression is specified the controller will parse it and mark
+                    the object as terminally failed if the expression is invalid or does not
+                    return a boolean.
+                  type: string
+                resources:
+                  description: A list of resources to be notified about changes.
+                  items:
+                    description: |-
+                      CrossNamespaceObjectReference contains enough information to let you locate the
+                      typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
                         type: string
-                      description: |-
-                        MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
-                        map is equivalent to an element of matchExpressions, whose key field is "key", the
-                        operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        MatchLabels requires the name to be set to `*`.
-                      type: object
-                    name:
-                      description: |-
-                        Name of the referent
-                        If multiple resources are targeted `*` may be set.
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                    namespace:
-                      description: Namespace of the referent
-                      maxLength: 253
-                      minLength: 1
-                      type: string
-                  required:
-                  - kind
-                  - name
-                  type: object
-                type: array
-              secretRef:
-                description: |-
-                  SecretRef specifies the Secret containing the token used
-                  to validate the payload authenticity.
-                properties:
-                  name:
-                    description: Name of the referent.
-                    type: string
-                required:
-                - name
-                type: object
-              suspend:
-                description: |-
-                  Suspend tells the controller to suspend subsequent
-                  events handling for this receiver.
-                type: boolean
-              type:
-                description: |-
-                  Type of webhook sender, used to determine
-                  the validation procedure and payload deserialization.
-                enum:
-                - generic
-                - generic-hmac
-                - github
-                - gitlab
-                - bitbucket
-                - harbor
-                - dockerhub
-                - quay
-                - gcr
-                - nexus
-                - acr
-                type: string
-            required:
-            - resources
-            - secretRef
-            - type
-            type: object
-          status:
-            default:
-              observedGeneration: -1
-            description: ReceiverStatus defines the observed state of the Receiver.
-            properties:
-              conditions:
-                description: Conditions holds the conditions for the Receiver.
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                          - OCIRepository
+                          - ArtifactGenerator
+                          - ExternalArtifact
+                        type: string
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          MatchLabels requires the name to be set to `*`.
+                        type: object
+                      name:
+                        description: |-
+                          Name of the referent
+                          If multiple resources are targeted `*` may be set.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing the token used
+                    to validate the payload authenticity. The Secret must contain a 'token'
+                    key. For GCR receivers, the Secret must also contain an 'email' key
+                    with the IAM service account email configured on the Pub/Sub push
+                    subscription, and an 'audience' key with the expected OIDC token audience.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    name:
+                      description: Name of the referent.
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - name
                   type: object
-                type: array
-              lastHandledReconcileAt:
-                description: |-
-                  LastHandledReconcileAt holds the value of the most recent
-                  reconcile request value, so a change of the annotation value
-                  can be detected.
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the last observed generation of
-                  the Receiver object.
-                format: int64
-                type: integer
-              url:
-                description: |-
-                  URL is the generated incoming webhook address in the format
-                  of '/hook/sha256sum(token+name+namespace)'.
-                  Deprecated: Replaced by WebhookPath.
-                type: string
-              webhookPath:
-                description: |-
-                  WebhookPath is the generated incoming webhook address in the format
-                  of '/hook/sha256sum(token+name+namespace)'.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this receiver.
+                  type: boolean
+                type:
+                  description: |-
+                    Type of webhook sender, used to determine
+                    the validation procedure and payload deserialization.
+                  enum:
+                    - generic
+                    - generic-hmac
+                    - github
+                    - gitlab
+                    - bitbucket
+                    - harbor
+                    - dockerhub
+                    - quay
+                    - gcr
+                    - nexus
+                    - acr
+                    - cdevents
+                  type: string
+              required:
+                - resources
+                - secretRef
+                - type
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: ReceiverStatus defines the observed state of the Receiver.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the Receiver.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation of the Receiver object.
+                  format: int64
+                  type: integer
+                webhookPath:
+                  description: |-
+                    WebhookPath is the generated incoming webhook address in the format
+                    of '/hook/sha256sum(token+name+namespace)'.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          type: string
+      deprecated: true
+      deprecationWarning: v1beta2 Receiver is deprecated, upgrade to v1
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Receiver is the Schema for the receivers API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReceiverSpec defines the desired state of the Receiver.
+              properties:
+                events:
+                  description: |-
+                    Events specifies the list of event types to handle,
+                    e.g. 'push' for GitHub or 'Push Hook' for GitLab.
+                  items:
+                    type: string
+                  type: array
+                interval:
+                  description: Interval at which to reconcile the Receiver with its Secret references.
+                  pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                  type: string
+                resources:
+                  description: A list of resources to be notified about changes.
+                  items:
+                    description: |-
+                      CrossNamespaceObjectReference contains enough information to let you locate the
+                      typed referenced object at cluster level
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: Kind of the referent
+                        enum:
+                          - Bucket
+                          - GitRepository
+                          - Kustomization
+                          - HelmRelease
+                          - HelmChart
+                          - HelmRepository
+                          - ImageRepository
+                          - ImagePolicy
+                          - ImageUpdateAutomation
+                          - OCIRepository
+                          - ArtifactGenerator
+                          - ExternalArtifact
+                        type: string
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          MatchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          MatchLabels requires the name to be set to `*`.
+                        type: object
+                      name:
+                        description: |-
+                          Name of the referent
+                          If multiple resources are targeted `*` may be set.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace of the referent
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                  type: array
+                secretRef:
+                  description: |-
+                    SecretRef specifies the Secret containing the token used
+                    to validate the payload authenticity.
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                    - name
+                  type: object
+                suspend:
+                  description: |-
+                    Suspend tells the controller to suspend subsequent
+                    events handling for this receiver.
+                  type: boolean
+                type:
+                  description: |-
+                    Type of webhook sender, used to determine
+                    the validation procedure and payload deserialization.
+                  enum:
+                    - generic
+                    - generic-hmac
+                    - github
+                    - gitlab
+                    - bitbucket
+                    - harbor
+                    - dockerhub
+                    - quay
+                    - gcr
+                    - nexus
+                    - acr
+                  type: string
+              required:
+                - resources
+                - secretRef
+                - type
+              type: object
+            status:
+              default:
+                observedGeneration: -1
+              description: ReceiverStatus defines the observed state of the Receiver.
+              properties:
+                conditions:
+                  description: Conditions holds the conditions for the Receiver.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                lastHandledReconcileAt:
+                  description: |-
+                    LastHandledReconcileAt holds the value of the most recent
+                    reconcile request value, so a change of the annotation value
+                    can be detected.
+                  type: string
+                observedGeneration:
+                  description: ObservedGeneration is the last observed generation of the Receiver object.
+                  format: int64
+                  type: integer
+                url:
+                  description: |-
+                    URL is the generated incoming webhook address in the format
+                    of '/hook/sha256sum(token+name+namespace)'.
+                    Deprecated: Replaced by WebhookPath.
+                  type: string
+                webhookPath:
+                  description: |-
+                    WebhookPath is the generated incoming webhook address in the format
+                    of '/hook/sha256sum(token+name+namespace)'.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -6310,10 +6186,10 @@ metadata:
   namespace: flux-system
 spec:
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: http
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
   selector:
     app: notification-controller
   type: ClusterIP
@@ -6331,10 +6207,10 @@ metadata:
   namespace: flux-system
 spec:
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: http-webhook
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http-webhook
   selector:
     app: notification-controller
   type: ClusterIP
@@ -6368,64 +6244,64 @@ spec:
         app.kubernetes.io/version: v2.8.6
     spec:
       containers:
-      - args:
-        - --watch-all-namespaces=true
-        - --log-level=info
-        - --log-encoding=json
-        - --enable-leader-election
-        env:
-        - name: RUNTIME_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: GOMEMLIMIT
-          valueFrom:
-            resourceFieldRef:
-              containerName: manager
-              resource: limits.memory
-        image: ghcr.io/fluxcd/notification-controller:v1.8.4
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: healthz
-        name: manager
-        ports:
-        - containerPort: 9090
-          name: http
-          protocol: TCP
-        - containerPort: 9292
-          name: http-webhook
-          protocol: TCP
-        - containerPort: 8080
-          name: http-prom
-          protocol: TCP
-        - containerPort: 9440
-          name: healthz
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: healthz
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /tmp
-          name: temp
+        - args:
+            - --watch-all-namespaces=true
+            - --log-level=info
+            - --log-encoding=json
+            - --enable-leader-election
+          env:
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: manager
+                  resource: limits.memory
+          image: ghcr.io/fluxcd/notification-controller:v1.8.4
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          name: manager
+          ports:
+            - containerPort: 9090
+              name: http
+              protocol: TCP
+            - containerPort: 9292
+              name: http-webhook
+              protocol: TCP
+            - containerPort: 8080
+              name: http-prom
+              protocol: TCP
+            - containerPort: 9440
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -6433,5 +6309,5 @@ spec:
       serviceAccountName: notification-controller
       terminationGracePeriodSeconds: 10
       volumes:
-      - emptyDir: {}
-        name: temp
+        - emptyDir: {}
+          name: temp

--- a/kubernetes/infra/monitoring/loki/app.yaml
+++ b/kubernetes/infra/monitoring/loki/app.yaml
@@ -50,7 +50,7 @@ spec:
 
     limits_config:
       allow_structured_metadata: true
-      retention_period: 336h # 14 days
+      retention_period: 336h  # 14 days
 
     deploymentMode: SimpleScalable
 

--- a/kubernetes/infra/monitoring/mimir/app.yaml
+++ b/kubernetes/infra/monitoring/mimir/app.yaml
@@ -29,8 +29,8 @@ spec:
         limits:
           max_global_series_per_user: 2000000
           out_of_order_time_window: 5m
-          ingestion_rate: 50000 # samples/sec (increased from default 10000)
-          ingestion_burst_size: 500000 # increased from default 200000
+          ingestion_rate: 50000  # samples/sec (increased from default 10000)
+          ingestion_burst_size: 500000  # increased from default 200000
         ingester:
           ring:
             replication_factor: 1

--- a/kubernetes/infra/monitoring/snmp-exporter/servicemonitor.yaml
+++ b/kubernetes/infra/monitoring/snmp-exporter/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
       path: /snmp
       params:
         module: [synology]
-        target: [nas.beagle.casa] # Your Synology hostname
+        target: [nas.beagle.casa]  # Your Synology hostname
       relabelings:
         - sourceLabels: [__address__]
           targetLabel: __param_target


### PR DESCRIPTION
This pull request makes a series of formatting improvements to the `kubernetes/clusters/production/flux-system/gotk-components.yaml` file. The main focus is on consolidating multi-line descriptions into single lines for better readability and consistency. Additionally, some minor adjustments are made to the formatting of validation rules. There are no functional or behavioral changes to the configuration.

The most important changes include:

**Description Formatting Improvements:**

* Consolidated multi-line `description` fields throughout the YAML schema into single-line descriptions for improved readability and consistency. [[1]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL396-R396) [[2]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL416-R415) [[3]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL443-R441) [[4]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL613-R604) [[5]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL674-R664) [[6]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL760-R749) [[7]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL770-R758) [[8]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL782-R769) [[9]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL831-R817) [[10]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1032-R1017) [[11]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1050-R1034) [[12]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1092-R1079) [[13]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1140-R1128) [[14]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1197-R1176) [[15]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1259-R1237) [[16]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1272-R1249) [[17]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1477-R1453) [[18]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1552-R1527) [[19]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1592-R1566) [[20]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1641-R1614) [[21]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1936-R1908) [[22]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1985-R1956) [[23]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL2152-R2122) [[24]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL2222-R2191) [[25]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL2248-R2220)

**Validation Rule Formatting:**

* Reformatted validation rules under `x-kubernetes-validations` to use single-line messages and rules, enhancing YAML clarity and maintainability. [[1]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL539-R546) [[2]](diffhunk://#diff-2689f59c97c4dd841b817017067955aa0608dc639d28d58863379f0fcc8a4fadL1140-R1128)

No logic or behavioral changes have been introduced—these are purely formatting and documentation improvements.