### PR TITLE
Fix Synology DSM gateway proxying

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,7 +99,7 @@ This document is generated for agentic repo navigation. It records relationships
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
-| `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology:5001` |
+| `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |

--- a/docs/decisions/cilium-gateway-api-ingress.md
+++ b/docs/decisions/cilium-gateway-api-ingress.md
@@ -13,6 +13,7 @@ Use Cilium Gateway API for cluster ingress. Do not add traditional Kubernetes In
 - Cilium provides Gateway API support, L2 load balancer IP advertisement, and kube-proxy replacement in one networking layer.
 - Gateway API separates shared listener configuration from app-owned routes.
 - Existing apps use `HTTPRoute` for Gateway-terminated HTTPS and `TLSRoute` for passthrough to external services that terminate TLS themselves.
+- Cilium Gateway routes forward HTTP traffic to `HTTPRoute` backends. Use an explicit in-cluster proxy when an external backend must be contacted over HTTPS but cannot present a certificate trusted for the public hostname.
 
 ## Consequences
 

--- a/docs/decisions/synology-gateway-terminated-https.md
+++ b/docs/decisions/synology-gateway-terminated-https.md
@@ -6,11 +6,13 @@ Accepted.
 
 ## Decision
 
-Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gateway with Gateway-terminated HTTPS. The Gateway presents a cert-manager certificate for `synology.petebeegle.com` and proxies DSM over HTTPS to the NAS on port 5001.
+Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gateway with Gateway-terminated HTTPS. The Gateway presents a cert-manager certificate for `synology.petebeegle.com` and sends HTTP to an in-cluster nginx proxy, which then proxies DSM over HTTPS to the NAS on port 5001.
 
 ## Rationale
 
 - DSM's built-in certificate for `192.168.30.99:5001` is not trusted for `synology.petebeegle.com`.
+- Cilium Gateway does not originate HTTPS upstream just because a Service port advertises `appProtocol: https`.
+- DSM's HTTP port redirects browsers to `:5001`, which exposes the backend port if the Gateway proxies to port 5000 directly.
 - Gateway termination lets cert-manager issue and renew the public hostname certificate.
 - Users should access DSM without a visible backend port.
 - Authentik and DSM SSO should use the same public URL.
@@ -19,6 +21,6 @@ Expose Synology DSM at `synology.petebeegle.com` through the Cilium internal Gat
 
 - DNS for `synology.petebeegle.com` must point at the internal Gateway IP, not directly at the NAS.
 - Synology uses an `HTTPRoute` to the internal Gateway instead of a `TLSRoute` to the passthrough Gateway.
-- The Synology Service advertises `appProtocol: https` so Cilium uses HTTPS to reach DSM and avoids DSM's HTTP-to-HTTPS redirect to `:5001`.
+- The Synology route targets `synology-proxy`, not DSM directly. The proxy connects to `https://192.168.30.99:5001`, accepts DSM's internal certificate, and rewrites DSM responses that include `https://synology.petebeegle.com:5001` or `https://192.168.30.99:5001`.
 - Use `HTTPRoute` for external services when the cluster should provide the trusted certificate or hide backend ports.
 - Use `TLSRoute` passthrough only when the external target should terminate TLS itself and presents an acceptable certificate for the hostname.

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -101,7 +101,7 @@ spec:
 ## External Service HTTPRoute Template
 
 Use this pattern for a service outside the cluster when the Gateway should present the trusted certificate or hide the backend port.
-Set `appProtocol: https` on the Service port when the Gateway should use HTTPS to reach the backend.
+If the backend only accepts HTTPS and cannot present a certificate trusted for the public hostname, add an in-cluster proxy and point the `HTTPRoute` at the proxy. Do not rely on `appProtocol: https` alone to make the Gateway originate HTTPS upstream.
 
 ```yaml
 ---
@@ -114,7 +114,6 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      appProtocol: <http-or-https>
       port: <backend-port>
       targetPort: <backend-port>
 ---
@@ -129,7 +128,6 @@ addressType: IPv4
 ports:
   - name: http
     protocol: TCP
-    appProtocol: <http-or-https>
     port: <backend-port>
 endpoints:
   - addresses:
@@ -154,6 +152,8 @@ spec:
 ```
 
 Add a matching Gateway HTTPS listener and cert-manager `Certificate` when the hostname is outside `${cluster_domain}`.
+
+For HTTPS-only external backends with untrusted certificates or backend redirects that expose ports, use a small proxy Deployment instead of routing directly to the external `EndpointSlice`. The proxy can connect to the backend over HTTPS, set forwarded headers, and normalize redirects or response bodies before returning traffic to the Gateway route.
 
 ## External TLSRoute Template
 

--- a/kubernetes/apps/external/synology.yaml
+++ b/kubernetes/apps/external/synology.yaml
@@ -1,33 +1,122 @@
 ---
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: synology
+  name: synology-proxy-nginx
+  namespace: external
+data:
+  nginx.conf: |
+    pid /tmp/nginx.pid;
+
+    events {}
+
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path /tmp/proxy_temp;
+      fastcgi_temp_path /tmp/fastcgi_temp;
+      uwsgi_temp_path /tmp/uwsgi_temp;
+      scgi_temp_path /tmp/scgi_temp;
+
+      map $http_upgrade $connection_upgrade {
+        default upgrade;
+        "" close;
+      }
+
+      server {
+        listen 8080;
+        server_name synology.petebeegle.com;
+
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_ssl_name synology;
+        proxy_ssl_verify off;
+
+        proxy_set_header Host synology.petebeegle.com;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Accept-Encoding "";
+
+        proxy_redirect https://synology.petebeegle.com:5001/ https://synology.petebeegle.com/;
+        proxy_redirect https://192.168.30.99:5001/ https://synology.petebeegle.com/;
+        proxy_redirect https://synology:5001/ https://synology.petebeegle.com/;
+
+        sub_filter_once off;
+        sub_filter_types text/css application/javascript text/javascript application/json;
+        sub_filter "https://synology.petebeegle.com:5001" "https://synology.petebeegle.com";
+        sub_filter "https://192.168.30.99:5001" "https://synology.petebeegle.com";
+
+        location / {
+          proxy_pass https://192.168.30.99:5001;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synology-proxy
   namespace: external
 spec:
-  ports:
-    - name: https
-      protocol: TCP
-      appProtocol: https
-      port: 5001
-      targetPort: 5001
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: synology-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: synology-proxy
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: config
+          configMap:
+            name: synology-proxy-nginx
+        - name: tmp
+          emptyDir: {}
 ---
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
+apiVersion: v1
+kind: Service
 metadata:
-  name: synology
+  name: synology-proxy
   namespace: external
-  labels:
-    kubernetes.io/service-name: synology
-addressType: IPv4
-ports:
-  - name: https
-    protocol: TCP
-    appProtocol: https
-    port: 5001
-endpoints:
-  - addresses:
-      - ${nfs_server}
+spec:
+  selector:
+    app.kubernetes.io/name: synology-proxy
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -43,5 +132,5 @@ spec:
     - synology.petebeegle.com
   rules:
     - backendRefs:
-        - name: synology
-          port: 5001
+        - name: synology-proxy
+          port: 8080

--- a/tools/policy/check_synology_oauth_redirect.py
+++ b/tools/policy/check_synology_oauth_redirect.py
@@ -11,6 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 BLUEPRINT = ROOT / "kubernetes/infra/authentik/blueprints/synology-oauth.yaml"
 EXPECTED_REDIRECT = "https://synology.petebeegle.com"
 FORBIDDEN_REDIRECTS = {
+    "https://synology.petebeegle.com:5001",
     "https://synology.petebeegle.com/#/signin",
     "https://192.168.30.99:5001",
 }


### PR DESCRIPTION
## Summary

Fix Synology DSM routing after the direct Gateway backend proved to send plaintext HTTP to DSM's HTTPS port.

## Changes

- Replace the direct external Service/EndpointSlice backend with an in-cluster nginx proxy.
- Keep Gateway-terminated HTTPS for `synology.petebeegle.com`; route Gateway HTTP traffic to `synology-proxy:8080`.
- Have nginx connect to `https://192.168.30.99:5001`, accept DSM's internal certificate, preserve forwarded HTTPS headers, and rewrite DSM `:5001` URLs to the clean hostname.
- Strengthen the Synology OAuth policy check to reject `https://synology.petebeegle.com:5001`.

## Documentation

- Regenerated `docs/architecture.md`.
- Updated Synology and Cilium Gateway decision records to document why this service needs an explicit proxy.
- Updated the add-app runbook so future external HTTPS backends do not rely on `appProtocol: https` for upstream TLS.

## Validation

- `kubectl kustomize kubernetes/apps/external`
- `kubectl kustomize kubernetes/infra/network/gateway`
- `kubectl kustomize kubernetes/infra/authentik`
- `kubectl kustomize kubernetes/apps/external | kubectl apply --dry-run=server -f -`
- `docker run --rm -v /tmp/synology-nginx.conf:/etc/nginx/nginx.conf:ro nginx:1.27-alpine nginx -t`
- `python3 tools/policy/check_synology_oauth_redirect.py`
- `python3 tools/architecture/render.py --check`
- `pre-commit run --all-files`

## Operational Follow-up

- DNS still needs `synology.petebeegle.com` pointed at the internal Gateway IP `192.168.30.241`.
- DSM SSO redirect/base URL should remain `https://synology.petebeegle.com` without `:5001`.
