### PR TITLE
Implementation: proxmox-ve9-host-baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ kubectl get helmrepositories -n kube-system
 ---
 ## Appendices
 Random things that have caused me suffering:
+- [Proxmox VE Host Baseline](./docs/decisions/proxmox-ve-host-baseline.md)
+- [Proxmox No-Subscription Repository](./docs/runbooks/proxmox-no-subscription-repository.md)
 - [Configure NFS With Proxmox](./.codex/runbooks/configure-nfs-with-proxmox.md)
 - [Cloudflare Tunnels](./.codex/runbooks/cloudflare-tunnels.md)
 - [Resize a PVC](./.codex/runbooks/resize-pvc.md)

--- a/docs/decisions/proxmox-ve-host-baseline.md
+++ b/docs/decisions/proxmox-ve-host-baseline.md
@@ -1,0 +1,41 @@
+---
+id: ADR-0011
+status: accepted
+scope:
+  - proxmox
+  - operations
+  - host-baseline
+authority: binding
+created: 2026-05-10
+last_verified: 2026-05-10
+supersedes: []
+superseded_by:
+---
+
+# Proxmox VE Host Baseline
+
+## Decision
+
+The current Proxmox host baseline is Proxmox VE 9 on Debian Trixie.
+
+Host package repository examples and rebuild runbooks should target this baseline unless this decision is superseded.
+
+The Proxmox VE no-subscription repository is acceptable for this homelab because the hosts do not have enterprise subscriptions. Proxmox still recommends the enterprise repository for production support and stability.
+
+## Rationale
+
+- Recording the Proxmox version baseline keeps host rebuild procedures from depending on memory.
+- Proxmox VE 9 uses Debian Trixie and the deb822 `.sources` repository format.
+- The homelab needs repeatable package repository configuration for recreated Proxmox nodes without requiring an enterprise subscription.
+
+## Consequences
+
+- Proxmox host runbooks should verify the host is Proxmox VE 9 on Debian Trixie before applying version-specific package repository instructions.
+- Upgrade or rebuild documentation must be reviewed when the Proxmox host baseline changes.
+- The no-subscription repository should be treated as a homelab/non-enterprise choice, not as a general production recommendation.
+
+## Operational Notes
+
+- Check the Proxmox version with `pveversion`.
+- Check the Debian suite with `. /etc/os-release && echo "$VERSION_CODENAME"`.
+- Configure the Proxmox VE 9 no-subscription repository with `docs/runbooks/proxmox-no-subscription-repository.md`.

--- a/docs/runbooks/proxmox-no-subscription-repository.md
+++ b/docs/runbooks/proxmox-no-subscription-repository.md
@@ -1,0 +1,74 @@
+# Proxmox No-Subscription Repository
+
+Use this runbook to configure the Proxmox VE no-subscription repository when recreating or creating Proxmox hosts.
+
+This procedure applies to the current Proxmox host baseline: Proxmox VE 9 on Debian Trixie. See `docs/decisions/proxmox-ve-host-baseline.md`.
+
+Proxmox says the no-subscription repository does not require a subscription key and can be used for testing or non-production use. It is not recommended for production servers because packages are not always tested and validated as heavily as the enterprise repository.
+
+Reference: <https://pve.proxmox.com/pve-docs/chapter-sysadmin.html>
+
+## Pre-Checks
+
+Confirm the host is Proxmox VE 9:
+
+```bash
+pveversion
+```
+
+Confirm the host is running Debian Trixie:
+
+```bash
+. /etc/os-release
+echo "$VERSION_CODENAME"
+```
+
+Expected codename:
+
+```text
+trixie
+```
+
+Confirm the Proxmox archive keyring exists:
+
+```bash
+test -f /usr/share/keyrings/proxmox-archive-keyring.gpg
+```
+
+If the keyring is missing, stop and follow the current Proxmox documentation before continuing.
+
+## Configure Repository
+
+Disable the enterprise repository on unsubscribed hosts to avoid apt authentication errors. Check for enterprise source files:
+
+```bash
+grep -R "enterprise.proxmox.com" /etc/apt/sources.list /etc/apt/sources.list.d/ || true
+```
+
+Comment out or remove the enterprise Proxmox source on hosts without a subscription.
+
+Create or update `/etc/apt/sources.list.d/proxmox.sources`:
+
+```text
+Types: deb
+URIs: http://download.proxmox.com/debian/pve
+Suites: trixie
+Components: pve-no-subscription
+Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+```
+
+## Verify
+
+Refresh package metadata:
+
+```bash
+apt update
+```
+
+Expected outcomes:
+
+- Apt reads `http://download.proxmox.com/debian/pve`.
+- Apt does not report enterprise repository authentication errors.
+- The configured suite is `trixie`.
+
+Treat `apt full-upgrade` as a separate reviewed maintenance action after repository configuration is verified.


### PR DESCRIPTION
## Summary
## Summary

- Document Proxmox VE 9 on Debian Trixie as the current homelab Proxmox host baseline.
- Add a runbook for configuring the Proxmox VE no-subscription repository on Proxmox VE 9 hosts.
- Link the new decision record and runbook from the README appendices.

## Important Changes

- Added ADR-0011 for the Proxmox VE host baseline and no-subscription repository acceptability in this homelab.
- Added operational steps to verify Proxmox VE 9/Trixie, configure `/etc/apt/sources.list.d/proxmox.sources`, disable enterprise sources on unsubscribed hosts, and verify `apt update`.

## Documentation Impact

- Updated documentation only: new decision record, new runbook, and README links.
- `docs/architecture.md` was intentionally not updated because no Kubernetes or Terraform source changed.


## Changes
- README.md
- docs/decisions/proxmox-ve-host-baseline.md
- docs/runbooks/proxmox-no-subscription-repository.md

## Commits
- 5e35982 docs: document proxmox ve9 host baseline

## Verification
- Verified HEAD: `5e35982c6cdc74846beab11554d0a335d82938e2`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
