### PR TITLE
fix: update snmp exporter health probes

### DIFF
--- a/kubernetes/infra/monitoring/snmp-exporter/deployment.yaml
+++ b/kubernetes/infra/monitoring/snmp-exporter/deployment.yaml
@@ -26,13 +26,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: /-/healthy
               port: http
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: /-/healthy
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5


### PR DESCRIPTION
## Summary

Fix the SNMP exporter probes so the `monitoring` Flux Kustomization can roll out `prom/snmp-exporter:v0.30.1`.

## Important changes

- Update the SNMP exporter liveness and readiness probes from `/health` to `/-/healthy`.
- Keep the exporter image, SNMP config, Service, and ServiceMonitor unchanged.

## Documentation impact

No documentation changed. This is a compatibility fix for the workload health endpoint exposed by the current exporter image and does not change operator workflow or architecture.

## Verification

- `kubectl kustomize kubernetes/infra/monitoring/snmp-exporter`
- `python3 tools/architecture/render.py --check`
- `docker run ... prom/snmp-exporter:v0.30.1` with rendered `snmp.yml`; verified `/-/healthy` returns `200`, `/health` returns `404`, and `/metrics` returns `200`
