### PR TITLE
fix(alerts): use exported namespace for app availability

### DIFF
--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-apps.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-apps.yaml
@@ -137,7 +137,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(kube_pod_status_phase{namespace="pihole",phase="Running"} > bool 0) OR vector(0)
+            expr: sum(kube_pod_status_phase{exported_namespace="pihole",phase="Running"} > bool 0) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:
@@ -190,7 +190,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(kube_pod_status_phase{namespace="jellyfin",phase="Running"} > bool 0) OR vector(0)
+            expr: sum(kube_pod_status_phase{exported_namespace="jellyfin",phase="Running"} > bool 0) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:
@@ -243,7 +243,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(kube_pod_status_phase{namespace="valheim",phase="Running"} > bool 0) OR vector(0)
+            expr: sum(kube_pod_status_phase{exported_namespace="valheim",phase="Running"} > bool 0) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:


### PR DESCRIPTION
## Summary

Fix Pi-hole, Jellyfin, and Valheim availability alert PromQL to filter `kube_pod_status_phase` by `exported_namespace`.

## Important Changes

- Updated only the scoped app availability expressions in `kubernetes/infra/monitoring/grafana/alerting/alert-rules-apps.yaml`.
- Preserved existing thresholds, severities, timing, labels, annotations, and rule structure.

## Documentation Impact

No documentation changes were needed because this only corrects existing Grafana alert query label selectors and does not change user-facing behavior, runbooks, architecture, or operating procedures.

## Verification

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/architecture/render.py --check`
- `pre-commit run --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-apps.yaml`
- `kubectl kustomize kubernetes/clusters/production >/tmp/homelab-production-app-availability-exported-namespace.yaml`
- `git diff --check`

## Workflow Notes

Dedicated verifier sign-off was recorded for exact commit `6ec0fcb631769215b82ea8679de347e24d99d736` in `.codex/tmp/verifier-approved` and `.codex/tmp/verifier-attestation.yaml`.
