### PR TITLE
docs: add idea-based agent workflow

### DIFF
--- a/.codex/hooks/verifier_push_guard.sh
+++ b/.codex/hooks/verifier_push_guard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote_name="${PRE_COMMIT_REMOTE_NAME:-}"
+remote_url="${PRE_COMMIT_REMOTE_URL:-}"
+
+if [[ -z "$remote_name" && -z "$remote_url" ]]; then
+  remote_name="${1:-}"
+  remote_url="${2:-}"
+fi
+
+explicit_pre_push_remote=0
+if [[ -n "$remote_name" || -n "$remote_url" ]]; then
+  explicit_pre_push_remote=1
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+origin_url="$(git remote get-url origin 2>/dev/null || true)"
+
+if [[ -z "$remote_name" && -n "$remote_url" && -n "$origin_url" && "$remote_url" == "$origin_url" ]]; then
+  remote_name="origin"
+fi
+
+if [[ -z "$remote_name" && "$explicit_pre_push_remote" -eq 0 ]]; then
+  upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ "$upstream" == */* ]]; then
+    remote_name="${upstream%%/*}"
+  fi
+fi
+
+if [[ "$remote_name" != "origin" ]]; then
+  exit 0
+fi
+
+head_sha="$(git rev-parse HEAD)"
+approval_file=".codex/tmp/verifier-approved"
+
+if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
+  {
+    printf 'Verifier push guard: refusing to push to origin.\n'
+    printf 'Expected %s to contain the exact HEAD SHA:\n' "$approval_file"
+    printf '  %s\n' "$head_sha"
+    printf 'Run verifier-agent review, resolve any blockers, then record approval for the exact HEAD before pushing.\n'
+  } >&2
+  exit 1
+fi

--- a/.codex/memory/approved/2026-05-09-idea-pr-agent-workflow.md
+++ b/.codex/memory/approved/2026-05-09-idea-pr-agent-workflow.md
@@ -1,0 +1,20 @@
+---
+status: approved
+created: 2026-05-09
+source: user-preference
+kind: workflow-preference
+---
+
+# Idea PR Agent Workflow
+
+Break work into named ideas before implementation.
+
+Each idea maps to one pull request and may contain multiple conventional commits. A separate implementation agent owns each idea's implementation work.
+
+New idea branches must always branch from `main`.
+
+As implementation agents finish, create separate verifier agents to review the result. The planner coordinates the idea breakdown, delegates implementation and verification, and summarizes status.
+
+Conventional commits are enforced locally and by origin.
+
+Do not push to origin until verifier approval is recorded for the exact `HEAD` commit.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
           - test
   - repo: local
     hooks:
+      - id: verifier-push-guard
+        name: Require verifier approval before origin push
+        entry: .codex/hooks/verifier_push_guard.sh
+        language: system
+        stages: [pre-push]
+        pass_filenames: false
+        always_run: true
       - id: architecture-doc
         name: Check generated architecture document
         entry: python3 tools/architecture/render.py --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 - Use StorageClass `nfs-csi-storage` for persistent app storage unless a decision record supersedes it.
 - Manage Talos nodes through `talosctl`; Talos nodes do not support SSH.
 - Preserve other people's work. Check the working tree before editing and avoid unrelated rewrites.
+- Break work into named ideas before implementation. Each idea maps to one PR and may contain multiple conventional commits.
+- New idea branches must always branch from `main`.
+- Implement each idea with a separate implementation agent. As implementations finish, create separate verifier agents; the planner coordinates, delegates, and summarizes.
+- Conventional commits are enforced locally and by origin.
+- Do not push to origin until verifier approval is recorded for the exact `HEAD`.
 
 ## Tool Routing
 


### PR DESCRIPTION
## Summary
- document the idea-to-PR workflow in AGENTS.md
- add approved memory for planner-led implementation and verifier agents
- add a pre-push guard requiring verifier approval for the exact HEAD before origin pushes

## Verification
- bash -n .codex/hooks/verifier_push_guard.sh
- .codex/hooks/stop_self_verify.sh
- pre-commit run --all-files
- pre-commit validate-config
- direct verifier guard smoke tests for origin/non-origin and missing/stale/matching receipts
- staged pre-push integration smoke with matching verifier receipt
- verifier agent approved commit 174a925f60e70a231291bd7a4f39a533fe636e9b

Replaces closed PR #134, which was opened from the wrong branch.