### PR TITLE
fix(network): make wireguard hooks use nftables

### DIFF
--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -1,0 +1,26 @@
+# WireGuard
+
+Use this runbook to check the `wg-easy` deployment that provides VPN access to the external `192.168.40.x` service plane.
+
+## Client API Returns 500
+
+If `https://vpn.<cluster-domain>/api/client` returns HTTP 500, confirm that the WireGuard interface exists inside the pod:
+
+```bash
+kubectl -n wireguard exec deploy/wireguard -- wg show wg0 dump
+```
+
+If this fails with `Unable to access interface: No such device`, inspect the recent pod logs:
+
+```bash
+kubectl -n wireguard logs deploy/wireguard --since=10m --all-containers=true
+```
+
+On Talos, `wg-easy` default hooks may fail if they resolve to legacy `iptables` instead of nftables. The desired state provides `/opt/wg-hooks-bin/iptables` and `/opt/wg-hooks-bin/ip6tables` shims and prepends that directory to `PATH`, so the default hooks use `iptables-nft` and `ip6tables-nft`.
+
+After Flux reconciles a fix or after a pod restart, verify:
+
+```bash
+kubectl -n wireguard rollout status deploy/wireguard
+kubectl -n wireguard exec deploy/wireguard -- wg show wg0 dump
+```

--- a/kubernetes/infra/network/vpn/deployment.yaml
+++ b/kubernetes/infra/network/vpn/deployment.yaml
@@ -18,9 +18,26 @@ spec:
       labels:
         app.kubernetes.io/name: wireguard
     spec:
+      initContainers:
+        - name: iptables-nft-shims
+          image: ghcr.io/wg-easy/wg-easy:15.2.2
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              test -x /usr/sbin/iptables-nft
+              test -x /usr/sbin/ip6tables-nft
+              ln -sf /usr/sbin/iptables-nft /opt/wg-hooks-bin/iptables
+              ln -sf /usr/sbin/ip6tables-nft /opt/wg-hooks-bin/ip6tables
+          volumeMounts:
+            - mountPath: /opt/wg-hooks-bin
+              name: wg-hooks-bin
       containers:
         - name: wireguard
           env:
+            - name: PATH
+              value: /opt/wg-hooks-bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: WG_HOST
               valueFrom:
                 secretKeyRef:
@@ -83,10 +100,14 @@ spec:
                 - SYS_MODULE
           # Persistent storage location
           volumeMounts:
+            - mountPath: /opt/wg-hooks-bin
+              name: wg-hooks-bin
             - mountPath: /etc/wireguard
               name: config
       restartPolicy: Always
       volumes:
+        - name: wg-hooks-bin
+          emptyDir: {}
         - name: config
           persistentVolumeClaim:
             claimName: wireguard-pvc


### PR DESCRIPTION
# Fix WireGuard nftables hooks

## Summary

wg-easy was returning HTTP 500 from `/api/client` because `wg0` did not exist. Pod logs showed `wg-quick up wg0` failing when default hooks invoked legacy `iptables`, which is not available on the Talos host path. Live recovery patched the persisted wg-easy hook commands to use `iptables-nft` and confirmed `wg show wg0 dump` succeeds.

## Changes

- Add an `iptables-nft-shims` init container to the WireGuard Deployment.
- Mount an emptyDir at `/opt/wg-hooks-bin` and create `iptables` / `ip6tables` shims pointing at `iptables-nft` / `ip6tables-nft`.
- Prepend `/opt/wg-hooks-bin` to the wg-easy container `PATH` so default hook commands use nftables.
- Add `docs/runbooks/wireguard.md` with the `/api/client` 500 troubleshooting path.

## Documentation Impact

Added a WireGuard runbook note. `docs/architecture.md` was not regenerated because `python3 tools/architecture/render.py --check` passed without changes.

## Verification

- Live temporary remediation: scaled WireGuard down, patched the persisted wg-easy hooks on the PVC with a maintenance pod, scaled back up, and confirmed `wg show wg0 dump` returns data.
- `kubectl kustomize kubernetes/clusters/production`
- `kubectl kustomize kubernetes/infra/network/vpn`, confirming the rendered Deployment includes the shim init container and PATH override.
- `python3 tools/architecture/render.py --check`
- SOPS safety check confirmed `kubernetes/infra/network/vpn/secret.yaml` still has encrypted `stringData` and no plaintext `WG_HOST`.

Standalone `kustomize build kubernetes/clusters/production` could not run in this workspace because the `kustomize` binary is not installed; `kubectl kustomize` was used as the render fallback.

Self-verification fallback was used because the active runtime policy only permits subagents when explicitly requested by the user.
