### PR TITLE
feat(observability): establish alloy metrics foundation

### DIFF
--- a/docs/runbooks/observability-scrape-topology.md
+++ b/docs/runbooks/observability-scrape-topology.md
@@ -1,0 +1,16 @@
+---
+status: current
+scope:
+  - observability
+  - alloy
+  - metrics
+last_verified: 2026-05-11
+---
+
+# Observability Scrape Topology
+
+Alloy runs as a DaemonSet and tolerates the control-plane taint so one pod can run on every Kubernetes node. Pod logs are discovered independently from metrics and are scoped to the local node; together, the DaemonSet collects logs for all pods without requiring metrics annotations.
+
+Metrics scraping is opt-in for workloads. Alloy scrapes services and pods only when they set `prometheus.io/scrape: "true"` and rewrites the target port from `prometheus.io/port` when present. Prefer annotated service scraping for shared exporters such as kube-state-metrics; kube-state-metrics pods are excluded from pod metrics scraping to avoid duplicate series.
+
+Container and node resource metrics come from kubelet HTTPS endpoints through the Kubernetes API server proxy. Alloy uses its service account token and CA bundle to scrape per-node `/metrics/cadvisor` and `/metrics/resource`, which provide container metrics such as `container_memory_working_set_bytes`.

--- a/kubernetes/infra/monitoring/alloy/app.yaml
+++ b/kubernetes/infra/monitoring/alloy/app.yaml
@@ -24,6 +24,15 @@ spec:
         name: grafana
         namespace: flux-system
   values:
+    rbac:
+      create: true
+    serviceAccount:
+      automountServiceAccountToken: true
+    controller:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
     alloy:
       clustering:
         enabled: true

--- a/kubernetes/infra/monitoring/alloy/config/config.alloy
+++ b/kubernetes/infra/monitoring/alloy/config/config.alloy
@@ -1,136 +1,308 @@
 logging {
-  level  = "info"
-  format = "logfmt"
+	level  = "info"
+	format = "logfmt"
 }
 
 loki.write "default" {
-  endpoint {
-    url = "http://loki-gateway.loki.svc.cluster.local/loki/api/v1/push"
-    tenant_id = 1
-  }
+	endpoint {
+		url       = "http://loki-gateway.loki.svc.cluster.local/loki/api/v1/push"
+		tenant_id = 1
+	}
 }
 
 prometheus.remote_write "default" {
-    endpoint {
-      url = "http://mimir-nginx.mimir.svc.cluster.local/api/v1/push"
-    }
+	endpoint {
+		url = "http://mimir-nginx.mimir.svc.cluster.local/api/v1/push"
+	}
 
-    // Prevent WAL from growing unbounded during outages
-    wal {
-      truncate_frequency = "2h"
-      min_keepalive_time = "5m"
-      max_keepalive_time = "8h"
-    }
+	// Prevent WAL from growing unbounded during outages
+	wal {
+		truncate_frequency = "2h"
+		min_keepalive_time = "5m"
+		max_keepalive_time = "8h"
+	}
 }
 
-discovery.kubernetes "pods" {
-  role = "pod"
+discovery.kubernetes "pod_logs" {
+	role = "pod"
+
+	selectors {
+		role  = "pod"
+		field = "spec.nodeName=" + coalesce(sys.env("HOSTNAME"), constants.hostname)
+	}
+}
+
+discovery.kubernetes "pod_metrics" {
+	role = "pod"
 }
 
 discovery.kubernetes "service" {
-  role = "service"
+	role = "service"
 }
 
-discovery.kubernetes "node" {
-  role = "node"
+discovery.kubernetes "kubelet" {
+	role = "node"
 }
 
-prometheus.exporter.unix "unix" {
-
-}
-
-prometheus.scrape "pods" {
-  targets    = discovery.relabel.pods.output
-  forward_to = [prometheus.remote_write.default.receiver]
-  clustering {
-    enabled = true
-  }
-}
+prometheus.exporter.unix "unix" { }
 
 discovery.relabel "service" {
-  targets = discovery.kubernetes.service.targets
+	targets = discovery.kubernetes.service.targets
 
-  // Only scrape services with prometheus.io/scrape annotation
-  rule {
-    source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_scrape"]
-    regex = "true"
-    action = "keep"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_scrape"]
+		regex         = "true"
+		action        = "keep"
+	}
 
-  // Use custom port from annotation if specified
-  rule {
-    source_labels = ["__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"]
-    regex = "([^:]+)(?::\\d+)?;(\\d+)"
-    replacement = "$1:$2"
-    target_label = "__address__"
-  }
+	// Use custom port from annotation if specified
+	rule {
+		source_labels = ["__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"]
+		regex         = "([^:]+)(?::\\d+)?;(\\d+)"
+		replacement   = "$1:$2"
+		target_label  = "__address__"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_path"]
+		regex         = "(.+)"
+		target_label  = "__metrics_path__"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "namespace"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_service_name"]
+		target_label  = "service"
+	}
+
+	rule {
+		replacement  = "prometheus.scrape.service"
+		target_label = "job"
+	}
 }
 
 prometheus.scrape "service" {
-  targets    = discovery.relabel.service.output
-  forward_to = [prometheus.remote_write.default.receiver]
-}
+	targets    = discovery.relabel.service.output
+	forward_to = [prometheus.remote_write.default.receiver]
 
-prometheus.scrape "node" {
-  targets    = discovery.kubernetes.node.targets
-  forward_to = [prometheus.remote_write.default.receiver]
+	clustering {
+		enabled = true
+	}
 }
 
 prometheus.scrape "unix" {
-  targets    = prometheus.exporter.unix.unix.targets
-  forward_to = [prometheus.remote_write.default.receiver]
+	targets    = prometheus.exporter.unix.unix.targets
+	forward_to = [prometheus.remote_write.default.receiver]
 }
 
-discovery.relabel "pods" {
-  targets = discovery.kubernetes.pods.targets
+discovery.relabel "pod_metrics" {
+	targets = discovery.kubernetes.pod_metrics.targets
 
-  rule {
-    source_labels = ["__meta_kubernetes_namespace"]
-    target_label  = "namespace"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
+		regex         = "true"
+		action        = "keep"
+	}
 
-  rule {
-    source_labels = ["__meta_kubernetes_pod_name"]
-    target_label  = "pod"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+		regex         = "kube-state-metrics"
+		action        = "drop"
+	}
 
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_name"]
-    target_label  = "container"
-  }
+	rule {
+		source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+		regex         = "([^:]+)(?::\\d+)?;(\\d+)"
+		replacement   = "$1:$2"
+		target_label  = "__address__"
+	}
 
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    target_label  = "node_name"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
+		regex         = "(.+)"
+		target_label  = "__metrics_path__"
+	}
 
-  // Set job label to match existing dashboard queries
-  rule {
-    replacement = "prometheus.scrape.pods"
-    target_label = "job"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "namespace"
+	}
 
-  rule {
-    source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
-    target_label  = "__path__"
-    replacement   = "/var/log/pods/*$1/*.log"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_pod_name"]
+		target_label  = "pod"
+	}
 
-  rule {
-    source_labels = ["__meta_kubernetes_pod_label_app"]
-    action        = "replace"
-    target_label  = "app"
-    regex         = "(.+)"
-    replacement   = "$1"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_pod_container_name"]
+		target_label  = "container"
+	}
 
-  rule {
-    action = "labeldrop"
-    regex  = "__meta_kubernetes_pod_label_app"
-  }
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "node"
+	}
+
+	// Set job label to match existing dashboard queries
+	rule {
+		replacement  = "prometheus.scrape.pods"
+		target_label = "job"
+	}
+}
+
+prometheus.scrape "pods" {
+	targets    = discovery.relabel.pod_metrics.output
+	forward_to = [prometheus.remote_write.default.receiver]
+
+	clustering {
+		enabled = true
+	}
+}
+
+discovery.relabel "pod_logs" {
+	targets = discovery.kubernetes.pod_logs.targets
+
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "namespace"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_name"]
+		target_label  = "pod"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_container_name"]
+		target_label  = "container"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "node"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+		separator     = "/"
+		target_label  = "job"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+		target_label  = "__path__"
+		replacement   = "/var/log/pods/*$1/*.log"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_label_app"]
+		action        = "replace"
+		target_label  = "app"
+		regex         = "(.+)"
+		replacement   = "$1"
+	}
+
+	rule {
+		action = "labeldrop"
+		regex  = "__meta_kubernetes_pod_label_app"
+	}
 }
 
 loki.source.kubernetes "pods" {
-  targets    = discovery.relabel.pods.output
-  forward_to = [loki.write.default.receiver]
+	targets    = discovery.relabel.pod_logs.output
+	forward_to = [loki.write.default.receiver]
+}
+
+discovery.relabel "kubelet_cadvisor" {
+	targets = discovery.kubernetes.kubelet.targets
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "node"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "instance"
+	}
+
+	rule {
+		replacement  = "kubernetes.default.svc:443"
+		target_label = "__address__"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "__metrics_path__"
+		replacement   = "/api/v1/nodes/$1/proxy/metrics/cadvisor"
+	}
+
+	rule {
+		replacement  = "kubelet-cadvisor"
+		target_label = "job"
+	}
+}
+
+prometheus.scrape "kubelet_cadvisor" {
+	targets           = discovery.relabel.kubelet_cadvisor.output
+	forward_to        = [prometheus.remote_write.default.receiver]
+	scheme            = "https"
+	bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	tls_config {
+		ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	}
+
+	clustering {
+		enabled = true
+	}
+}
+
+discovery.relabel "kubelet_resource" {
+	targets = discovery.kubernetes.kubelet.targets
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "node"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "instance"
+	}
+
+	rule {
+		replacement  = "kubernetes.default.svc:443"
+		target_label = "__address__"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_node_name"]
+		target_label  = "__metrics_path__"
+		replacement   = "/api/v1/nodes/$1/proxy/metrics/resource"
+	}
+
+	rule {
+		replacement  = "kubelet-resource"
+		target_label = "job"
+	}
+}
+
+prometheus.scrape "kubelet_resource" {
+	targets           = discovery.relabel.kubelet_resource.output
+	forward_to        = [prometheus.remote_write.default.receiver]
+	scheme            = "https"
+	bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+	tls_config {
+		ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	}
+
+	clustering {
+		enabled = true
+	}
 }

--- a/kubernetes/infra/monitoring/kube-state-metrics/config/metrics.yaml
+++ b/kubernetes/infra/monitoring/kube-state-metrics/config/metrics.yaml
@@ -1,3 +1,8 @@
+service:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
+
 rbac:
   extraRules:
     - apiGroups:


### PR DESCRIPTION
# Observability Metrics Foundation

## Implementation Summary

Establishes the Alloy metrics foundation for all-node scheduling, annotation-gated workload scraping, and kubelet-backed container resource metrics while preserving pod log collection.

## Important Changes

- Configures the Alloy HelmRelease to keep RBAC enabled, mount the service account token, and tolerate `node-role.kubernetes.io/control-plane:NoSchedule` so the DaemonSet can run on all five nodes.
- Splits Alloy pod log discovery from pod metrics discovery. Logs stay node-local and cover every pod through the all-node DaemonSet, while pod metrics require `prometheus.io/scrape: "true"` and honor `prometheus.io/port`.
- Keeps annotated service metrics scraping, enables scrape clustering, and annotates kube-state-metrics service values so kube-state-metrics is scraped through the service path.
- Drops kube-state-metrics from pod metrics scraping to avoid duplicate `kube_node_info` series.
- Removes the broken direct `prometheus.scrape "node"` path and adds Kubernetes API server proxy scrapes for kubelet `/metrics/cadvisor` and `/metrics/resource` using the Alloy service account token and CA bundle.

## Documentation Impact

- Added `docs/runbooks/observability-scrape-topology.md` describing the intended logs, annotated workload metrics, and kubelet/cAdvisor scrape topology.

## Verification

- `kubectl kustomize kubernetes/infra/monitoring/alloy`
- `kubectl kustomize kubernetes/infra/monitoring/kube-state-metrics`
- `helm template alloy grafana/alloy --version 1.2.1 --namespace alloy -f <rendered Alloy HelmRelease values>` to inspect chart-rendered DaemonSet tolerations and ClusterRole `nodes/proxy`/`nodes/metrics` access.
- `docker run --rm -v "$PWD/kubernetes/infra/monitoring/alloy/config/config.alloy:/etc/alloy/config.alloy:ro" grafana/alloy:v1.10.1 validate /etc/alloy/config.alloy`
- `docker run --rm -v "$PWD/kubernetes/infra/monitoring/alloy/config/config.alloy:/etc/alloy/config.alloy:ro" grafana/alloy:v1.10.1 fmt -t /etc/alloy/config.alloy`
- `python3 tools/architecture/render.py --check`
- Confirmed rendered Alloy config no longer contains `prometheus.scrape "node"` and includes kubelet cAdvisor/resource scrapes.
- Confirmed no SOPS or secret manifests changed.

## Workflow Note

- Verifier Raman approved exact HEAD `8448e1bb84bf659b8f26f52cbf81ea775b5640d6`.
- Non-blocking: kube-state-metrics templating shows duplicate `prometheus.io/scrape` annotations, both set to `true`.
