### PR TITLE
fix(grafana): reconcile alert rules in grafana namespace

### DIFF
--- a/docs/runbooks/verify-grafana-alert-rules.md
+++ b/docs/runbooks/verify-grafana-alert-rules.md
@@ -1,0 +1,27 @@
+# Verify Grafana Alert Rules
+
+Use this after changing `GrafanaAlertRuleGroup` manifests.
+
+1. Confirm Flux rendered the alert rule CRs in the Grafana namespace.
+
+```bash
+kubectl get grafanaalertrulegroups.grafana.integreatly.org -n grafana
+kubectl describe grafanaalertrulegroup -n grafana <name>
+```
+
+2. Check Grafana Operator reconciliation.
+
+```bash
+kubectl get pods -n grafana-operator
+kubectl logs -n grafana-operator "$(kubectl get deploy -n grafana-operator -o name | head -n1)" --since=15m
+```
+
+3. Check Grafana ruler state from inside the cluster or through a port-forward.
+
+```bash
+kubectl port-forward -n grafana svc/grafana 3000:80
+curl -fsS -u "$GRAFANA_USER:$GRAFANA_PASSWORD" \
+  http://127.0.0.1:3000/api/ruler/grafana/api/v1/rules | jq .
+```
+
+Expected result: the `proxmox`, `flux`, `valheim`, and `mimir` rule groups appear in the ruler output, and the `GrafanaAlertRuleGroup` resources report successful reconciliation.

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-flux.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-flux.yaml
@@ -116,14 +116,14 @@ spec:
             refId: C
 
     - uid: flux-resources-stale
-      title: Flux Resources Stale
+      title: Flux Resources Readiness Unknown
       condition: C
       for: 5m
       noDataState: NoData
       execErrState: Error
       annotations:
-        description: "{{ $value }} Flux resource(s) have not reconciled in over 30 minutes"
-        summary: Flux resources are stale
+        description: "{{ $value }} Flux resource(s) report unknown readiness and may not be reconciling cleanly"
+        summary: Flux resource readiness is unknown
       labels:
         severity: warning
         component: flux
@@ -134,7 +134,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: count((time() - gotk_reconcile_condition{status="True",type="Ready",job="prometheus.scrape.pods"}) > 1800) OR vector(0)
+            expr: count(gotk_resource_info{ready="Unknown",job="prometheus.scrape.pods"}) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-mimir.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-mimir.yaml
@@ -18,7 +18,7 @@ spec:
       noDataState: Alerting
       execErrState: Error
       annotations:
-        description: "Mimir has no ACTIVE ingesters in the ring. Metrics are not being stored and Grafana dashboards will show no data. Fix: kubectl delete pod mimir-ingester-0 -n monitoring"
+        description: "Mimir has no ACTIVE ingesters in the ring. Metrics are not being stored and Grafana dashboards will show no data. Fix: kubectl delete pod mimir-ingester-0 -n mimir"
         summary: Mimir ingester is not healthy in the ring
       labels:
         severity: critical

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-proxmox.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-proxmox.yaml
@@ -18,7 +18,7 @@ spec:
       noDataState: Alerting
       execErrState: Error
       annotations:
-        description: "Expected 4 Proxmox nodes, currently detecting {{ $values.B.Value }} node(s)"
+        description: "Expected 3 Proxmox nodes, currently detecting {{ $values.B.Value }} node(s)"
         summary: One or more Proxmox nodes are unreachable
       labels:
         severity: critical
@@ -52,7 +52,7 @@ spec:
             conditions:
               - evaluator:
                   params:
-                    - 4
+                    - 3
                   type: lt
                 operator:
                   type: and

--- a/kubernetes/infra/monitoring/grafana/alerting/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: monitoring
+namespace: grafana
 resources:
   - alert-rules-proxmox.yaml
   - alert-rules-flux.yaml


### PR DESCRIPTION
## Summary

Fix Grafana alert rule reconciliation by rendering `GrafanaAlertRuleGroup` resources in the `grafana` namespace with the Grafana instance they select.

## Important Changes

- Changed the Grafana alerting kustomization namespace from `monitoring` to `grafana` so the operator reconciles alert rule groups against the `grafana` namespace instance.
- Preserved existing alert rule metadata and `instanceSelector` values.
- Kept Discord contact point and pretty-discord-alerts notification policy behavior unchanged.
- Corrected Mimir alert remediation text to reference namespace `mimir`.
- Corrected the Proxmox node-count alert threshold and description to expect 3 nodes.
- Replaced the Flux stale alert expression that used absent metric `gotk_reconcile_condition` with an existing `gotk_resource_info{ready="Unknown"}` check.

## Documentation Impact

- Added `docs/runbooks/verify-grafana-alert-rules.md` with concise commands to verify Grafana Operator alert rule reconciliation and Grafana ruler state.

## Verification

- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- Rendered `GrafanaAlertRuleGroup` resources resolve to namespace `grafana`.
- `python3 tools/architecture/render.py --check`
- Checked that no SOPS secret manifest or encrypted Grafana environment file was modified.

## Workflow Notes

- Verifier Pauli approved exact HEAD `355cc1ceeaaf5800dc80d998f058859e361c2c21`.
