### PR TITLE
fix(authentik): emit synology username claim

### DIFF
--- a/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
+++ b/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
@@ -23,16 +23,24 @@ entries:
     attrs:
       name: Synology Editors
 
-  # Custom property mapping for groups
+  # Custom property mapping for Synology profile compatibility
   - identifiers:
-      managed: goauthentik.io/providers/oauth2/synology-groups
+      managed: goauthentik.io/providers/oauth2/synology-profile
     model: authentik_providers_oauth2.scopemapping
     attrs:
-      name: Synology Groups Mapping
-      scope_name: groups
+      name: Synology Profile Mapping
+      scope_name: profile
       expression: |
+        username = request.user.username
         return {
-          "groups": [group.name for group in request.user.ak_groups.all()],
+          "name": request.user.name,
+          "given_name": request.user.name,
+          "preferred_username": username,
+          "username": username,
+          "nickname": username,
+          "email": request.user.email,
+          "email_verified": False,
+          "groups": [group.name for group in request.user.groups.all()],
         }
 
   # OAuth2 Provider for Synology
@@ -55,8 +63,7 @@ entries:
       property_mappings:
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
-        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/synology-groups]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/synology-profile]]
       sub_mode: hashed_user_id
       issuer_mode: per_provider
       access_code_validity: minutes=1


### PR DESCRIPTION
Summary:
- Add a Synology-specific Authentik OAuth profile scope mapping that emits both preferred_username and username for DSM compatibility.
- Include profile fields, email, email_verified=false, and groups from request.user.groups in the Synology profile response.
- Update the Synology provider to use the custom profile mapping while preserving existing redirect URIs and launch URL.

Important changes:
- Removed the separate Synology groups scope mapping from the provider mapping set to avoid duplicate group claims.
- No secrets were staged or changed.
