### PR TITLE
fix(grafana): repair observability dashboards

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
 | `kubernetes/infra/monitoring/alloy` | `repositories.yaml`, `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml`, `alert-rules-mimir.yaml` |
-| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml` |
+| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml` |
 | `kubernetes/infra/monitoring/grafana` | `namespace.yaml`, `repositories.yaml`, `app.yaml`, `secret.yaml`, `grafana-env.yaml`, `gateway.yaml`, `grafana-instance.yaml`, `folders.yaml`, `dashboards`, `alerting` |
 | `kubernetes/infra/monitoring/kube-state-metrics` | `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring` | `namespace.yaml`, `kube-state-metrics`, `snmp-exporter`, `pretty-discord-alerts` |

--- a/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
@@ -177,7 +177,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Resources not reconciled in the last 30 minutes",
+      "description": "Resources whose p95 reconcile duration over 30 minutes exceeds 60 seconds, using gotk_reconcile_duration_seconds buckets.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -232,11 +232,11 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count((time() - gotk_reconcile_condition{exported_namespace=~\"$namespace\",status=\"True\",type=\"Ready\",job=\"prometheus.scrape.pods\"}) > 1800) OR vector(0)",
+          "expr": "count(histogram_quantile(0.95, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[30m])) by (le, exported_namespace, name, kind)) > 60) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "⏰ Stale (>30m)",
+      "title": "⏱️ Slow p95 Reconciles (>60s)",
       "type": "stat"
     },
     {

--- a/kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json
@@ -93,7 +93,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count(kube_node_status_condition{condition=\"Ready\",status=\"true\"} == 0) OR vector(0)",
+          "expr": "sum(max by (node) (kube_node_status_condition{condition=\"Ready\",status=\"true\"} == bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -157,7 +157,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_pod_status_phase{phase=\"Failed\"}) OR vector(0)",
+          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{phase=\"Failed\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -225,7 +225,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_pod_container_status_waiting{reason!=\"ContainerCreating\"}) OR vector(0)",
+          "expr": "sum(max by (namespace, pod, container, reason) (kube_pod_container_status_waiting{reason!=\"ContainerCreating\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -293,7 +293,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_persistentvolumeclaim_status_phase{phase=\"Pending\"}) OR vector(0)",
+          "expr": "sum(max by (namespace, persistentvolumeclaim) (kube_persistentvolumeclaim_status_phase{phase=\"Pending\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -305,7 +305,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Container restarts in the last hour",
+      "description": "Containers with one or more restarts in the last hour",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -361,11 +361,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(increase(kube_pod_container_status_restarts_total[1h])) OR vector(0)",
+          "expr": "sum(max by (namespace, pod, container) (increase(kube_pod_container_status_restarts_total[1h]) > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "🔄 Restarts (1h)",
+      "title": "🔄 Containers Restarted (1h)",
       "type": "stat"
     },
     {
@@ -425,7 +425,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count(kube_deployment_status_replicas_available != kube_deployment_spec_replicas) OR vector(0)",
+          "expr": "sum(max by (namespace, deployment) (kube_deployment_status_replicas_available != bool kube_deployment_spec_replicas)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -556,7 +556,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_pod_status_phase{phase=\"Running\"})",
+          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} > bool 0))",
           "refId": "A"
         }
       ],
@@ -763,7 +763,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (phase) (kube_pod_status_phase)",
+          "expr": "sum by (phase) (max by (namespace, pod, phase) (kube_pod_status_phase > bool 0))",
           "legendFormat": "{{phase}}",
           "refId": "A"
         }
@@ -984,7 +984,8 @@
         }
       ],
       "title": "Node Memory Usage %",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Uses MemAvailable/MemTotal so Linux cache is not treated as unavailable memory."
     },
     {
       "collapsed": false,
@@ -993,6 +994,334 @@
         "w": 24,
         "x": 0,
         "y": 24
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Memory Context",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_MemAvailable_bytes",
+          "refId": "A",
+          "legendFormat": "{{instance}} available"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes",
+          "refId": "B",
+          "legendFormat": "{{instance}} raw used"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_memory_Cached_bytes + node_memory_Buffers_bytes",
+          "refId": "C",
+          "legendFormat": "{{instance}} cache+buffers"
+        }
+      ],
+      "title": "Node Memory Available, Raw Used, Cache",
+      "type": "timeseries",
+      "description": "Shows the raw node-exporter memory signals behind the MemAvailable-based usage panel."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (node) (kube_node_status_condition{condition=\"MemoryPressure\",status=\"true\"} > bool 0)",
+          "refId": "A",
+          "legendFormat": "{{node}}"
+        }
+      ],
+      "title": "Kubernetes Node Memory Pressure",
+      "type": "timeseries",
+      "description": "kube-state-metrics MemoryPressure condition; 1 means the node reports pressure."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (namespace, pod) (container_memory_working_set_bytes{container!=\"\",container!=\"POD\"})) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{namespace}}/{{pod}} working set"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (namespace, pod) (container_memory_rss{container!=\"\",container!=\"POD\"})) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "{{namespace}}/{{pod}} RSS"
+        }
+      ],
+      "title": "Top Pods by Working Set and RSS",
+      "type": "timeseries",
+      "description": "Uses cAdvisor container memory when available; falls back to zero until those metrics are present."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
       },
       "id": 10,
       "panels": [],
@@ -1077,7 +1406,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 50
       },
       "id": 11,
       "options": {
@@ -1106,7 +1435,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "kube_pod_container_status_waiting{reason!=\"ContainerCreating\"} > 0",
+          "expr": "max by (namespace, pod, container, reason) (kube_pod_container_status_waiting{reason!=\"ContainerCreating\"} > bool 0)",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -1242,7 +1571,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 58
       },
       "id": 14,
       "options": {
@@ -1271,7 +1600,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "kube_pod_container_status_waiting{reason!=\"ContainerCreating\",namespace=\"monitoring\"} > 0",
+          "expr": "max by (namespace, pod, container, reason) (kube_pod_container_status_waiting{reason!=\"ContainerCreating\",namespace=\"monitoring\"} > bool 0)",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -1371,7 +1700,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 42
       },
       "id": 12,
       "options": {
@@ -1397,7 +1726,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "topk(10, sum by (namespace, pod) (increase(kube_pod_container_status_restarts_total[1h])))",
+          "expr": "topk(10, sum by (namespace, pod) (increase(kube_pod_container_status_restarts_total[1h]) > bool 0))",
           "legendFormat": "{{namespace}}/{{pod}}",
           "refId": "A"
         }
@@ -1463,7 +1792,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 25
+        "y": 42
       },
       "id": 13,
       "options": {
@@ -1487,7 +1816,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (namespace) (kube_pod_status_phase{phase=\"Running\"})",
+          "expr": "sum by (namespace) (max by (namespace, pod) (kube_pod_status_phase{phase=\"Running\"} > bool 0))",
           "legendFormat": "{{namespace}}",
           "refId": "A"
         }

--- a/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
@@ -27,8 +27,15 @@ configMapGenerator:
       - dashboard.json=authentik-dashboard.json
     options:
       disableNameSuffixHash: true
+  - name: observability-health-dashboard
+    namespace: grafana
+    files:
+      - dashboard.json=observability-health-dashboard.json
+    options:
+      disableNameSuffixHash: true
 resources:
   - proxmox-dashboard.yaml
   - flux-dashboard.yaml
   - kubernetes-dashboard.yaml
   - authentik-dashboard.yaml
+  - observability-health-dashboard.yaml

--- a/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.json
@@ -16,11 +16,11 @@
     ]
   },
   "editable": true,
-  "fiscalYearStartMonth": 0,
-  "folderTitle": "Authentik",
+  "fiscalYearStart": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -32,7 +32,7 @@
       },
       "id": 100,
       "panels": [],
-      "title": "🔐 System Overview",
+      "title": "Platform Health",
       "type": "row"
     },
     {
@@ -40,7 +40,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Running authentik server pods from kube-state-metrics pod labels.",
+      "description": "Minimum up value for Grafana scrape targets.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -65,15 +65,15 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 6,
+        "h": 4,
+        "w": 4,
         "x": 0,
         "y": 1
       },
       "id": 101,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -85,18 +85,18 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{namespace=\"authentik\",pod=~\"authentik-server-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
+          "expr": "min(up{namespace=\"grafana\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "🟢 Server Pods Running",
+      "title": "Grafana Targets Up",
       "type": "stat"
     },
     {
@@ -104,7 +104,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Running authentik worker pods from kube-state-metrics pod labels.",
+      "description": "Minimum up value for Mimir scrape targets.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -129,15 +129,15 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 6,
+        "h": 4,
+        "w": 4,
+        "x": 4,
         "y": 1
       },
       "id": 102,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -149,18 +149,18 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{namespace=\"authentik\",pod=~\"authentik-worker-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
+          "expr": "min(up{namespace=\"mimir\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "🔧 Worker Pods Running",
+      "title": "Mimir Targets Up",
       "type": "stat"
     },
     {
@@ -168,68 +168,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Total request rate per second (last 5 minutes)",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 1
-      },
-      "id": 103,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(authentik_main_requests_count{namespace=\"authentik\"}[5m])) OR sum(rate(authentik_main_requests_total{namespace=\"authentik\"}[5m])) OR vector(0)",
-          "refId": "A"
-        }
-      ],
-      "title": "📊 Request Rate",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Active Celery worker tasks",
+      "description": "Minimum up value for Loki scrape targets.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -239,17 +178,13 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 5
-              },
               {
                 "color": "red",
-                "value": 20
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
               }
             ]
           },
@@ -258,15 +193,15 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 18,
+        "h": 4,
+        "w": 4,
+        "x": 8,
         "y": 1
       },
-      "id": 104,
+      "id": 103,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
@@ -278,45 +213,225 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "authentik_tasks_workers{namespace=\"authentik\"} OR vector(0)",
+          "expr": "min(up{namespace=\"loki\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "⚙️ Active Workers",
+      "title": "Loki Targets Up",
       "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 6
-      },
-      "id": 200,
-      "panels": [],
-      "title": "📈 Request Metrics",
-      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Request rate over time by destination (backend vs outpost)",
+      "description": "Minimum up value for Alloy scrape targets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "min(up{namespace=\"alloy\"}) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Alloy Targets Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Scrape targets currently down.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 105,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(up == bool 0) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape Targets Down",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Scrape targets currently up.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 106,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(up == bool 1) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape Targets Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Down scrape targets grouped by job.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -326,10 +441,11 @@
             "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -356,7 +472,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -364,38 +480,34 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 5
       },
       "id": 201,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (dest) (rate(authentik_main_requests_count{namespace=\"authentik\"}[5m])) OR sum by (dest) (rate(authentik_main_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{dest}}",
-          "refId": "A"
+          "expr": "sum by (job) (up == bool 0) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{job}}"
         }
       ],
-      "title": "Main Request Rate by Destination",
+      "title": "Scrape Failures by Job",
       "type": "timeseries"
     },
     {
@@ -403,26 +515,28 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Request duration percentiles",
+      "description": "Largest scrape payloads by current sample count.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -449,7 +563,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -457,65 +571,34 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 5
       },
       "id": 202,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p50",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p90",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p95",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p99",
-          "refId": "D"
+          "expr": "topk(15, sum by (job) (scrape_samples_scraped))",
+          "refId": "A",
+          "legendFormat": "{{job}}"
         }
       ],
-      "title": "Request Duration",
+      "title": "Scrape Samples by Job",
       "type": "timeseries"
     },
     {
@@ -524,11 +607,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 13
       },
       "id": 300,
       "panels": [],
-      "title": "🛡️ Proxy & LDAP Outposts",
+      "title": "Observability Services",
       "type": "row"
     },
     {
@@ -536,13 +619,14 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Proxy outpost request rate by provider",
+      "description": "Grafana request rate and server errors.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -552,10 +636,11 @@
             "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -582,7 +667,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -590,37 +675,43 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 14
       },
       "id": 301,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider) (rate(authentik_outpost_proxy_requests_count{namespace=\"authentik\"}[5m])) OR sum by (provider) (rate(authentik_outpost_proxy_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{provider}}",
-          "refId": "A"
+          "expr": "sum(rate(grafana_http_request_duration_seconds_count[5m])) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "requests"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(grafana_http_request_duration_seconds_count{status_code=~\"5..\"}[5m])) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "5xx"
         }
       ],
-      "title": "Proxy Outpost Request Rate",
+      "title": "Grafana HTTP Requests",
       "type": "timeseries"
     },
     {
@@ -628,13 +719,14 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "LDAP outpost request rate by provider and operation type",
+      "description": "Remote-write-like sample ingestion where Mimir/cortex metrics exist.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -644,10 +736,11 @@
             "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -674,7 +767,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -682,37 +775,43 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 14
       },
       "id": 302,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider, type) (rate(authentik_outpost_ldap_requests_count{namespace=\"authentik\"}[5m])) OR sum by (provider, type) (rate(authentik_outpost_ldap_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{provider}} - {{type}}",
-          "refId": "A"
+          "expr": "sum(rate(cortex_distributor_received_samples_total[5m])) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "received samples"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(cortex_distributor_refused_samples_total[5m])) OR sum(rate(cortex_discarded_samples_total[5m])) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "refused/discarded samples"
         }
       ],
-      "title": "LDAP Outpost Request Rate",
+      "title": "Mimir Remote Write Ingestion",
       "type": "timeseries"
     },
     {
@@ -720,26 +819,28 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Proxy outpost request duration percentiles",
+      "description": "Loki distributor ingest bytes and request errors.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -766,7 +867,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "Bps"
         },
         "overrides": []
       },
@@ -774,65 +875,43 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 22
       },
       "id": 303,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p50",
-          "refId": "A"
+          "expr": "sum(rate(loki_distributor_bytes_received_total[5m])) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "bytes received"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p90",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p95",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p99",
-          "refId": "D"
+          "expr": "sum(rate(loki_request_duration_seconds_count{status_code=~\"5..\"}[5m])) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "5xx requests"
         }
       ],
-      "title": "Proxy Request Duration",
+      "title": "Loki Ingest and Errors",
       "type": "timeseries"
     },
     {
@@ -840,26 +919,28 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "LDAP outpost request duration percentiles",
+      "description": "Alloy component running state and slow evaluations where exported.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -886,7 +967,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -894,65 +975,43 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 22
       },
       "id": 304,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p50",
-          "refId": "A"
+          "expr": "min by (component_path) (alloy_component_controller_running) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{component_path}} running"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p90",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p95",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p99",
-          "refId": "D"
+          "expr": "sum by (component_path) (rate(alloy_component_evaluation_slow_seconds[5m])) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "{{component_path}} slow eval"
         }
       ],
-      "title": "LDAP Request Duration",
+      "title": "Alloy Component Health",
       "type": "timeseries"
     },
     {
@@ -961,11 +1020,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 30
       },
       "id": 400,
       "panels": [],
-      "title": "💾 Resource Utilization",
+      "title": "Cardinality and Logs",
       "type": "row"
     },
     {
@@ -973,13 +1032,14 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Uses cAdvisor container CPU when available; shows zero until container metrics are present.",
+      "description": "Scrape-time series churn by job.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -989,10 +1049,11 @@
             "fillOpacity": 20,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
@@ -1019,7 +1080,7 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -1027,38 +1088,34 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 31
       },
       "id": 401,
       "options": {
         "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
+          "calcs": [],
+          "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"authentik\", pod=~\"authentik-.*\", container!=\"\", container!=\"POD\"}[5m])) OR on() vector(0)",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
+          "expr": "topk(15, sum by (job) (scrape_series_added))",
+          "refId": "A",
+          "legendFormat": "{{job}}"
         }
       ],
-      "title": "CPU Usage",
+      "title": "Top Jobs by Series Added",
       "type": "timeseries"
     },
     {
@@ -1066,41 +1123,18 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Uses cAdvisor working set and RSS metrics when available; the panel tolerates no container-memory data.",
+      "description": "Instant cardinality view grouped by metric name.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
             },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
@@ -1111,8 +1145,7 @@
                 "value": null
               }
             ]
-          },
-          "unit": "bytes"
+          }
         },
         "overrides": []
       },
@@ -1120,140 +1153,237 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 31
       },
       "id": 402,
       "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "show": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
+        "showHeader": true
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"authentik\", pod=~\"authentik-.*\", container!=\"\", container!=\"POD\"}) OR on() vector(0)",
+          "expr": "topk(20, count by (__name__) ({__name__=~\".+\"}))",
           "refId": "A",
-          "legendFormat": "{{pod}} working set"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (pod) (container_memory_rss{namespace=\"authentik\", pod=~\"authentik-.*\", container!=\"\", container!=\"POD\"}) OR on() vector(0)",
-          "refId": "B",
-          "legendFormat": "{{pod}} RSS"
+          "instant": true,
+          "format": "table"
         }
       ],
-      "title": "Memory Working Set/RSS (if cAdvisor present)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 41
-      },
-      "id": 500,
-      "panels": [],
-      "title": "📜 Recent Logs",
-      "type": "row"
+      "title": "Top Metrics by Active Series",
+      "type": "table"
     },
     {
       "datasource": {
         "type": "loki",
         "uid": "loki"
       },
-      "description": "Recent logs from Authentik server and worker pods",
+      "description": "Log volume by namespace from Loki.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 12,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 42
+        "y": 39
       },
-      "id": 501,
+      "id": 403,
       "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": false
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "12.1.0",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{namespace=\"authentik\", pod=~\"authentik-.*\"} |~ \"$log_filter\"",
+          "expr": "sum by (namespace) (bytes_rate({namespace!=\"\"}[5m]))",
           "refId": "A"
         }
       ],
-      "title": "Authentik Logs",
-      "type": "logs"
+      "title": "Loki Log Bytes by Namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "description": "Log line rate by namespace from Loki.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 404,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum by (namespace) (rate({namespace!=\"\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Loki Log Lines by Namespace",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "authentik",
-    "authentication",
-    "sso"
+    "monitoring",
+    "observability",
+    "health"
   ],
   "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
-        },
-        "hide": 0,
-        "label": "Log Filter",
-        "name": "log_filter",
-        "options": [
-          {
-            "selected": true,
-            "text": "",
-            "value": ""
-          }
-        ],
-        "query": "",
-        "skipUrlSync": false,
-        "type": "textbox"
-      }
-    ]
+    "list": []
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Authentik - Overview",
-  "uid": "authentik-overview",
+  "title": "Observability - Health",
+  "uid": "observability-health",
   "version": 1,
   "weekStart": ""
 }

--- a/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: observability-health
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "monitoring"
+  configMapRef:
+    name: observability-health-dashboard
+    key: dashboard.json

--- a/kubernetes/infra/monitoring/grafana/dashboards/proxmox-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/proxmox-dashboard.json
@@ -926,8 +926,127 @@
           "refId": "A"
         }
       ],
-      "title": "Top 10 VMs by Memory %",
-      "type": "timeseries"
+      "title": "Top 10 VMs by Allocated/Raw Memory %",
+      "type": "timeseries",
+      "description": "Proxmox VM memory is host-observed allocated/raw VM memory, not guest memory pressure. Pair this with node-exporter available memory for Kubernetes/Talos guests."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 306,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(100 * (node_memory_MemAvailable_bytes{node_name=~\"k8s-.+\"} / node_memory_MemTotal_bytes{node_name=~\"k8s-.+\"}), \"guest\", \"$1\", \"node_name\", \"(.*)\") OR label_replace(100 * (node_memory_MemAvailable_bytes{instance=~\"k8s-.+(:[0-9]+)?|.*k8s-.+\"} / node_memory_MemTotal_bytes{instance=~\"k8s-.+(:[0-9]+)?|.*k8s-.+\"}), \"guest\", \"$1\", \"instance\", \"([^.:]+).*\")",
+          "refId": "A",
+          "legendFormat": "{{guest}} available"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "label_replace(100 * (1 - (node_memory_MemAvailable_bytes{node_name=~\"k8s-.+\"} / node_memory_MemTotal_bytes{node_name=~\"k8s-.+\"})), \"guest\", \"$1\", \"node_name\", \"(.*)\") OR label_replace(100 * (1 - (node_memory_MemAvailable_bytes{instance=~\"k8s-.+(:[0-9]+)?|.*k8s-.+\"} / node_memory_MemTotal_bytes{instance=~\"k8s-.+(:[0-9]+)?|.*k8s-.+\"})), \"guest\", \"$1\", \"instance\", \"([^.:]+).*\")",
+          "refId": "B",
+          "legendFormat": "{{guest}} used"
+        }
+      ],
+      "title": "Kubernetes/Talos Guest Available Memory %",
+      "type": "timeseries",
+      "description": "Node-exporter guest memory context for Kubernetes/Talos VM names; available memory explains Linux cache-heavy guests such as k8s-eminent-collie."
     },
     {
       "datasource": {
@@ -990,7 +1109,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 47
       },
       "id": 304,
       "options": {
@@ -1087,7 +1206,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 47
       },
       "id": 305,
       "options": {


### PR DESCRIPTION
# observability-dashboard-repair

## Implementation Summary

Repair Grafana dashboard queries for Kubernetes, Proxmox, Flux, and Authentik, and add an `Observability - Health` dashboard wired into the existing monitoring folder.

## Important Changes

- Preserved Kubernetes node memory usage as `MemAvailable / MemTotal` and added node memory available/raw used/cache, kube-state-metrics MemoryPressure, and cAdvisor working set/RSS context.
- Updated Kubernetes kube-state-metrics status panels to count active nonzero states with `bool` comparisons and `max by (...)` deduping for failed pods, waiting containers, PVC pending, restarts, and related pod phase views.
- Clarified Proxmox VM memory as allocated/raw host-observed memory and added Kubernetes/Talos guest available/used memory context from node-exporter metrics for Kubernetes VM names.
- Replaced the Flux stale reconcile panel that referenced absent `gotk_reconcile_condition` with a slow p95 reconcile panel using `gotk_reconcile_duration_seconds_bucket`.
- Updated Authentik server/worker pod status panels to use namespace/pod kube-state-metrics labels and made cAdvisor CPU/memory panels tolerate missing data.
- Added `Observability - Health` dashboard coverage for Grafana, Mimir, Loki, Alloy, scrape health, Mimir remote-write-like ingestion, cardinality/noisy metric context, and Loki log volume by namespace.

## Documentation Impact

- Refreshed generated `docs/architecture.md` because the Grafana dashboard Kustomization now includes `observability-health-dashboard.yaml`.
- No runbook or decision record changed; behavior remains dashboard-only.

## Verification

- Verifier Plato initially blocked PR 3 because Kubernetes dashboard byte-valued memory context panels inherited fixed percent-style `max: 100` axis/threshold config; fixed by keeping byte units and removing the fixed percent max/thresholds from those panels.
- `jq empty kubernetes/infra/monitoring/grafana/dashboards/*.json`
- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- `rg -n "gotk_reconcile_condition" kubernetes/infra/monitoring/grafana/dashboards`
- `python3 tools/architecture/render.py --check`
- `git diff --check`
- `git diff --name-only | rg '(^|/)secret\.yaml$|grafana-env\.yaml$|\.sops\.ya?ml$'`

## Workflow Notes

- Implementation owner: `gpt5-codex-20260511-a`.
- Verifier Plato approved exact HEAD `7dccaed97d35df107e95f7d851fc4557bba0c73c` after the Kubernetes byte-panel field config fix.
