### PR TITLE
Implementation: subagents-default-implementation-workflow

### DIFF
--- a/.codex/memory/approved/2026-05-09-implementation-workflow.md
+++ b/.codex/memory/approved/2026-05-09-implementation-workflow.md
@@ -19,6 +19,8 @@ All repository code changes must use the implementation workflow. Agents must no
 
 Break work into named implementations before editing. Each implementation maps to one pull request and may contain multiple conventional commits. A single implementation owner or integrator owns each implementation's tracked-file edits, commits, active implementation marker, PR summary, and final branch state.
 
+When runtime tooling exposes implementation or verifier subagents, delegate normal implementation and verification work to those subagents by default. The user's standing repository preference is subagents opt-out, not opt-in: do not ask whether to use subagents for the standard implementation owner or verifier roles. Respect explicit task instructions such as "do not use subagents."
+
 Implementation agents must work in full sibling clones under `/workspaces/homelab-ideas/<implementation>`, not in the planner checkout. Create each implementation branch from `origin/main`.
 
 Branches must follow the format `codex/<implementation>`.
@@ -32,6 +34,8 @@ The active implementation clone must record `.codex/tmp/active-implementation` w
 Multiple helper agents may contribute to one implementation clone when useful. Use the single integrator model: helper agents may research, inspect, test, verify, or prepare focused patch recommendations, but the implementation owner applies tracked-file edits and creates commits in the shared clone.
 
 As implementation agents finish, create separate verifier agents to review the result. The planner coordinates implementation breakdown, delegates implementation and verification, and summarizes status.
+
+Self-implementation or self-verification is acceptable only when subagent tooling is unavailable or higher-priority runtime policy blocks delegation. Any fallback to self-verification must be recorded in `.codex/tmp/pr-summary.md`.
 
 Implementation and verifier agents must install the staged secret/config files into their sibling clone before running commands that need them, preserving the repo-relative paths from the staged tree.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 - All repository code changes must use the mandatory implementation workflow, no questions asked.
 - Break work into named implementations before editing. Each implementation maps to one PR and may contain multiple conventional commits.
 - New work must always leverage `.codex/memory/approved/2026-05-09-implementation-workflow.md`.
+- Use implementation and verifier subagents by default whenever runtime tooling exposes them. This is a standing opt-out preference, so do not ask whether to use subagents for normal implementation or verifier roles; respect explicit task instructions such as "do not use subagents."
+- Self-implementation or self-verification is acceptable only when subagent tooling is unavailable or higher-priority runtime policy blocks delegation. Record any fallback to self-verification in `.codex/tmp/pr-summary.md`.
 - Every implementation must consider documentation impact. Update stale docs, generated docs, decision records, runbooks, or agent guidance when behavior changes; otherwise record why no docs changed.
 - Before cloning, the planner must stage any required ignored local secret/config files into `.codex/tmp/implementation-secrets/<implementation>/`, preserving their repo-relative paths and never logging secret contents.
 - Implementation agents must clone `https://github.com/petebeegle/homelab.git` into `/workspaces/homelab-ideas/<implementation>`, create `codex/<implementation>` from `origin/main`, and work only in that sibling clone.


### PR DESCRIPTION
## Summary
Summary:
- Update the mandatory implementation workflow and AGENTS guidance so implementation and verifier subagents are the default for repository changes whenever runtime tooling exposes them.

Important changes:
- Document that the repository preference is subagents opt-out, not opt-in, and agents should not ask whether to use subagents for normal implementation or verifier roles.
- Document that self-implementation or self-verification is only acceptable when subagent tooling is unavailable or higher-priority runtime policy blocks delegation.
- Require any fallback to self-verification to be recorded in this PR summary file.
- Leave verifier agent config and implementation harness behavior unchanged because the guidance update closes the planned gap without requiring enforcement changes.

Documentation impact:
- Updated `AGENTS.md` and `.codex/memory/approved/2026-05-09-implementation-workflow.md` because this changes repository workflow guidance.
- No generated architecture, Kubernetes, Terraform, SOPS, decision record, or runbook updates were needed.

Verification:
- `git diff --check`
- Reviewed changed files and confirmed the diff is limited to workflow documentation plus this PR summary.
- Confirmed there are no Kubernetes, Terraform, SOPS, or generated architecture changes.


## Changes
- .codex/memory/approved/2026-05-09-implementation-workflow.md
- AGENTS.md

## Commits
- 238925e docs: default workflow roles to subagents

## Verification
- Verified HEAD: `238925e059355f92a088a04e7c5dd3dbd471ab61`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
