### PR TITLE
fix(network): correct wireguard image tag

### DIFF
--- a/kubernetes/infra/network/vpn/deployment.yaml
+++ b/kubernetes/infra/network/vpn/deployment.yaml
@@ -36,7 +36,7 @@ spec:
                 secretKeyRef:
                   name: wireguard-env
                   key: WG_ALLOWED_IPS
-          image: ghcr.io/wg-easy/wg-easy:v15.2.2
+          image: ghcr.io/wg-easy/wg-easy:15.2.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 30000


### PR DESCRIPTION
## Summary

Fixes the WireGuard deployment image reference so Kubernetes can pull the wg-easy container.

## Important Changes

- Replaces `ghcr.io/wg-easy/wg-easy:v15.2.2` with `ghcr.io/wg-easy/wg-easy:15.2.2`.

## Documentation Impact

No docs changed; this is a one-line image tag correction.

## Verification

- `docker manifest inspect ghcr.io/wg-easy/wg-easy:15.2.2`
- `kubectl kustomize kubernetes/infra/network/vpn`
- `pre-commit run --all-files`

## Workflow Note

Self-verification fallback was used because higher-priority runtime policy blocks spawning implementation or verifier subagents unless the user explicitly asks for delegated subagent work.
