### PR TITLE
docs: fix flux kustomizations watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ docker run --rm \
 ```sh
 # View Flux logs
 flux logs -f
-# Watch kustomization events
-flux get kustomizations --watch
+# Watch Kustomizations across namespaces
+flux get kustomizations --all-namespaces --watch
 # List Helm releases
 kubectl get helmreleases -n kube-system
 # List Helm repositories


### PR DESCRIPTION
## Summary

- Update the README Flux command to watch Kustomizations across all namespaces.
- Clarify the command comment so it describes Kustomization status watches rather than Kubernetes events.

## Documentation impact

- Updated README command documentation only; no generated architecture docs needed because no Kubernetes or Terraform source changed.

## Verification

- `flux get kustomizations --all-namespaces --watch --help`
- `python3 tools/architecture/render.py --check`
- `git diff --check`
