### PR TITLE
fix(grafana): use authentik service for oauth exchange

### DIFF
--- a/kubernetes/infra/monitoring/grafana/app.yaml
+++ b/kubernetes/infra/monitoring/grafana/app.yaml
@@ -44,8 +44,8 @@ spec:
         client_secret: $__file{/etc/secrets/oauth-client-secret}
         scopes: openid email profile groups
         auth_url: https://authentik.${cluster_domain}/application/o/authorize/
-        token_url: https://authentik.${cluster_domain}/application/o/token/
-        api_url: https://authentik.${cluster_domain}/application/o/userinfo/
+        token_url: http://authentik-server.authentik.svc.cluster.local/application/o/token/
+        api_url: http://authentik-server.authentik.svc.cluster.local/application/o/userinfo/
         role_attribute_path: contains(groups[*], 'Grafana Admins') && 'Admin' || contains(groups[*], 'Grafana Editors') && 'Editor' || 'Viewer'
         allow_sign_up: true
     extraSecretMounts:


### PR DESCRIPTION
# grafana-authentik-service-oauth

## Summary

Fix Grafana Authentik OAuth token exchange by keeping the browser-facing authorization URL external while routing Grafana's server-side token and userinfo requests to the in-cluster Authentik service.

## Important Changes

- Updated `kubernetes/infra/monitoring/grafana/app.yaml` so `auth_url` remains `https://authentik.${cluster_domain}/application/o/authorize/`.
- Updated `token_url` to `http://authentik-server.authentik.svc.cluster.local/application/o/token/`.
- Updated `api_url` to `http://authentik-server.authentik.svc.cluster.local/application/o/userinfo/`.

## Documentation Impact

No documentation changed. This is a narrow endpoint correction in existing Grafana Helm values and does not change operating procedures, architecture relationships, or user-facing runbooks.

## Tests

- `python3 tools/architecture/render.py --check`
- `kubectl kustomize kubernetes/infra/monitoring/grafana >/tmp/grafana-authentik-service-oauth.kustomize.yaml`
- `pre-commit run --files kubernetes/infra/monitoring/grafana/app.yaml`
- `git diff --check`

## Verification Status

Implementation owner checks passed. Dedicated verifier sign-off was recorded for exact commit `ac74200ee17a496619fd484256471910b14f5e21` in `.codex/tmp/verifier-approved` and `.codex/tmp/verifier-attestation.yaml`.
