### PR TITLE
fix(observability): repair dashboard scrape queries

### DIFF
--- a/kubernetes/infra/monitoring/alloy/app.yaml
+++ b/kubernetes/infra/monitoring/alloy/app.yaml
@@ -26,6 +26,10 @@ spec:
   values:
     rbac:
       create: true
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "12345"
     serviceAccount:
       automountServiceAccountToken: true
     controller:

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-flux.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-flux.yaml
@@ -31,7 +31,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: count(gotk_resource_info{suspended="true",job="prometheus.scrape.pods"}) OR vector(0)
+            expr: count(gotk_resource_info{suspended="true",job="prometheus.scrape.service"}) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:
@@ -84,7 +84,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: count(gotk_resource_info{ready="False",job="prometheus.scrape.pods"}) OR vector(0)
+            expr: count(gotk_resource_info{ready="False",job="prometheus.scrape.service"}) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:
@@ -137,7 +137,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: count(gotk_resource_info{ready="Unknown",job="prometheus.scrape.pods"}) OR vector(0)
+            expr: count(gotk_resource_info{ready="Unknown",job="prometheus.scrape.service"}) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         description: "Mimir has {{ $values.B.Value }} ACTIVE ingester(s) in the ring. Metrics ingestion or long-term storage may be impaired."
         summary: Mimir ingester is not healthy in the ring
-        runbook: "Start with: kubectl -n mimir get pods -o wide; kubectl -n mimir logs statefulset/mimir-ingester --tail=100; flux debug helmrelease mimir -n mimir --show-values"
+        runbook: "Start with: kubectl -n mimir get pods -o wide; kubectl -n mimir logs statefulset/mimir-ingester --tail=100; flux debug helmrelease mimir -n mimir --show-values. Confirm ring state and recent rollouts before restarting or deleting pods."
       labels:
         severity: critical
         component: observability
@@ -31,7 +31,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(cortex_ring_members{name="ingester",state="ACTIVE",job="prometheus.scrape.pods"}) OR vector(0)
+            expr: sum(cortex_ring_members{name="ingester",state="ACTIVE",job="prometheus.scrape.service"}) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-proxmox.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-proxmox.yaml
@@ -190,7 +190,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: max(100 * (1 - (rate(proxmox_proxmox_node_cpustat_idle_seconds_total[5m]) / on(proxmox_node) group_left() proxmox_proxmox_node_cpustat_cpus_ratio))) OR vector(0)
+            expr: max(100 * proxmox_proxmox_node_cpustat_cpu_percent) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:

--- a/kubernetes/infra/monitoring/grafana/app.yaml
+++ b/kubernetes/infra/monitoring/grafana/app.yaml
@@ -27,10 +27,16 @@ spec:
     envFromSecret: grafana-env
     admin:
       existingSecret: grafana-credentials
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "80"
     grafana.ini:
       server:
         domain: monitoring.${cluster_domain}
         root_url: https://monitoring.${cluster_domain}
+      metrics:
+        enabled: true
       auth.generic_oauth:
         enabled: true
         name: Authentik

--- a/kubernetes/infra/monitoring/grafana/dashboards/authentik-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/authentik-dashboard.json
@@ -92,7 +92,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{namespace=\"authentik\",pod=~\"authentik-server-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
+          "expr": "sum(max by (exported_namespace, pod) (kube_pod_status_phase{exported_namespace=\"authentik\",pod=~\"authentik-server-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -156,7 +156,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{namespace=\"authentik\",pod=~\"authentik-worker-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
+          "expr": "sum(max by (exported_namespace, pod) (kube_pod_status_phase{exported_namespace=\"authentik\",pod=~\"authentik-worker-.*\",phase=\"Running\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -217,7 +217,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(authentik_main_requests_count{namespace=\"authentik\"}[5m])) OR sum(rate(authentik_main_requests_total{namespace=\"authentik\"}[5m])) OR vector(0)",
+          "expr": "sum(rate(authentik_main_request_duration_seconds_count{namespace=\"authentik\"}[5m])) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -310,7 +310,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Request rate over time by destination (backend vs outpost)",
+      "description": "Main Authentik HTTP request rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -390,12 +390,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (dest) (rate(authentik_main_requests_count{namespace=\"authentik\"}[5m])) OR sum by (dest) (rate(authentik_main_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{dest}}",
+          "expr": "sum by (method, status) (rate(authentik_main_request_duration_seconds_count{namespace=\"authentik\"}[5m])) OR on() vector(0)",
+          "legendFormat": "{{method}} {{status}}",
           "refId": "A"
         }
       ],
-      "title": "Main Request Rate by Destination",
+      "title": "Main Request Rate",
       "type": "timeseries"
     },
     {
@@ -483,7 +483,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
+          "expr": "histogram_quantile(0.50, sum(rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
           "legendFormat": "p50",
           "refId": "A"
         },
@@ -492,7 +492,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
+          "expr": "histogram_quantile(0.90, sum(rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
           "legendFormat": "p90",
           "refId": "B"
         },
@@ -501,7 +501,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
+          "expr": "histogram_quantile(0.95, sum(rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
           "legendFormat": "p95",
           "refId": "C"
         },
@@ -510,7 +510,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_main_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_main_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
+          "expr": "histogram_quantile(0.99, sum(rate(authentik_main_request_duration_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
           "legendFormat": "p99",
           "refId": "D"
         }
@@ -528,7 +528,7 @@
       },
       "id": 300,
       "panels": [],
-      "title": "🛡️ Proxy & LDAP Outposts",
+      "title": "🛡️ Outpost Status",
       "type": "row"
     },
     {
@@ -536,7 +536,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Proxy outpost request rate by provider",
+      "description": "Current outpost connection gauge",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -582,7 +582,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
@@ -615,12 +615,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider) (rate(authentik_outpost_proxy_requests_count{namespace=\"authentik\"}[5m])) OR sum by (provider) (rate(authentik_outpost_proxy_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{provider}}",
+          "expr": "authentik_outpost_connection{namespace=\"authentik\"} OR vector(0)",
+          "legendFormat": "{{outpost_name}} {{outpost_type}}",
           "refId": "A"
         }
       ],
-      "title": "Proxy Outpost Request Rate",
+      "title": "Outpost Connection Status",
       "type": "timeseries"
     },
     {
@@ -628,7 +628,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "LDAP outpost request rate by provider and operation type",
+      "description": "Seconds since each outpost last updated",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -674,7 +674,7 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -707,12 +707,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (provider, type) (rate(authentik_outpost_ldap_requests_count{namespace=\"authentik\"}[5m])) OR sum by (provider, type) (rate(authentik_outpost_ldap_requests_total{namespace=\"authentik\"}[5m]))",
-          "legendFormat": "{{provider}} - {{type}}",
+          "expr": "time() - authentik_outpost_last_update{namespace=\"authentik\"}",
+          "legendFormat": "{{outpost_name}} {{outpost_type}}",
           "refId": "A"
         }
       ],
-      "title": "LDAP Outpost Request Rate",
+      "title": "Outpost Last Update Age",
       "type": "timeseries"
     },
     {
@@ -720,7 +720,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Proxy outpost request duration percentiles",
+      "description": "Current outpost build and version labels",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -766,13 +766,13 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
         "y": 24
       },
@@ -800,160 +800,14 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p50",
+          "expr": "authentik_outpost_info{namespace=\"authentik\"}",
+          "format": "table",
+          "instant": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p90",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p95",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_outpost_proxy_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_outpost_proxy_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p99",
-          "refId": "D"
         }
       ],
-      "title": "Proxy Request Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "LDAP outpost request duration percentiles",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 304,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "mean",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.1.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.50, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.50, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p50",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.90, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.90, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p90",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.95, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.95, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p95",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum(rate(authentik_outpost_ldap_requests_seconds_bucket{namespace=\"authentik\"}[5m])) by (le)) OR histogram_quantile(0.99, sum(rate(authentik_outpost_ldap_requests_bucket{namespace=\"authentik\"}[5m])) by (le)) OR vector(0)",
-          "legendFormat": "p99",
-          "refId": "D"
-        }
-      ],
-      "title": "LDAP Request Duration",
-      "type": "timeseries"
+      "title": "Outpost Info",
+      "type": "table"
     },
     {
       "collapsed": false,

--- a/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
@@ -102,7 +102,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",suspended=\"true\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",suspended=\"true\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -165,7 +165,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -295,7 +295,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -421,7 +421,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"Kustomization|HelmRelease\",job=\"prometheus.scrape.pods\"})",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"Kustomization|HelmRelease\",job=\"prometheus.scrape.service\"})",
           "refId": "A"
         }
       ],
@@ -571,7 +571,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"True\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"True\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Ready",
           "refId": "A"
         },
@@ -580,7 +580,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Failing",
           "refId": "B"
         },
@@ -589,7 +589,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.pods\"}) OR vector(0)",
+          "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Unknown",
           "refId": "C"
         }
@@ -905,7 +905,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.pods\"}",
+          "expr": "gotk_resource_info{exported_namespace=~\"$namespace\", customresource_kind=~\"$resource_type\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -1014,7 +1014,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count by (customresource_kind) (gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"})",
+          "expr": "count by (customresource_kind) (gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.service\"})",
           "format": "time_series",
           "legendFormat": "{{customresource_kind}}",
           "refId": "A"
@@ -1106,7 +1106,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "count by (exported_namespace) (gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.pods\"})",
+          "expr": "count by (exported_namespace) (gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.service\"})",
           "legendFormat": "{{exported_namespace}}",
           "refId": "A"
         }
@@ -1313,7 +1313,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(gotk_resource_info{job=\"prometheus.scrape.pods\"}, exported_namespace)",
+        "definition": "label_values(gotk_resource_info{job=\"prometheus.scrape.service\"}, exported_namespace)",
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
@@ -1321,7 +1321,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(gotk_resource_info{job=\"prometheus.scrape.pods\"}, exported_namespace)",
+          "query": "label_values(gotk_resource_info{job=\"prometheus.scrape.service\"}, exported_namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1341,7 +1341,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}, customresource_kind)",
+        "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.service\"}, customresource_kind)",
         "hide": 0,
         "includeAll": true,
         "label": "Resource Type",
@@ -1349,7 +1349,7 @@
         "name": "resource_type",
         "options": [],
         "query": {
-          "query": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}, customresource_kind)",
+          "query": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.service\"}, customresource_kind)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -1369,7 +1369,7 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.pods\"}, name)",
+        "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.service\"}, name)",
         "hide": 0,
         "includeAll": true,
         "label": "Resource Name",
@@ -1377,7 +1377,7 @@
         "name": "resource_name",
         "options": [],
         "query": {
-          "query": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.pods\"}, name)",
+          "query": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.service\"}, name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
@@ -362,7 +362,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(gotk_reconcile_duration_seconds_count{namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[5m])) OR on() vector(0)",
+          "expr": "sum(rate(gotk_reconcile_duration_seconds_count{job=\"prometheus.scrape.pods\"}[5m])) OR on() vector(0)",
           "refId": "A"
         }
       ],

--- a/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/observability-health-dashboard.json
@@ -92,11 +92,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min(up{namespace=\"grafana\"}) OR vector(0)",
+          "expr": "min(up{job=\"prometheus.scrape.service\",namespace=\"grafana\",service=\"grafana\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Grafana Targets Up",
+      "title": "Grafana Scrape Healthy",
       "type": "stat"
     },
     {
@@ -156,11 +156,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min(up{namespace=\"mimir\"}) OR vector(0)",
+          "expr": "min(up{job=\"prometheus.scrape.service\",namespace=\"mimir\",service=~\"mimir-(distributor|ingester|querier|query-frontend|store-gateway|compactor)\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Mimir Targets Up",
+      "title": "Mimir Scrape Healthy",
       "type": "stat"
     },
     {
@@ -220,11 +220,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min(up{namespace=\"loki\"}) OR vector(0)",
+          "expr": "min(up{job=\"prometheus.scrape.service\",namespace=\"loki\",service=~\"loki-(backend|read|write)\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Loki Targets Up",
+      "title": "Loki Scrape Healthy",
       "type": "stat"
     },
     {
@@ -284,11 +284,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min(up{namespace=\"alloy\"}) OR vector(0)",
+          "expr": "min(up{job=\"prometheus.scrape.service\",namespace=\"alloy\",service=\"alloy\"}) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Alloy Targets Up",
+      "title": "Alloy Scrape Healthy",
       "type": "stat"
     },
     {
@@ -348,11 +348,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(up == bool 0) OR vector(0)",
+          "expr": "sum(max by (exported_namespace, pod) (kube_pod_status_phase{exported_namespace=~\"grafana|mimir|loki|alloy\",phase=\"Running\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Scrape Targets Down",
+      "title": "Observability Pods Running",
       "type": "stat"
     },
     {
@@ -412,11 +412,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(up == bool 1) OR vector(0)",
+          "expr": "sum(max by (exported_namespace, pod) (kube_pod_status_phase{exported_namespace=~\"grafana|mimir|loki|alloy\",phase=~\"Pending|Failed|Unknown\"} > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Scrape Targets Up",
+      "title": "Observability Pods Unavailable",
       "type": "stat"
     },
     {
@@ -502,12 +502,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (job) (up == bool 0) OR on() vector(0)",
+          "expr": "sum by (namespace, service) (up{job=\"prometheus.scrape.service\",namespace=~\"grafana|mimir|loki|alloy\"} == bool 0) OR on() vector(0)",
           "refId": "A",
           "legendFormat": "{{job}}"
         }
       ],
-      "title": "Scrape Failures by Job",
+      "title": "Scrape Failures by Service",
       "type": "timeseries"
     },
     {
@@ -593,12 +593,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "topk(15, sum by (job) (scrape_samples_scraped))",
+          "expr": "topk(15, sum by (namespace, service) (scrape_samples_scraped{job=\"prometheus.scrape.service\",namespace=~\"grafana|mimir|loki|alloy\"}))",
           "refId": "A",
           "legendFormat": "{{job}}"
         }
       ],
-      "title": "Scrape Samples by Job",
+      "title": "Scrape Samples by Service",
       "type": "timeseries"
     },
     {

--- a/kubernetes/infra/monitoring/grafana/dashboards/proxmox-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/proxmox-dashboard.json
@@ -257,7 +257,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "100 * (1 - (rate(proxmox_proxmox_node_cpustat_idle_seconds_total[5m]) / on(proxmox_node) group_left() proxmox_proxmox_node_cpustat_cpus_ratio))",
+          "expr": "100 * proxmox_proxmox_node_cpustat_cpu_percent",
           "legendFormat": "{{proxmox_node}}",
           "refId": "A"
         }

--- a/kubernetes/infra/monitoring/loki/app.yaml
+++ b/kubernetes/infra/monitoring/loki/app.yaml
@@ -56,10 +56,22 @@ spec:
 
     backend:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "3100"
     read:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "3100"
     write:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "3100"
 
     # Enable minio for storage
     minio:

--- a/kubernetes/infra/monitoring/mimir/app.yaml
+++ b/kubernetes/infra/monitoring/mimir/app.yaml
@@ -39,18 +39,45 @@ spec:
             replication_factor: 1
     distributor:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
     alertmanager:
       enabled: false
     ingester:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
       zoneAwareReplication:
         enabled: false
       persistentVolume:
         size: 50Gi
+    querier:
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
+    query_frontend:
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
     store_gateway:
       replicas: 1
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
       zoneAwareReplication:
         enabled: false
+    compactor:
+      service:
+        annotations:
+          prometheus.io/scrape: "true"
+          prometheus.io/port: "8080"
     minio:
       persistence:
         size: 50Gi


### PR DESCRIPTION
## Summary

Repair observability dashboards and alert rules so Grafana panels and Mimir alerts match the service-scrape labels and current metric names.

## Important Changes

- Added service scrape annotations for Grafana, Mimir, Loki, and Alloy metrics endpoints, and enabled Grafana metrics.
- Updated the Observability Health dashboard to show service scrape health plus pod availability using `exported_namespace`.
- Updated Flux dashboard and alert `gotk_resource_info` queries to use the service scrape source, while leaving Flux controller reconcile metrics on pod scraping.
- Replaced the Proxmox dashboard host CPU expression with `100 * proxmox_proxmox_node_cpustat_cpu_percent`.
- Updated Authentik pod panels to use `exported_namespace`, switched main request panels to `authentik_main_request_duration_seconds_count` and `_bucket`, and replaced outpost request panels with connection, last update, and info panels.
- Updated the Mimir ingester alert to use service-scraped ring metrics and to recommend investigation before restart or deletion.

## Documentation Impact

No documentation changes were needed. This changes dashboard, alert, and Helm desired state only; operator workflows, runbooks, decision records, and generated architecture did not change. `python3 tools/architecture/render.py --check` passed.

## Verification

- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- `kubectl kustomize kubernetes/infra/monitoring/mimir`
- `kubectl kustomize kubernetes/infra/monitoring/loki`
- `kubectl kustomize kubernetes/infra/monitoring/alloy`
- `python3 tools/architecture/render.py --check`
- `git diff --check`
- `jq -e . kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json`
- Confirmed no SOPS secret manifest changes.

## Workflow Notes

- Implementation owner: `gpt5-codex-observability-owner-20260511`.
- Verifier follow-up findings were addressed in a focused follow-up commit.
- A read-only Grafana metric-name lookup was attempted, but the Grafana datasource request returned `401 Unauthorized`; no live cluster mutation was performed.
