### PR TITLE
Implementation: fix-pretty-discord-alerts-secret

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `grafana` | `./kubernetes/infra/monitoring/grafana` | `gateway`, `grafana-operator`, `loki`, `mimir` | `cluster-vars` | `sops` |
 | `loki` | `./kubernetes/infra/monitoring/loki` | `crds` | `cluster-vars` | `no` |
 | `mimir` | `./kubernetes/infra/monitoring/mimir` | `crds`, `nfs-csi` | `cluster-vars` | `no` |
-| `monitoring` | `./kubernetes/infra/monitoring` | (none) | `cluster-vars` | `no` |
+| `monitoring` | `./kubernetes/infra/monitoring` | (none) | `cluster-vars` | `sops` |
 | `nfs-csi` | `./kubernetes/infra/controllers/nfs-csi` | (none) | `cluster-vars` | `no` |
 | `otel-collector` | `./kubernetes/infra/monitoring/otel-collector` | `crds`, `gateway` | `cluster-vars` | `no` |
 
@@ -78,7 +78,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/monitoring/loki` | `namespace.yaml`, `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/mimir` | `namespace.yaml`, `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/otel-collector` | `namespace.yaml`, `app.yaml`, `httproute.yaml` |
-| `kubernetes/infra/monitoring/pretty-discord-alerts` | `deployment.yaml`, `service.yaml` |
+| `kubernetes/infra/monitoring/pretty-discord-alerts` | `grafana-env.yaml`, `deployment.yaml`, `service.yaml` |
 | `kubernetes/infra/monitoring/snmp-exporter` | `repositories.yaml`, `deployment.yaml`, `service.yaml`, `servicemonitor.yaml` |
 | `kubernetes/infra/network/certs` | `./issuer.yaml` |
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
@@ -136,6 +136,7 @@ This lists secret manifest presence only. Secret values are not rendered.
 | `foundryvtt` | `foundryvtt/foundryvtt-secret` | `yes` | `kubernetes/apps/foundryvtt/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-credentials` | `yes` | `kubernetes/infra/monitoring/grafana/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-env` | `yes` | `kubernetes/infra/monitoring/grafana/grafana-env.yaml` |
+| `monitoring/pretty-discord-alerts` | `monitoring/grafana-env` | `yes` | `kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml` |
 | `network/vpn` | `wireguard/wireguard-env` | `yes` | `kubernetes/infra/network/vpn/secret.yaml` |
 | `pihole` | `pihole/pihole-admin-password` | `yes` | `kubernetes/apps/pihole/secret.yaml` |
 | `renovate` | `renovate/renovate-secret` | `yes` | `kubernetes/apps/renovate/secret.yaml` |

--- a/kubernetes/clusters/production/infra/monitoring.yaml
+++ b/kubernetes/clusters/production/infra/monitoring.yaml
@@ -13,6 +13,10 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml
+++ b/kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-env
+    namespace: monitoring
+type: Opaque
+stringData:
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:mUWCqnIWC9jopETe2cHx//q8OfSFKDS/KJ5GFbUmyp6qi8oOnpoQelaYf00OawqPcCB6t2J8hd7lzjmDAr2e6e3hZirW72M2F6RSKmnA2Uf16ZQtBrC2aKDHDpsxmJWR6bkq424G4202r1Kms7pmDYO9heJQ8JAdng==,iv:7cAnllHBmYifJwE+D3LKRNs26n/ob9RCbVgMbYgTyrM=,tag:mlHL779h0TVqdx/NfAHf8A==,type:str]
+sops:
+    age:
+        - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQ0xxNjVkMSttd1k5N1BF
+            bU5QYkZ5S2V5WkI0Nm1CLzR4Ry9FWUxMaEFRCjE0MHBiNWdYcWpxYUVTVjF5VC95
+            dmdvRlRnTjZnQVA0M09zYWI0bVQvMU0KLS0tIEExVzhSdFhIaXROZ3BReTZOZXI5
+            d2VKUWNwbUsxQmQvOUN5b3Y3c3BFVlUK7Dfeldhskcv9UyMvPtsb94LD3u5elGZF
+            Z2i5eQ9OChvt0YT764YuYN60BR/xOZCw9jqs93g++69iaPSlZ+hmtA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-08T04:33:41Z"
+    mac: ENC[AES256_GCM,data:CNMv+JORh48JQcUe1ycNBz+mopRPcvFCR1dX2P33RAxAEm6yilXQggV5SyUVj10jbhS3wQstEBYNlN+aADgpgtNyPTB0j5izkVtgihaU89+1/vDVxCNl6e0GwNiYPXurhOrw8IseNhw5vBB4P0w/RLxsF0lRiwWYGx4SN+M0lQ0=,iv:Y3GHVUcvkw0GncNQPRWxq41wvA81fsi/v0L41UB1GwI=,tag:wqsaR/27G4/ZpYTLm7x1Fw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/kubernetes/infra/monitoring/pretty-discord-alerts/kustomization.yaml
+++ b/kubernetes/infra/monitoring/pretty-discord-alerts/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - grafana-env.yaml
   - deployment.yaml
   - service.yaml


### PR DESCRIPTION
## Summary
Fixes the monitoring health check failure by ensuring `pretty-discord-alerts` owns a `monitoring/grafana-env` Secret in the same namespace as its Deployment.

Important changes:
- Add a SOPS-encrypted `grafana-env.yaml` resource under `kubernetes/infra/monitoring/pretty-discord-alerts`.
- Include that secret in the `pretty-discord-alerts` kustomization.
- Enable SOPS decryption for the production `monitoring` Flux Kustomization so Flux can apply the encrypted secret.

Documentation impact:
- Refreshed generated `docs/architecture.md` because Kubernetes source and Flux decryption settings changed.


## Changes
- docs/architecture.md
- kubernetes/clusters/production/infra/monitoring.yaml
- kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml
- kubernetes/infra/monitoring/pretty-discord-alerts/kustomization.yaml

## Commits
- 0f21170 fix(monitoring): provide discord alert webhook secret

## Verification
- Verified HEAD: `0f21170fb047923e404852a87d5cc262592cb006`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
