### PR TITLE
Update PR workflow

### DIFF
--- a/.codex/memory/approved/2026-05-09-idea-pr-agent-workflow.md
+++ b/.codex/memory/approved/2026-05-09-idea-pr-agent-workflow.md
@@ -13,6 +13,8 @@ Each idea maps to one pull request and may contain multiple conventional commits
 
 New idea branches must always branch from `main`.
 
+Branches should follow the format `codex/<IDEA>`.
+
 As implementation agents finish, create separate verifier agents to review the result. The planner coordinates the idea breakdown, delegates implementation and verification, and summarizes status.
 
 Conventional commits are enforced locally and by origin.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,7 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 - Manage Talos nodes through `talosctl`; Talos nodes do not support SSH.
 - Preserve other people's work. Check the working tree before editing and avoid unrelated rewrites.
 - Break work into named ideas before implementation. Each idea maps to one PR and may contain multiple conventional commits.
-- New idea branches must always branch from `main`.
-- Implement each idea with a separate implementation agent. As implementations finish, create separate verifier agents; the planner coordinates, delegates, and summarizes.
-- Conventional commits are enforced locally and by origin.
-- Do not push to origin until verifier approval is recorded for the exact `HEAD`.
+- New work must always leverage the 2026-05-09-idea-pr-agent-workflow.md
 
 ## Tool Routing
 


### PR DESCRIPTION
This pull request updates documentation to clarify and centralize the workflow for implementing new ideas and managing branches. The changes focus on improving clarity around branching strategy and referencing the canonical workflow documentation.

Workflow and branching documentation:

* Updated `.codex/memory/approved/2026-05-09-idea-pr-agent-workflow.md` to specify that new branches should follow the format `codex/<IDEA>`.
* Simplified and consolidated workflow instructions in `AGENTS.md` by replacing detailed steps with a reference to the canonical `2026-05-09-idea-pr-agent-workflow.md` file.