### PR TITLE
chore: enforce conventional commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,23 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - build
+          - chore
+          - ci
+          - docs
+          - feat
+          - fix
+          - perf
+          - refactor
+          - revert
+          - style
+          - test
   - repo: local
     hooks:
       - id: architecture-doc

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ This repo is set up for use with [Claude Code](https://claude.ai/code) inside th
 
 `GRAFANA_API_KEY` is injected at container start from `terraform/external/grafana` output — no secrets in committed files.
 
+### Git Hooks
+
+Install both pre-commit and commit-msg hooks:
+
+```sh
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
 ---
 
 ## Kubernetes & Flux Quick Reference


### PR DESCRIPTION
This pull request adds support for commit message linting using Conventional Commits through a new pre-commit hook, and updates the documentation to guide developers on installing the necessary git hooks.

**Pre-commit hook configuration:**

* Added the `conventional-pre-commit` hook to `.pre-commit-config.yaml` to enforce Conventional Commits on commit messages, specifying allowed types such as `feat`, `fix`, `docs`, etc.

**Documentation updates:**

* Updated `README.md` with instructions for installing both `pre-commit` and `commit-msg` hooks to ensure developers set up their local environment correctly.