### PR TITLE
Fix Synology gateway TLS and SSO URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,12 @@ repos:
         stages: [pre-commit]
         pass_filenames: false
         always_run: true
+      - id: synology-oauth-redirect
+        name: Check Synology OAuth redirect path
+        entry: python3 tools/policy/check_synology_oauth_redirect.py
+        language: system
+        files: ^(kubernetes/infra/authentik/blueprints/synology-oauth\.yaml|tools/policy/check_synology_oauth_redirect\.py|\.pre-commit-config\.yaml)$
+        pass_filenames: false
       - id: agent-memory-lint
         name: Lint Codex memory docs
         entry: bash -c 'PYTHONPATH=tools/agent-memory/src python3 -m agent_memory.cli lint'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,8 +99,9 @@ This document is generated for agentic repo navigation. It records relationships
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
+| `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology:5000` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
-| `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway` | `(none)` |
+| `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |
 | `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |
@@ -111,7 +112,6 @@ This document is generated for agentic repo navigation. It records relationships
 | `TLSRoute` | `external/pve02-route` | `pve02.petebeegle.com` | `gateway/passthrough` | `pve02:8006` |
 | `TLSRoute` | `external/pve03-route` | `pve03.petebeegle.com` | `gateway/passthrough` | `pve03:8006` |
 | `TLSRoute` | `external/pve04-route` | `pve04.petebeegle.com` | `gateway/passthrough` | `pve04:8006` |
-| `TLSRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/passthrough` | `synology:5001` |
 | `TLSRoute` | `external/unifi-route` | `unifi.petebeegle.com` | `gateway/passthrough` | `unifi:443` |
 
 ## Storage Relationships

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ This document is generated for agentic repo navigation. It records relationships
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
-| `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology:5000` |
+| `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology:5001` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |

--- a/docs/decisions/cilium-gateway-api-ingress.md
+++ b/docs/decisions/cilium-gateway-api-ingress.md
@@ -12,13 +12,15 @@ Use Cilium Gateway API for cluster ingress. Do not add traditional Kubernetes In
 
 - Cilium provides Gateway API support, L2 load balancer IP advertisement, and kube-proxy replacement in one networking layer.
 - Gateway API separates shared listener configuration from app-owned routes.
-- Existing apps use `HTTPRoute` for internal HTTPS and `TLSRoute` for passthrough to external services.
+- Existing apps use `HTTPRoute` for Gateway-terminated HTTPS and `TLSRoute` for passthrough to external services that terminate TLS themselves.
 
 ## Consequences
 
 - Internal HTTP apps attach to Gateway `internal` in namespace `gateway`, section `https-gateway`.
 - Hostnames should use `${cluster_domain}` in shared manifests.
 - Cilium settings such as `kubeProxyReplacement: true` and L2 announcements are ingress-critical.
+- Use `HTTPRoute` when the cluster should provide the trusted certificate, normalize a public hostname, or hide a backend port.
+- Use `TLSRoute` passthrough only when the target should terminate TLS itself and presents an acceptable certificate for the hostname.
 - TLS passthrough targets terminate TLS themselves and do not need cert-manager certificates.
 
 ## Operational Notes

--- a/docs/decisions/synology-gateway-terminated-https.md
+++ b/docs/decisions/synology-gateway-terminated-https.md
@@ -1,0 +1,23 @@
+# Synology Gateway-Terminated HTTPS
+
+## Status
+
+Accepted.
+
+## Decision
+
+Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gateway with Gateway-terminated HTTPS. The Gateway presents a cert-manager certificate for `synology.petebeegle.com` and proxies DSM over HTTP to the NAS on port 5000.
+
+## Rationale
+
+- DSM's built-in certificate for `192.168.30.99:5001` is not trusted for `synology.petebeegle.com`.
+- Gateway termination lets cert-manager issue and renew the public hostname certificate.
+- Users should access DSM without a visible backend port.
+- Authentik and DSM SSO should use the same public URL.
+
+## Consequences
+
+- DNS for `synology.petebeegle.com` must point at the internal Gateway IP, not directly at the NAS.
+- Synology uses an `HTTPRoute` to the internal Gateway instead of a `TLSRoute` to the passthrough Gateway.
+- Use `HTTPRoute` for external services when the cluster should provide the trusted certificate or hide backend ports.
+- Use `TLSRoute` passthrough only when the external target should terminate TLS itself and presents an acceptable certificate for the hostname.

--- a/docs/decisions/synology-gateway-terminated-https.md
+++ b/docs/decisions/synology-gateway-terminated-https.md
@@ -6,7 +6,7 @@ Accepted.
 
 ## Decision
 
-Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gateway with Gateway-terminated HTTPS. The Gateway presents a cert-manager certificate for `synology.petebeegle.com` and proxies DSM over HTTP to the NAS on port 5000.
+Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gateway with Gateway-terminated HTTPS. The Gateway presents a cert-manager certificate for `synology.petebeegle.com` and proxies DSM over HTTPS to the NAS on port 5001.
 
 ## Rationale
 
@@ -19,5 +19,6 @@ Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gat
 
 - DNS for `synology.petebeegle.com` must point at the internal Gateway IP, not directly at the NAS.
 - Synology uses an `HTTPRoute` to the internal Gateway instead of a `TLSRoute` to the passthrough Gateway.
+- The Synology Service advertises `appProtocol: https` so Cilium uses HTTPS to reach DSM and avoids DSM's HTTP-to-HTTPS redirect to `:5001`.
 - Use `HTTPRoute` for external services when the cluster should provide the trusted certificate or hide backend ports.
 - Use `TLSRoute` passthrough only when the external target should terminate TLS itself and presents an acceptable certificate for the hostname.

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -101,6 +101,7 @@ spec:
 ## External Service HTTPRoute Template
 
 Use this pattern for a service outside the cluster when the Gateway should present the trusted certificate or hide the backend port.
+Set `appProtocol: https` on the Service port when the Gateway should use HTTPS to reach the backend.
 
 ```yaml
 ---
@@ -113,6 +114,7 @@ spec:
   ports:
     - name: http
       protocol: TCP
+      appProtocol: <http-or-https>
       port: <backend-port>
       targetPort: <backend-port>
 ---
@@ -127,6 +129,7 @@ addressType: IPv4
 ports:
   - name: http
     protocol: TCP
+    appProtocol: <http-or-https>
     port: <backend-port>
 endpoints:
   - addresses:

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -6,7 +6,7 @@ Use this runbook to add a Kubernetes app managed by Flux.
 
 - App name and namespace.
 - Deployment style: raw manifests or HelmRelease.
-- Exposure model: no route, internal `HTTPRoute`, or external `TLSRoute`.
+- Exposure model: no route, Gateway-terminated `HTTPRoute`, or `TLSRoute` passthrough.
 - Storage needs, especially whether PVCs require `nfs-csi-storage`.
 - Secret needs; if present, also follow `docs/runbooks/add-secret.md`.
 
@@ -15,7 +15,7 @@ Use this runbook to add a Kubernetes app managed by Flux.
 1. Create `kubernetes/apps/<app-name>/`.
 2. Add `namespace.yaml` or include the Namespace in `app.yaml`.
 3. Add the workload manifest or HelmRelease.
-4. Add `httproute.yaml` if the app is exposed internally.
+4. Add `httproute.yaml` for Gateway-terminated HTTP(S), or `tlsroute.yaml` for TLS passthrough.
 5. Add `kustomization.yaml` listing the app resources.
 6. Add `kubernetes/clusters/production/apps/<app-name>.yaml` as a Flux Kustomization.
 7. Add the new cluster-layer file to `kubernetes/clusters/production/apps/kustomization.yaml`.
@@ -96,6 +96,84 @@ spec:
         - name: <service-name>
           port: <port>
           weight: 1
+```
+
+## External Service HTTPRoute Template
+
+Use this pattern for a service outside the cluster when the Gateway should present the trusted certificate or hide the backend port.
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <service-name>
+  namespace: external
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: <backend-port>
+      targetPort: <backend-port>
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: <service-name>
+  namespace: external
+  labels:
+    kubernetes.io/service-name: <service-name>
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: <backend-port>
+endpoints:
+  - addresses:
+      - <backend-ip>
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <service-name>-route
+  namespace: external
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+      sectionName: <listener-name>
+  hostnames:
+    - <hostname>
+  rules:
+    - backendRefs:
+        - name: <service-name>
+          port: <backend-port>
+```
+
+Add a matching Gateway HTTPS listener and cert-manager `Certificate` when the hostname is outside `${cluster_domain}`.
+
+## External TLSRoute Template
+
+Use this pattern only when the external service should terminate TLS itself and already presents an acceptable certificate for the hostname.
+Define the backing `Service` and `EndpointSlice` with the target TLS port, as shown in the external HTTPRoute example.
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: <service-name>-route
+  namespace: external
+spec:
+  parentRefs:
+    - name: passthrough
+      namespace: gateway
+  hostnames:
+    - <hostname>
+  rules:
+    - backendRefs:
+        - name: <service-name>
+          port: <tls-port>
 ```
 
 ## App Kustomization Template

--- a/kubernetes/apps/external/synology.yaml
+++ b/kubernetes/apps/external/synology.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: external
 spec:
   ports:
-    - name: https
+    - name: http
       protocol: TCP
-      port: 5001
-      targetPort: 5001
+      port: 5000
+      targetPort: 5000
 ---
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
@@ -20,25 +20,26 @@ metadata:
     kubernetes.io/service-name: synology
 addressType: IPv4
 ports:
-  - name: https
+  - name: http
     protocol: TCP
-    port: 5001
+    port: 5000
 endpoints:
   - addresses:
       - ${nfs_server}
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: TLSRoute
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
 metadata:
   name: synology-route
   namespace: external
 spec:
   parentRefs:
-    - name: passthrough
+    - name: internal
       namespace: gateway
+      sectionName: synology-https-gateway
   hostnames:
     - synology.petebeegle.com
   rules:
     - backendRefs:
         - name: synology
-          port: 5001
+          port: 5000

--- a/kubernetes/apps/external/synology.yaml
+++ b/kubernetes/apps/external/synology.yaml
@@ -6,10 +6,11 @@ metadata:
   namespace: external
 spec:
   ports:
-    - name: http
+    - name: https
       protocol: TCP
-      port: 5000
-      targetPort: 5000
+      appProtocol: https
+      port: 5001
+      targetPort: 5001
 ---
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
@@ -20,9 +21,10 @@ metadata:
     kubernetes.io/service-name: synology
 addressType: IPv4
 ports:
-  - name: http
+  - name: https
     protocol: TCP
-    port: 5000
+    appProtocol: https
+    port: 5001
 endpoints:
   - addresses:
       - ${nfs_server}
@@ -42,4 +44,4 @@ spec:
   rules:
     - backendRefs:
         - name: synology
-          port: 5000
+          port: 5001

--- a/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
+++ b/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
@@ -48,7 +48,7 @@ entries:
       client_secret: !Context synology_client_secret
       redirect_uris:
         - matching_mode: strict
-          url: https://synology.petebeegle.com/#/signin
+          url: https://synology.petebeegle.com
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
       property_mappings:
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]

--- a/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
+++ b/kubernetes/infra/authentik/blueprints/synology-oauth.yaml
@@ -48,9 +48,7 @@ entries:
       client_secret: !Context synology_client_secret
       redirect_uris:
         - matching_mode: strict
-          url: https://192.168.30.99:5001
-        - matching_mode: strict
-          url: https://synology.petebeegle.com
+          url: https://synology.petebeegle.com/#/signin
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
       property_mappings:
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]

--- a/kubernetes/infra/network/gateway/certificate.yaml
+++ b/kubernetes/infra/network/gateway/certificate.yaml
@@ -11,3 +11,16 @@ spec:
   issuerRef:
     name: cloudflare
     kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: synology-petebeegle-com
+  namespace: gateway
+spec:
+  secretName: synology-petebeegle-com
+  dnsNames:
+    - synology.petebeegle.com
+  issuerRef:
+    name: cloudflare
+    kind: ClusterIssuer

--- a/kubernetes/infra/network/gateway/gateway-internal.yaml
+++ b/kubernetes/infra/network/gateway/gateway-internal.yaml
@@ -41,3 +41,15 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - protocol: HTTPS
+      port: 443
+      name: synology-https-gateway
+      hostname: synology.petebeegle.com
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: synology-petebeegle-com
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/infra/network/gateway/gateway-passthrough.yaml
+++ b/kubernetes/infra/network/gateway/gateway-passthrough.yaml
@@ -64,12 +64,3 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - protocol: TLS
-      port: 443
-      name: synology-passthrough
-      hostname: "synology.petebeegle.com"
-      tls:
-        mode: Passthrough
-      allowedRoutes:
-        namespaces:
-          from: All

--- a/kubernetes/infra/network/gateway/https-redirect.yaml
+++ b/kubernetes/infra/network/gateway/https-redirect.yaml
@@ -11,6 +11,7 @@ spec:
   hostnames:
     - "*.${cluster_domain}"
     - ${cluster_domain}
+    - synology.petebeegle.com
   rules:
     - matches:
         - path:

--- a/kubernetes/infra/network/gateway/referencegrant.yaml
+++ b/kubernetes/infra/network/gateway/referencegrant.yaml
@@ -19,6 +19,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: whoami
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: external
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/tools/policy/check_synology_oauth_redirect.py
+++ b/tools/policy/check_synology_oauth_redirect.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 BLUEPRINT = ROOT / "kubernetes/infra/authentik/blueprints/synology-oauth.yaml"
-EXPECTED_REDIRECT = "https://synology.petebeegle.com/#/signin"
+EXPECTED_REDIRECT = "https://synology.petebeegle.com"
 FORBIDDEN_REDIRECTS = {
-    "https://synology.petebeegle.com",
+    "https://synology.petebeegle.com/#/signin",
     "https://192.168.30.99:5001",
 }
 

--- a/tools/policy/check_synology_oauth_redirect.py
+++ b/tools/policy/check_synology_oauth_redirect.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Validate Synology Authentik OAuth redirect policy."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BLUEPRINT = ROOT / "kubernetes/infra/authentik/blueprints/synology-oauth.yaml"
+EXPECTED_REDIRECT = "https://synology.petebeegle.com/#/signin"
+FORBIDDEN_REDIRECTS = {
+    "https://synology.petebeegle.com",
+    "https://192.168.30.99:5001",
+}
+
+
+def main() -> int:
+    text = BLUEPRINT.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    redirect_urls = {
+        line.split("url:", 1)[1].strip()
+        for line in text.splitlines()
+        if line.lstrip().startswith("url:")
+    }
+
+    if EXPECTED_REDIRECT not in redirect_urls:
+        errors.append(
+            f"{BLUEPRINT.relative_to(ROOT)} must include Synology OAuth redirect "
+            f"{EXPECTED_REDIRECT!r}"
+        )
+
+    for forbidden in sorted(FORBIDDEN_REDIRECTS):
+        if forbidden in redirect_urls:
+            errors.append(
+                f"{BLUEPRINT.relative_to(ROOT)} must not use redirect "
+                f"{forbidden!r}"
+            )
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Route `synology.petebeegle.com` through the Cilium internal Gateway with cert-manager TLS termination.
- Proxy DSM over HTTPS to `192.168.30.99:5001` using `appProtocol: https`, avoiding DSM's HTTP-to-HTTPS redirect that exposes `:5001`.
- Update the Authentik Synology OAuth redirect and launch URLs to the hostname without `:5001`; assert the redirect remains the bare hostname with no fragment path.
- Document the Synology routing decision and update external route guidance.

## Validation

- `kubectl kustomize kubernetes/infra/network/gateway`
- `kubectl kustomize kubernetes/apps/external`
- `kubectl kustomize kubernetes/infra/authentik`
- server-side dry-run for rendered gateway resources with production substitutions
- server-side dry-run for rendered external Synology resources with production substitutions
- `python3 tools/architecture/render.py --check`
- `python3 tools/policy/check_synology_oauth_redirect.py`
- `pre-commit run --all-files`
