### PR TITLE
fix(certs): allow cloudflare issuer for apex zone hosts

### DIFF
--- a/kubernetes/infra/network/certs/issuer.yaml
+++ b/kubernetes/infra/network/certs/issuer.yaml
@@ -18,6 +18,7 @@ spec:
               key: token
         selector:
           dnsZones:
+            - "petebeegle.com"
             - "*.${cluster_domain}"
 ---
 apiVersion: cert-manager.io/v1
@@ -39,4 +40,5 @@ spec:
               key: token
         selector:
           dnsZones:
+            - "petebeegle.com"
             - "*.${cluster_domain}"


### PR DESCRIPTION
## Summary

- Fix cert-manager Cloudflare solver selection for hostnames under `petebeegle.com`.
- Add `petebeegle.com` to the production and staging ClusterIssuer `dnsZones` selectors.

## Important Changes

- PR #144 introduced `Certificate/gateway/synology-petebeegle-com` for `synology.petebeegle.com`.
- The existing Cloudflare solver only matched `*.lab.petebeegle.com`, so cert-manager could not choose a solver for the new certificate and left the gateway Kustomization unhealthy.
- The parent zone selector keeps the existing wildcard lab certificate covered and lets the Synology certificate use the same Cloudflare DNS-01 solver.

## Verification

- `python3 tools/architecture/render.py --check`
- `pre-commit run --files kubernetes/infra/network/certs/issuer.yaml kubernetes/infra/network/gateway/certificate.yaml kubernetes/infra/network/gateway/gateway-internal.yaml kubernetes/apps/external/synology.yaml`
- `pre-commit run --all-files`

## Documentation Impact

- No hand-written documentation changes required; generated architecture check is current.
