### PR TITLE
fix(grafana): shorten observability alert uid

### DIFF
--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-observability.yaml
@@ -488,7 +488,7 @@ spec:
             type: threshold
             refId: C
 
-    - uid: pretty-discord-alerts-webhook-discord-errors
+    - uid: pretty-discord-webhook-errors
       title: Pretty Discord Alerts Webhook Discord Errors
       condition: C
       for: 5m


### PR DESCRIPTION
## Summary

- Shorten the observability Grafana alert rule UID for Pretty Discord Alerts webhook Discord errors from `pretty-discord-alerts-webhook-discord-errors` to `pretty-discord-webhook-errors`.
- Keep the alert title, expression, labels, runbook, and notification behavior unchanged.

## Important Changes From Plan

- Completed the planned UID rename so the `GrafanaAlertRuleGroup` satisfies the CRD 40 byte UID limit.
- No live-cluster changes were made.

## Documentation Impact

- No documentation changes were needed; this is a manifest validation fix only and does not change operator workflow, runbooks, architecture relationships, or alert semantics.

## Verification

- `awk '/^[[:space:]]*- uid:/ { uid=$3; gsub(/\"/, \"\", uid); if (length(uid) > 40) { printf \"%s:%d:%s:%d\\n\", FILENAME, FNR, uid, length(uid); bad=1 } } END { exit bad }' kubernetes/infra/monitoring/grafana/alerting/alert-rules-*.yaml`
- `kubectl kustomize kubernetes/infra/monitoring/grafana/alerting >/tmp/grafana-alerting-render.yaml`
- `python3 tools/architecture/render.py --check`
- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind verifier --attestation .codex/tmp/verifier-attestation.yaml --marker .codex/tmp/active-implementation --owner-attestation .codex/tmp/implementation-owner-attestation.yaml --head "$(git rev-parse HEAD)" --root "$(pwd)" --branch "$(git branch --show-current)"`

## Agent Fallback

- Implementation and verification were performed locally because the runtime policy only permits subagent delegation when explicitly requested, which blocks the default subagent workflow preference for this turn.
