### PR TITLE
Implementation: doc-aware-workflow

### DIFF
--- a/.codex/agents/repo_migration_worker.toml
+++ b/.codex/agents/repo_migration_worker.toml
@@ -9,6 +9,7 @@ All code changes must use the mandatory implementation workflow:
 - Create your branch from origin/main with the name codex/<implementation>.
 - If the planner staged secrets at /workspaces/homelab/.codex/tmp/implementation-secrets/<implementation>, install them into identical repo-relative paths in your clone before running commands that need them.
 - Before changing tracked files, record .codex/tmp/active-implementation in the clone with implementation, branch, base, role=implementation, and clone_path fields.
+- If you are the implementation owner/integrator, you own tracked-file edits, commits, .codex/tmp/active-implementation, .codex/tmp/pr-summary.md, and final branch state. Helper agents may research, test, verify, or prepare patch recommendations, but should not directly mutate tracked files in the shared clone.
 - Leave the planner checkout untouched.
 
 Work in narrow, reversible slices:
@@ -16,6 +17,8 @@ Work in narrow, reversible slices:
 - Keep write scope to the requested files and avoid unrelated cleanup.
 - Do not revert or overwrite changes you did not make.
 - Use deterministic transforms where possible.
+- Consider documentation impact for every change. Update stale docs, generated docs, decision records, runbooks, or agent guidance when behavior changes; otherwise record why no docs changed in .codex/tmp/pr-summary.md.
+- For Kubernetes or Terraform source changes, rely on the deterministic architecture check. If python3 tools/architecture/render.py --check fails, run python3 tools/architecture/render.py --write and commit the generated docs/architecture.md update.
 - Validate each migration slice with the smallest relevant checks.
 - Leave clear notes about assumptions, skipped areas, and follow-up work.
 """

--- a/.codex/agents/verifier.toml
+++ b/.codex/agents/verifier.toml
@@ -9,6 +9,8 @@ Focus on correctness and operational safety:
 - Confirm SOPS-managed secrets remain encrypted.
 - Confirm Terraform changes have an appropriate plan or a clear reason a plan could not run.
 - Confirm Kubernetes and Flux changes preserve dependency order, namespaces, Gateway references, and StorageClass expectations.
+- Confirm documentation impact was considered: docs, generated docs, runbooks, decision records, or agent guidance were updated when behavior changed, or .codex/tmp/pr-summary.md explains why no docs changed.
+- Confirm generated architecture is fresh when Kubernetes or Terraform sources changed by checking python3 tools/architecture/render.py --check.
 - Prefer concrete file and command references over broad summaries.
 - Report blockers first, then residual risks, then successful checks.
 """

--- a/.codex/memory/approved/2026-05-09-implementation-workflow.md
+++ b/.codex/memory/approved/2026-05-09-implementation-workflow.md
@@ -9,7 +9,7 @@ kind: workflow-preference
 
 All repository code changes must use the implementation workflow. Agents must not ask whether to use it and must not make direct code changes outside it, except for the bootstrap change that installs the workflow guard.
 
-Break work into named implementations before editing. Each implementation maps to one pull request and may contain multiple conventional commits. A separate implementation agent owns each implementation's work.
+Break work into named implementations before editing. Each implementation maps to one pull request and may contain multiple conventional commits. A single implementation owner or integrator owns each implementation's tracked-file edits, commits, active implementation marker, PR summary, and final branch state.
 
 Implementation agents must work in full sibling clones under `/workspaces/homelab-ideas/<implementation>`, not in the planner checkout. Create each implementation branch from `origin/main`.
 
@@ -21,6 +21,8 @@ Only ignored local files, such as `terraform.tfvars`, other `*.tfvars`, kubeconf
 
 The active implementation clone must record `.codex/tmp/active-implementation` with the implementation name, branch, base, role, and clone path before tracked files are changed.
 
+Multiple helper agents may contribute to one implementation clone when useful. Use the single integrator model: helper agents may research, inspect, test, verify, or prepare focused patch recommendations, but the implementation owner applies tracked-file edits and creates commits in the shared clone.
+
 As implementation agents finish, create separate verifier agents to review the result. The planner coordinates implementation breakdown, delegates implementation and verification, and summarizes status.
 
 Implementation and verifier agents must install the staged secret/config files into their sibling clone before running commands that need them, preserving the repo-relative paths from the staged tree.
@@ -29,6 +31,10 @@ Conventional commits are enforced locally and by origin.
 
 Do not push to origin until verifier approval is recorded for the exact `HEAD` commit.
 
-Before PR creation, the planner or implementation agent should record plan-derived PR text in `.codex/tmp/pr-summary.md`. Keep this file concise and include the implementation summary plus the important changes from the plan. The automatic PR helper includes this text in the PR body and falls back to generated branch, file, commit, and verification details if the file is absent.
+Every implementation must consider whether documentation is stale or incomplete after the change. Update relevant docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no documentation changes are needed, record that decision and the reason in the PR summary.
+
+`docs/architecture.md` is generated from Kubernetes and Terraform source files. Do not edit it by hand. If `python3 tools/architecture/render.py --check` fails after Kubernetes or Terraform source changes, run `python3 tools/architecture/render.py --write` and commit the generated result in the same implementation.
+
+Before PR creation, the planner or implementation agent should record plan-derived PR text in `.codex/tmp/pr-summary.md`. Keep this file concise and include the implementation summary, the important changes from the plan, and a documentation impact note listing docs updated or explaining why none were needed. The automatic PR helper includes this text in the PR body and falls back to generated branch, file, commit, and verification details if the file is absent.
 
 After verifier approval is recorded, create the pull request without additional intervention. Push the current `codex/<implementation>` branch to origin, run `gh pr create --base main --head codex/<implementation>`, and delete the sibling clone only after the pull request is created successfully.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,12 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 - All repository code changes must use the mandatory implementation workflow, no questions asked.
 - Break work into named implementations before editing. Each implementation maps to one PR and may contain multiple conventional commits.
 - New work must always leverage `.codex/memory/approved/2026-05-09-implementation-workflow.md`.
+- Every implementation must consider documentation impact. Update stale docs, generated docs, decision records, runbooks, or agent guidance when behavior changes; otherwise record why no docs changed.
 - Before cloning, the planner must stage any required ignored local secret/config files into `.codex/tmp/implementation-secrets/<implementation>/`, preserving their repo-relative paths and never logging secret contents.
 - Implementation agents must clone `https://github.com/petebeegle/homelab.git` into `/workspaces/homelab-ideas/<implementation>`, create `codex/<implementation>` from `origin/main`, and work only in that sibling clone.
+- Multiple helper agents may contribute to one implementation clone only through the single integrator model: helpers may research, test, verify, or prepare patch recommendations, but one implementation owner owns tracked-file edits, commits, `.codex/tmp/active-implementation`, `.codex/tmp/pr-summary.md`, and final branch state.
 - Implementation and verifier agents must install staged secret/config files into identical repo-relative locations in their sibling clones before running commands that need them.
-- Before PR creation, record plan-derived PR text in `.codex/tmp/pr-summary.md` so the automatic PR body includes the implementation summary and important changes from the plan.
+- Before PR creation, record plan-derived PR text in `.codex/tmp/pr-summary.md` so the automatic PR body includes the implementation summary, important changes from the plan, and a documentation impact note listing docs updated/generated or explaining why none were needed.
 - After verifier sign-off for the exact `HEAD`, create the PR without intervention, then delete the sibling clone only after PR creation succeeds.
 
 ## Tool Routing
@@ -55,6 +57,7 @@ Generated relationship map:
 - `docs/architecture.md` is generated from Kubernetes and Terraform source files.
 - Do not edit it by hand. Run `python3 tools/architecture/render.py --write`, then commit the result.
 - Pre-commit runs `python3 tools/architecture/render.py --check` and fails if it is stale.
+- When Kubernetes or Terraform source changes make the architecture check fail, refresh `docs/architecture.md` with `python3 tools/architecture/render.py --write` as part of the same implementation.
 
 Flux cluster entrypoint:
 


### PR DESCRIPTION
## Summary
## Summary

- Require every implementation to consider stale or incomplete documentation.
- Document the existing deterministic architecture trigger and refresh command.
- Allow concurrent helper-agent work through a single implementation integrator.
- Update worker and verifier agent prompts to check docs impact and generated architecture freshness.

## Important Changes

- `AGENTS.md` and the approved implementation workflow now require a documentation impact note in `.codex/tmp/pr-summary.md`.
- Helper agents may research, test, verify, or prepare patch recommendations, while the integrator owns tracked-file edits, commits, PR summary, and final branch state.
- Verifiers now check documentation impact and run the generated architecture check when Kubernetes or Terraform sources changed.

## Documentation Impact

- Updated `AGENTS.md`, `.codex/memory/approved/2026-05-09-implementation-workflow.md`, `.codex/agents/repo_migration_worker.toml`, and `.codex/agents/verifier.toml`.
- `docs/architecture.md` did not change because this implementation changed workflow guidance only, not Kubernetes or Terraform source inputs.


## Changes
- .codex/agents/repo_migration_worker.toml
- .codex/agents/verifier.toml
- .codex/memory/approved/2026-05-09-implementation-workflow.md
- AGENTS.md

## Commits
- 3fce143 docs: require documentation impact checks

## Verification
- Verified HEAD: `3fce143423e8bf4e8299052fd616850ef473a580`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
