### PR TITLE
feat(monitoring): alert on discord delivery failures

### DIFF
--- a/docs/runbooks/discord-alert-delivery-health.md
+++ b/docs/runbooks/discord-alert-delivery-health.md
@@ -1,0 +1,98 @@
+# Discord Alert Delivery Health
+
+Use this runbook when Grafana alert state is healthy but Discord still shows stale or missing alert messages, or when the `pretty-discord-alerts` delivery failure alerts fire.
+
+## Scope
+
+- Treat Git as the source of truth for Grafana rules and routing.
+- Use live-cluster checks only to confirm current state and delivery symptoms.
+- Manual Discord message correction is operational cleanup. It is not a GitOps desired-state change and does not need a repository commit.
+
+## Confirm Grafana Rule State
+
+Check whether Grafana still believes the affected rules are firing.
+
+```bash
+kubectl get grafanaalertrulegroups.grafana.integreatly.org -n grafana
+kubectl describe grafanaalertrulegroup -n grafana apps
+kubectl describe grafanaalertrulegroup -n grafana observability
+```
+
+If needed, inspect the ruler API through a port-forward.
+
+```bash
+kubectl port-forward -n grafana svc/grafana 3000:80
+curl -fsS -u "$GRAFANA_USER:$GRAFANA_PASSWORD" \
+  http://127.0.0.1:3000/api/ruler/grafana/api/v1/rules | jq .
+```
+
+Expected result: the affected rule state is inactive or ok before treating Discord as the only stale surface.
+
+## Sanity-Check Mimir Queries
+
+Confirm the underlying alert expressions still evaluate as expected in Mimir. Use Grafana Explore or the Grafana Prometheus datasource and evaluate the exact expressions from the affected `GrafanaAlertRuleGroup`.
+
+Useful delivery-health checks:
+
+```promql
+sum(increase(webhook_discord_send_total{status="failure"}[10m])) OR vector(0)
+sum(increase(webhook_requests_total{status="discord_error"}[10m])) OR vector(0)
+sum by (pod) (increase(webhook_discord_send_total{status="failure"}[10m]))
+sum by (pod) (increase(webhook_requests_total{status="discord_error"}[10m]))
+```
+
+Expected result: app availability expressions are no longer firing, while any nonzero delivery-health result points at the relay or Discord webhook path.
+
+## Check Relay Replicas
+
+List the relay pods and confirm every replica is ready.
+
+```bash
+kubectl -n monitoring get deploy,rs,pods -l app=pretty-discord-alerts -o wide
+kubectl -n monitoring describe deploy pretty-discord-alerts
+kubectl -n monitoring get endpoints pretty-discord-alerts -o yaml
+```
+
+Check metrics per replica so one bad pod is not hidden by aggregate success from the others.
+
+```bash
+for pod in $(kubectl -n monitoring get pod -l app=pretty-discord-alerts -o name); do
+  kubectl -n monitoring port-forward "$pod" 18080:8080 >/tmp/pretty-discord-alerts-port-forward.log 2>&1 &
+  pf_pid=$!
+  sleep 2
+  echo "== $pod =="
+  curl -fsS http://127.0.0.1:18080/metrics | grep -E 'webhook_(discord_send|requests)_total'
+  kill "$pf_pid"
+  wait "$pf_pid" 2>/dev/null || true
+done
+```
+
+Expected result: failures are either absent or isolated to a specific replica that should be investigated with logs and events.
+
+## Inspect Logs And Events
+
+Review recent relay logs and Kubernetes events around the failure window.
+
+```bash
+kubectl -n monitoring logs deploy/pretty-discord-alerts --since=30m --tail=300
+kubectl -n monitoring get events --sort-by=.lastTimestamp
+kubectl -n grafana logs deploy/grafana --since=30m --tail=300
+kubectl -n grafana get events --sort-by=.lastTimestamp
+```
+
+Look for Discord HTTP errors, webhook secret issues, DNS or connection failures, Grafana contact point errors, pod restarts, and readiness probe failures.
+
+## Recover Discord-Only Stale Alerts
+
+If Grafana and Mimir show the alert is recovered but Discord still shows a stale firing message:
+
+1. Confirm the stale message is Discord-only by checking Grafana rule state and the source PromQL expression.
+2. Confirm `pretty-discord-alerts` is no longer recording new `status="failure"` or `status="discord_error"` increments.
+3. Manually correct or remove the stale Discord message if it is operationally confusing.
+4. Record the manual correction in the incident notes or operational handoff, not in Git.
+
+Do not change alert expressions, Flux state, or Kubernetes manifests solely to repair a stale Discord message.
+
+## Escalate
+
+Escalate when delivery failures continue after the relay is healthy and Grafana rule state is correct. Include the affected Grafana rule names, the Discord webhook failure metrics, relay logs, recent events, and whether failures are isolated to one `pretty-discord-alerts` replica.

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
@@ -434,3 +434,109 @@ spec:
                 type: query
             type: threshold
             refId: C
+
+    - uid: pretty-discord-alerts-send-failures
+      title: Pretty Discord Alerts Send Failures
+      condition: C
+      for: 5m
+      noDataState: NoData
+      execErrState: Error
+      annotations:
+        description: "pretty-discord-alerts recorded {{ $values.B.Value }} Discord send failure(s) over the last 10 minutes."
+        summary: Discord alert delivery is failing
+        runbook: "docs/runbooks/discord-alert-delivery-health.md"
+      labels:
+        severity: warning
+        component: observability
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: prometheus
+          model:
+            expr: sum(increase(webhook_discord_send_total{status="failure"}[10m])) OR vector(0)
+            refId: A
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: A
+            reducer: last
+            type: reduce
+            refId: B
+        - refId: C
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: B
+            conditions:
+              - evaluator:
+                  params:
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params:
+                    - C
+                type: query
+            type: threshold
+            refId: C
+
+    - uid: pretty-discord-alerts-webhook-discord-errors
+      title: Pretty Discord Alerts Webhook Discord Errors
+      condition: C
+      for: 5m
+      noDataState: NoData
+      execErrState: Error
+      annotations:
+        description: "pretty-discord-alerts returned {{ $values.B.Value }} discord_error webhook result(s) over the last 10 minutes."
+        summary: Grafana alert webhook delivery to Discord is failing
+        runbook: "docs/runbooks/discord-alert-delivery-health.md"
+      labels:
+        severity: warning
+        component: observability
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: prometheus
+          model:
+            expr: sum(increase(webhook_requests_total{status="discord_error"}[10m])) OR vector(0)
+            refId: A
+        - refId: B
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: A
+            reducer: last
+            type: reduce
+            refId: B
+        - refId: C
+          relativeTimeRange:
+            from: 600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: B
+            conditions:
+              - evaluator:
+                  params:
+                    - 0
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params:
+                    - C
+                type: query
+            type: threshold
+            refId: C


### PR DESCRIPTION
# discord-alert-delivery-health

## Summary

Add observability alerting for pretty-discord-alerts Discord delivery failures and document Discord-only stale alert recovery.

## Important Changes

- Added warning Grafana alerts for `webhook_discord_send_total{status="failure"}` and `webhook_requests_total{status="discord_error"}` increases over 10 minutes, guarded with `OR vector(0)`.
- Added `docs/runbooks/discord-alert-delivery-health.md` with checks for Grafana rule state, Mimir query sanity, per-replica relay metrics, relay/Grafana logs and events, and manual Discord-only stale message cleanup.
- Preserved existing PR 182 alert expressions and did not change live-cluster state.

## Documentation Impact

Added a new runbook for Discord-only stale alert recovery and pretty-discord-alerts delivery failure diagnostics. Generated architecture docs were not edited because `python3 tools/architecture/render.py --check` passed.

## Verification

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- `kubectl kustomize kubernetes/clusters/production >/tmp/homelab-discord-alert-delivery-health.yaml`
- `python3 tools/architecture/render.py --check`
- `pre-commit run --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml docs/runbooks/discord-alert-delivery-health.md`
- `git diff --check`

All verification passed.

## Workflow Notes

Implementation was performed by concrete owner agent `discord-alert-delivery-health-worker` in the sibling clone. Verifier approval is still pending and no PR has been created.
