### PR TITLE
fix(monitoring): remove duplicate kube-state-metrics scrape annotation

### DIFF
--- a/kubernetes/infra/monitoring/kube-state-metrics/config/metrics.yaml
+++ b/kubernetes/infra/monitoring/kube-state-metrics/config/metrics.yaml
@@ -1,6 +1,5 @@
 service:
   annotations:
-    prometheus.io/scrape: "true"
     prometheus.io/port: "8080"
 
 rbac:


### PR DESCRIPTION
## Summary

Remove the explicit `service.annotations.prometheus.io/scrape` value from kube-state-metrics Helm values so chart 6.3.0 renders only one scrape annotation.

## Important Changes

- Kept `service.annotations.prometheus.io/port: "8080"` for Alloy service discovery.
- Left docs unchanged because the architecture check passed and the scrape topology docs already cover annotated service scraping.

## Verification

- Validated active implementation marker, implementation plan, and owner attestation.
- Rendered `prometheus-community/kube-state-metrics` chart `6.3.0` with the adjusted values and confirmed the Service has exactly one `prometheus.io/scrape` annotation and one `prometheus.io/port: "8080"` annotation.
- Ran `python3 tools/architecture/render.py --check`.
