### PR TITLE
fix: Fix devcontainer poststart.sh

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,11 +5,6 @@
       "resolved": "ghcr.io/devcontainer-community/devcontainer-features/astral.sh-uv@sha256:36f95b90080248a05aba7b1b3cecf8018bb6d7222f6274f03f050b502abd4fe7",
       "integrity": "sha256:36f95b90080248a05aba7b1b3cecf8018bb6d7222f6274f03f050b502abd4fe7"
     },
-    "ghcr.io/devcontainers-extra/features/claude-code:2": {
-      "version": "2.0.0",
-      "resolved": "ghcr.io/devcontainers-extra/features/claude-code@sha256:37b0d444a704021ee5f6d24242a4621bf337867d110e4e3c06b863a3a78122ac",
-      "integrity": "sha256:37b0d444a704021ee5f6d24242a4621bf337867d110e4e3c06b863a3a78122ac"
-    },
     "ghcr.io/devcontainers-extra/features/cloudflared:1": {
       "version": "1.0.8",
       "resolved": "ghcr.io/devcontainers-extra/features/cloudflared@sha256:18b7db2cd2e84ce93716c465bebc4b5944b8309bdfe6fbf8c49b9129f3cc8253",
@@ -69,11 +64,6 @@
       "version": "1.0.0",
       "resolved": "ghcr.io/petebeegle/devcontainer-features/flux@sha256:236c9428ea837c68223c05b1f859bba983e83e843d4de53ceadfa2905e31947c",
       "integrity": "sha256:236c9428ea837c68223c05b1f859bba983e83e843d4de53ceadfa2905e31947c"
-    },
-    "ghcr.io/petebeegle/devcontainer-features/graphify:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/petebeegle/devcontainer-features/graphify@sha256:e05c6257894bac0ed549b956847949b2acee4012a43b4fc0e26493f55a98ae9f",
-      "integrity": "sha256:e05c6257894bac0ed549b956847949b2acee4012a43b4fc0e26493f55a98ae9f"
     },
     "ghcr.io/petebeegle/devcontainer-features/talosctl:1": {
       "version": "1.0.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,11 +10,9 @@
       "terragrunt": "none"
     },
     "ghcr.io/petebeegle/devcontainer-features/talosctl:1": {},
-    "ghcr.io/petebeegle/devcontainer-features/graphify:1": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers-extra/features/sops:1": {},
-    "ghcr.io/devcontainers-extra/features/claude-code:2": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers-extra/features/cloudflared:1": {},
@@ -28,20 +26,17 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "github.copilot-chat",
         "1password.1password",
         "HashiCorp.terraform",
         "EditorConfig.EditorConfig",
         "Weaveworks.vscode-gitops-tools",
         "Grafana.grafana-alloy",
-        "anthropic.claude-code"
+        "openai.chatgpt"
       ]
     }
   },
   "mounts": [
     "source=${localEnv:HOME}/.config/sops/age,target=/home/vscode/.config/sops/age,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
   ],
   "forwardPorts": [
     12345 // alloy

--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -54,6 +54,3 @@ if ! agnix --version >/dev/null 2>&1; then
   install -m 0755 "$tmpdir/agnix" "$HOME/.local/bin/agnix"
   rm -rf "$tmpdir"
 fi
-
-# pip install mcp (for graphify)
-python3 -m pip install mcp


### PR DESCRIPTION
This pull request removes support for the `claude-code` and `graphify` features from the development container setup, and updates related configuration such as VSCode extensions and volume mounts. It also cleans up an unnecessary Python package installation. These changes streamline the dev container by removing unused or deprecated tools.

**Dev container feature removals:**

* Removed the `claude-code` feature from both `.devcontainer/devcontainer.json` and `.devcontainer/devcontainer-lock.json`, along with its associated VSCode extension and data volume mount. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L13-L17) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L31-L44) [[3]](diffhunk://#diff-cd9c61f8ff24fb9bcc3663e346e2cfa419cfb84e02aae18d3dc66dd192681696L8-L12)
* Removed the `graphify` feature from both `.devcontainer/devcontainer.json` and `.devcontainer/devcontainer-lock.json`, and removed the related `mcp` Python package installation from `.devcontainer/poststart.sh`. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L13-L17) [[2]](diffhunk://#diff-cd9c61f8ff24fb9bcc3663e346e2cfa419cfb84e02aae18d3dc66dd192681696L73-L77) [[3]](diffhunk://#diff-36e8bc6a210e4b3dd4fffa1aa391ce61710c12f8f930243abda51945c0d253b7L57-L59)

**VSCode extension and mount updates:**

* Replaced the `anthropic.claude-code` VSCode extension with `openai.chatgpt` in the dev container configuration.
* Removed volume mounts for `.codex` and `.claude` directories, as they are no longer needed.