### PR TITLE
fix(terraform): source synology provider credentials from variables

### DIFF
--- a/docs/decisions/terraform-sensitive-values.md
+++ b/docs/decisions/terraform-sensitive-values.md
@@ -1,0 +1,28 @@
+# Terraform Sensitive Values
+
+## Status
+
+Accepted.
+
+## Decision
+
+Sensitive Terraform input values are stored in local untracked `*.tfvars` files. They are not committed to Git and are not SOPS-encrypted in this repo.
+
+Committed Kubernetes Secret manifests continue to use SOPS with Age recipients. Terraform operator credentials and local provider inputs, including Synology provider credentials, are supplied through ignored tfvars files on the operator workstation.
+
+## Rationale
+
+- Terraform provider credentials are local operator inputs rather than Kubernetes desired state.
+- Keeping tfvars files untracked avoids committing plaintext or encrypted workstation-specific credentials.
+- The repo already ignores `*.tfvars`, which keeps local Terraform inputs out of normal Git review.
+
+## Consequences
+
+- Operators must create or update local tfvars files before running Terraform plans or applies that require sensitive inputs.
+- Do not commit tfvars files, encrypted or plaintext.
+- Do not use Kubernetes SOPS secret manifests for Terraform provider credentials unless a future decision changes this policy.
+
+## Operational Notes
+
+- Use `terraform.tfvars` or another ignored `*.tfvars` file in the relevant Terraform root.
+- Kubernetes Secret files still follow the SOPS policy in `docs/decisions/sops-age-secrets.md`.

--- a/terraform/external/synology/provider.tf
+++ b/terraform/external/synology/provider.tf
@@ -12,9 +12,8 @@ terraform {
 }
 
 provider "synology" {
-  host       = "https://192.168.30.99:5001"
-  user       = "petebeegle"
-  password   = "4o3TkK4vA6gVeCQo8QPJ"
-  otp_secret = "2NDUKO44ISCVQK6S"
-
+  host       = var.synology.host
+  user       = var.synology.user
+  password   = var.synology.password
+  otp_secret = var.synology.otp_secret
 }

--- a/terraform/external/synology/variables.tf
+++ b/terraform/external/synology/variables.tf
@@ -1,3 +1,14 @@
+variable "synology" {
+  description = "Synology provider connection details supplied from an untracked local tfvars file."
+  type = object({
+    host       = string
+    user       = string
+    password   = string
+    otp_secret = string
+  })
+  sensitive = true
+}
+
 variable "homelab_user_password" {
   description = "Password for the homelab user (used by Kubernetes CSI driver)"
   type        = string


### PR DESCRIPTION
## Summary
- document that sensitive Terraform values belong in untracked local tfvars
- source Synology provider credentials from a sensitive `synology` variable
- remove hardcoded Synology provider credentials from tracked Terraform

## Validation
- `terraform -chdir=terraform/external/synology fmt -check`
- `terraform -chdir=terraform/external/synology validate`
- verifier approved HEAD `a34aea4f063aacfff74fddf476c43bacfa904453`