### PR TITLE
feat(network): add external vpn gateway plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ All shared manifests use `${variable}` placeholders instead of hardcoded values.
 | `cluster_env` | `production` | Environment name |
 | `gateway_internal_ip` | `192.168.30.241` | L2 IP for the internal Gateway |
 | `gateway_passthrough_ip` | `192.168.30.242` | L2 IP for the TLS passthrough Gateway |
+| `gateway_external_ip` | `192.168.40.241` | L2 IP for the external WireGuard-reachable Gateway |
+| `gateway_external_passthrough_ip` | `192.168.40.242` | L2 IP for the external WireGuard-reachable TLS passthrough Gateway |
 | `nfs_server` | `192.168.30.99` | NFS server IP for storage |
 | `letsencrypt_server` | `https://acme-v02...` | ACME server URL (use staging for test envs) |
 | `wildcard_cert_name` | `wildcard-lab-petebeegle-com` | Name of the wildcard TLS Secret |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ This document is generated for agentic repo navigation. It records relationships
 
 - Production root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
-- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
+- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
 - App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`.
 
 ### Flux Substitution Variables
@@ -17,6 +17,8 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- |
 | `cluster_domain` | `lab.petebeegle.com` |
 | `cluster_env` | `production` |
+| `gateway_external_ip` | `192.168.40.241` |
+| `gateway_external_passthrough_ip` | `192.168.40.242` |
 | `gateway_internal_ip` | `192.168.30.241` |
 | `gateway_passthrough_ip` | `192.168.30.242` |
 | `letsencrypt_server` | `https://acme-v02.api.letsencrypt.org/directory` |
@@ -43,6 +45,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `monitoring` | `./kubernetes/infra/monitoring` | (none) | `cluster-vars` | `sops` |
 | `nfs-csi` | `./kubernetes/infra/controllers/nfs-csi` | (none) | `cluster-vars` | `no` |
 | `otel-collector` | `./kubernetes/infra/monitoring/otel-collector` | `crds`, `gateway` | `cluster-vars` | `no` |
+| `vpn` | `./kubernetes/infra/network/vpn` | `cilium`, `nfs-csi`, `gateway` | `cluster-vars` | `sops` |
 
 ### Applications
 
@@ -82,8 +85,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/monitoring/snmp-exporter` | `repositories.yaml`, `deployment.yaml`, `service.yaml`, `servicemonitor.yaml` |
 | `kubernetes/infra/network/certs` | `./issuer.yaml` |
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
-| `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
-| `kubernetes/infra/network` | `./cilium`, `./certs`, `./gateway` |
+| `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
+| `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
 | `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
@@ -101,7 +104,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
-| `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway` | `(none)` |
+| `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |
 | `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -73,6 +73,8 @@ spec:
 
 ## Internal HTTPRoute Template
 
+Use the internal Gateway for services that should stay on the `192.168.30.x` service plane.
+
 ```yaml
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -100,7 +102,7 @@ spec:
 
 ## External Service HTTPRoute Template
 
-Use this pattern for a service outside the cluster when the Gateway should present the trusted certificate or hide the backend port.
+Use this pattern for a service outside the cluster when the internal Gateway should present the trusted certificate or hide the backend port.
 If the backend only accepts HTTPS and cannot present a certificate trusted for the public hostname, add an in-cluster proxy and point the `HTTPRoute` at the proxy. Do not rely on `appProtocol: https` alone to make the Gateway originate HTTPS upstream.
 
 ```yaml
@@ -155,9 +157,38 @@ Add a matching Gateway HTTPS listener and cert-manager `Certificate` when the ho
 
 For HTTPS-only external backends with untrusted certificates or backend redirects that expose ports, use a small proxy Deployment instead of routing directly to the external `EndpointSlice`. The proxy can connect to the backend over HTTPS, set forwarded headers, and normalize redirects or response bodies before returning traffic to the Gateway route.
 
+## WireGuard External HTTPRoute Template
+
+Use this pattern for services that should be reachable on the `192.168.40.x` service plane through WireGuard.
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app-name>
+  namespace: <app-name>
+spec:
+  parentRefs:
+    - name: external
+      namespace: gateway
+      sectionName: https-gateway
+  hostnames:
+    - <app-name>.${cluster_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: <service-name>
+          port: <port>
+          weight: 1
+```
+
 ## External TLSRoute Template
 
-Use this pattern only when the external service should terminate TLS itself and already presents an acceptable certificate for the hostname.
+Use this pattern only when the external service should terminate TLS itself and already presents an acceptable certificate for the hostname on the internal `192.168.30.x` passthrough Gateway.
 Define the backing `Service` and `EndpointSlice` with the target TLS port, as shown in the external HTTPRoute example.
 
 ```yaml
@@ -171,6 +202,30 @@ spec:
   parentRefs:
     - name: passthrough
       namespace: gateway
+  hostnames:
+    - <hostname>
+  rules:
+    - backendRefs:
+        - name: <service-name>
+          port: <tls-port>
+```
+
+## WireGuard External TLSRoute Template
+
+Use this pattern for TLS passthrough services that should be reachable on the `192.168.40.x` service plane through WireGuard.
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: <service-name>-route
+  namespace: external
+spec:
+  parentRefs:
+    - name: external-passthrough
+      namespace: gateway
+      sectionName: tls-passthrough
   hostnames:
     - <hostname>
   rules:

--- a/kubernetes/clusters/production/cluster-vars.yaml
+++ b/kubernetes/clusters/production/cluster-vars.yaml
@@ -9,6 +9,8 @@ data:
   cluster_env: "production"
   gateway_internal_ip: "192.168.30.241"
   gateway_passthrough_ip: "192.168.30.242"
+  gateway_external_ip: "192.168.40.241"
+  gateway_external_passthrough_ip: "192.168.40.242"
   nfs_server: "192.168.30.99"
   letsencrypt_server: "https://acme-v02.api.letsencrypt.org/directory"
   wildcard_cert_name: "wildcard-lab-petebeegle-com"

--- a/kubernetes/clusters/production/infra/kustomization.yaml
+++ b/kubernetes/clusters/production/infra/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - cilium.yaml
   - certs.yaml
   - gateway.yaml
+  - vpn.yaml
   - monitoring.yaml
   - loki.yaml
   - mimir.yaml

--- a/kubernetes/clusters/production/infra/vpn.yaml
+++ b/kubernetes/clusters/production/infra/vpn.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vpn
+  namespace: flux-system
+spec:
+  interval: 2m
+  retryInterval: 2m
+  path: ./kubernetes/infra/network/vpn
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: cilium
+    - name: nfs-csi
+    - name: gateway
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/kubernetes/infra/network/cilium/ip-pool.yaml
+++ b/kubernetes/infra/network/cilium/ip-pool.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
   name: ip-pool
@@ -7,3 +7,15 @@ metadata:
 spec:
   blocks:
     - cidr: 192.168.30.240/28
+---
+apiVersion: cilium.io/v2
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: external-ip-pool
+  namespace: kube-system
+spec:
+  blocks:
+    - cidr: 192.168.40.240/28
+  serviceSelector:
+    matchLabels:
+      homelab.petebeegle.com/exposure: external

--- a/kubernetes/infra/network/gateway/gateway-external-passthrough.yaml
+++ b/kubernetes/infra/network/gateway/gateway-external-passthrough.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-passthrough
+  namespace: gateway
+spec:
+  gatewayClassName: cilium
+  infrastructure:
+    labels:
+      homelab.petebeegle.com/exposure: external
+    annotations:
+      io.cilium/lb-ipam-ips: ${gateway_external_passthrough_ip}
+  listeners:
+    - protocol: TLS
+      port: 443
+      name: tls-passthrough
+      hostname: "*.${cluster_domain}"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/infra/network/gateway/gateway-external.yaml
+++ b/kubernetes/infra/network/gateway/gateway-external.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external
+  namespace: gateway
+  annotations:
+    cert-manager.io/issuer: cloudflare
+spec:
+  gatewayClassName: cilium
+  infrastructure:
+    labels:
+      homelab.petebeegle.com/exposure: external
+    annotations:
+      io.cilium/lb-ipam-ips: ${gateway_external_ip}
+  listeners:
+    - protocol: HTTP
+      port: 80
+      name: http-gateway
+      allowedRoutes:
+        namespaces:
+          from: All
+    - protocol: HTTPS
+      port: 443
+      name: https-gateway
+      hostname: "*.${cluster_domain}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: ${wildcard_cert_name}
+      allowedRoutes:
+        namespaces:
+          from: All
+    - protocol: HTTPS
+      port: 443
+      name: https-domain-gateway
+      hostname: ${cluster_domain}
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: ${wildcard_cert_name}
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/infra/network/gateway/https-redirect.yaml
+++ b/kubernetes/infra/network/gateway/https-redirect.yaml
@@ -8,6 +8,8 @@ spec:
   parentRefs:
     - name: internal
       sectionName: http-gateway
+    - name: external
+      sectionName: http-gateway
   hostnames:
     - "*.${cluster_domain}"
     - ${cluster_domain}

--- a/kubernetes/infra/network/gateway/kustomization.yaml
+++ b/kubernetes/infra/network/gateway/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - ./certificate.yaml
   - ./gateway-internal.yaml
   - ./gateway-passthrough.yaml
+  - ./gateway-external.yaml
+  - ./gateway-external-passthrough.yaml
   - ./https-redirect.yaml
   - ./referencegrant.yaml

--- a/kubernetes/infra/network/gateway/referencegrant.yaml
+++ b/kubernetes/infra/network/gateway/referencegrant.yaml
@@ -1,5 +1,5 @@
 ---
-# Allow HTTPRoutes from application namespaces to reference the internal Gateway
+# Allow HTTPRoutes from application namespaces to reference shared Gateways.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -22,11 +22,14 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: external
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: wireguard
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway
 ---
-# Allow TLSRoutes from external namespace to reference the passthrough Gateway
+# Allow TLSRoutes from external namespace to reference shared passthrough Gateways.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:

--- a/kubernetes/infra/network/kustomization.yaml
+++ b/kubernetes/infra/network/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 resources:
   - ./cilium
   - ./certs
-  # - ./vpn
+  - ./vpn
   - ./gateway

--- a/kubernetes/infra/network/vpn/secret.yaml
+++ b/kubernetes/infra/network/vpn/secret.yaml
@@ -7,7 +7,7 @@ type: Opaque
 stringData:
   WG_HOST: ENC[AES256_GCM,data:BVAkK52CsMVgwsBqJA==,iv:sU/1/4bC5c4dloasSaQf16KuRHx8wxbkHjoHyJTLKSM=,tag:xz2F7310O8o8UC2eGiQ/ag==,type:str]
   WG_PORT: ENC[AES256_GCM,data:R4yOSyQ=,iv:G8UT/Hg/eP/rWKfdsSimFc2q5Mep0IgLVh0C9FQMXD0=,tag:qqT3xsqQ058E45sPRspwgA==,type:str]
-  WG_ALLOWED_IPS: ENC[AES256_GCM,data:b8l1mJQqDz79N4Cqxg==,iv:XFb8JO0of3BhrnX+duPl+6gT2Gc3V2srPOtI7c07F8I=,tag:lub2QM+eOCOPvXL9F3jmDA==,type:str]
+  WG_ALLOWED_IPS: ENC[AES256_GCM,data:ZulHRfOWEcEbMRnQTPNTrME5kv2aaeOUsm36qFg=,iv:3S79ZpgFp0LMoYg25L9mahpmASC2xb0wsu9Iyovxybo=,tag:tZOTzEBlERSCitb1nW7/aA==,type:str]
 sops:
   age:
     - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
@@ -19,7 +19,7 @@ sops:
         MGozd0NUQVhHWFJLSDlrWHZxaWxSekkK9Tc0HANTdB8U5X/FgiJITz0oceQ3mX1W
         drsISfRDi0wfPNQiBlV+47znoZCwMw+EXwtioLMYS6kWZlsk88WHSw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-06-22T00:51:59Z"
-  mac: ENC[AES256_GCM,data:FxfieBnlsdmNZAJePBs7ICY3ZVIXgg91k91viCT4FRlzlwyYYTUDWl+CyPSFcjpcX59xTKWEQoDRCdGAxRklSI1Xy4h5dM7n/8AN3mJeX0ZJ4fJStvJWIH688pTzw40FrmlEtAmrj0O62znxtPDA0b/LnkNsYiVzZnDhQkzQXCg=,iv:7ZxTwlqrJOOWXwVI29ERtOSYP6b/txE7Vh2dCI8RTXo=,tag:AprgwV3QBQfcSMen0NW9Eg==,type:str]
   encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-05-12T02:50:57Z"
+  mac: ENC[AES256_GCM,data:qca2jYsMcMiTv58c57Tb3PiGqWKFxPwZIwmrL0QX62nAZ5GCjajuh5/9f+2EX86RbKWCIDSNTgWoBJemlOvklM20idgL16t2Fzg2YmjH1M3Fy5b5+AV6S4zvl7s+QJaqHHvm2+0NKIyU15SaQpQ7CrjuLEfnVFMT/0cTYgYAwzY=,iv:92Rb4nG2GRXa02KrRt1Dmb/hOkdyJ5ZTjGCxTwuf71w=,tag:8fBsBqD1ecjYcpDczw9+HA==,type:str]
   version: 3.10.2


### PR DESCRIPTION
## Summary

Adds a 192.168.40.x external Gateway plane alongside the existing 192.168.30.x internal plane, activates the existing WireGuard component through Flux, and updates WireGuard allowed routes so clients can reach the external service subnet.

## Important Changes

- Adds production variables for `gateway_external_ip` and `gateway_external_passthrough_ip`.
- Adds external Gateway API resources for terminated HTTPS and TLS passthrough on the 40.x plane.
- Adds a 192.168.40.240/28 Cilium LB IP pool selected by external Gateway service labels.
- Activates the VPN Flux Kustomization with dependencies on Cilium, NFS CSI, and Gateway.
- Updates the encrypted WireGuard env secret to include the 192.168.40.0/24 route.

## Documentation Impact

Updated `README.md`, `docs/runbooks/add-app.md`, and regenerated `docs/architecture.md` to describe the external Gateway variables, route templates, and activated VPN dependency.

## Verification

- `kubectl kustomize kubernetes/clusters/production`
- `python3 tools/architecture/render.py --check`
- SOPS decrypt and encrypted marker checks for `kubernetes/infra/network/vpn/secret.yaml`
- Server dry-run for `kubernetes/infra/network/cilium`
- Server dry-run for substituted `kubernetes/infra/network/gateway`
- Client dry-run for decrypted/substituted `kubernetes/infra/network/vpn`
- `pre-commit run --all-files`

## Workflow Note

Self-verification fallback was used because higher-priority runtime policy blocks spawning implementation or verifier subagents unless the user explicitly asks for delegated subagent work.
