### PR TITLE
feat(whoami): expose route on external gateway

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |
 | `HTTPRoute` | `pihole/pihole-httproute` | `pihole.${cluster_domain}` | `gateway/internal/https-gateway` | `pihole-web:80` |
-| `HTTPRoute` | `whoami/whoami` | `whoami.${cluster_domain}` | `gateway/internal/https-gateway` | `whoami:80` |
+| `HTTPRoute` | `whoami/whoami` | `whoami.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `whoami:80` |
 | `HTTPRoute` | `wireguard/wireguard-ui` | `vpn.${cluster_domain}` | `gateway/internal/https-gateway` | `wireguard-http:51821` |
 | `TLSRoute` | `external/pve01-route` | `pve01.petebeegle.com` | `gateway/passthrough` | `pve01:8006` |
 | `TLSRoute` | `external/pve02-route` | `pve02.petebeegle.com` | `gateway/passthrough` | `pve02:8006` |

--- a/kubernetes/apps/whoami/whoami.yaml
+++ b/kubernetes/apps/whoami/whoami.yaml
@@ -45,6 +45,9 @@ spec:
     - name: internal
       namespace: gateway
       sectionName: https-gateway
+    - name: external
+      namespace: gateway
+      sectionName: https-gateway
   hostnames:
     - whoami.${cluster_domain}
   rules:


### PR DESCRIPTION
# expose-whoami-external

## Implementation Summary

Expose `whoami` through the external WireGuard service plane while preserving the existing internal Gateway API route.

## Important Changes

- Added `gateway/external` as a second `parentRef` on the existing `whoami` `HTTPRoute`.
- Preserved the existing `gateway/internal` `parentRef`.
- Regenerated `docs/architecture.md`, which now shows `whoami/whoami` attached to both internal and external HTTPS gateways.

## Documentation Impact

- Updated generated architecture documentation with `python3 tools/architecture/render.py --write`.

## Tests And Verification

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/architecture/render.py --check` passed.
- `git diff --check` passed.
- `pre-commit run --all-files` passed.

## Fallback Notes

- Implementation was performed by implementation worker `019e1a71-4af4-7fa0-8289-871b080366b4` / `implementation-agent-expose-whoami-external`.
- Verifier approval was recorded by verifier worker `019e1a74-6baf-7d51-816f-6368fc65ce21` / `verifier-agent-expose-whoami-external` for `f9da5ca2d63a63f1c06bc57358a9f24dcdb49767`.
