### PR TITLE
chore(devcontainer): add github cli

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -35,6 +35,11 @@
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
       "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
     },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "version": "1.3.1",
       "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
     "ghcr.io/devcontainers-extra/features/sops:1": {},
     "ghcr.io/devcontainers-extra/features/claude-code:2": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers-extra/features/cloudflared:1": {},
     "ghcr.io/devcontainers-extra/features/terraform-docs:1": {},
     "ghcr.io/devcontainers-extra/features/pre-commit:2": {},


### PR DESCRIPTION
This pull request adds the GitHub CLI feature to the development container configuration. This will make the `gh` command-line tool available in the devcontainer, allowing for streamlined GitHub workflows during development.

**Devcontainer feature additions:**

* Added the `ghcr.io/devcontainers/features/github-cli:1` feature to `.devcontainer/devcontainer.json` to enable the GitHub CLI in the development environment.
* Updated `.devcontainer/devcontainer-lock.json` to include the lock entry for the `github-cli` feature, ensuring consistent and reproducible builds.