### PR TITLE
feat(wireguard): persist wg-easy global defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
 | `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
 | `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
-| `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./httproute.yaml` |
+| `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |

--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -2,6 +2,41 @@
 
 Use this runbook to check the `wg-easy` deployment that provides VPN access to the external `192.168.40.x` service plane.
 
+## Client Routing Defaults
+
+Global wg-easy client defaults are managed in `kubernetes/infra/network/vpn/global-config.yaml`.
+The desired global `AllowedIPs` default is `192.168.40.0/24`; the desired global DNS defaults are `1.1.1.1` and `2606:4700:4700::1111`.
+
+wg-easy v15 stores these defaults in `/etc/wireguard/wg-easy.db`.
+The `wg-easy-defaults` initContainer runs before the main `wireguard` container and reconciles the `user_configs_table` row with `id = "wg0"` without querying or printing client secrets.
+The main container also receives `INIT_ENABLED`, `INIT_ALLOWED_IPS`, and `INIT_DNS` so a fresh database bootstraps with the same defaults.
+
+Existing clients keep the per-client values copied when they were created.
+If a client has the old route or DNS values, regenerate or edit that client once after the global defaults are corrected.
+
+Verify the stored defaults without selecting secret-bearing columns:
+
+```bash
+kubectl -n wireguard exec deploy/wireguard -- sh -ec 'cd /app/server && node -e '"'"'
+const { createRequire } = require("node:module");
+const { createClient } = createRequire("/app/server/package.json")("@libsql/client");
+const db = createClient({ url: "file:/etc/wireguard/wg-easy.db" });
+(async () => {
+  const result = await db.execute({
+    sql: "SELECT default_allowed_ips, default_dns FROM user_configs_table WHERE id = ?",
+    args: ["wg0"],
+  });
+  console.log(JSON.stringify(result.rows[0] ?? null, null, 2));
+  if (typeof db.close === "function") {
+    await db.close();
+  }
+})().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+'"'"''
+```
+
 ## Client API Returns 500
 
 If `https://vpn.<cluster-domain>/api/client` returns HTTP 500, confirm that the WireGuard interface exists inside the pod:

--- a/kubernetes/infra/network/vpn/deployment.yaml
+++ b/kubernetes/infra/network/vpn/deployment.yaml
@@ -19,6 +19,30 @@ spec:
         app.kubernetes.io/name: wireguard
     spec:
       initContainers:
+        - name: wg-easy-defaults
+          image: ghcr.io/wg-easy/wg-easy:15.2.2
+          imagePullPolicy: IfNotPresent
+          workingDir: /app/server
+          command:
+            - node
+            - /opt/wg-easy-defaults/reconcile-wg-easy-defaults.mjs
+          env:
+            - name: WG_EASY_DEFAULT_ALLOWED_IPS
+              valueFrom:
+                configMapKeyRef:
+                  name: wireguard-global-config
+                  key: default_allowed_ips
+            - name: WG_EASY_DEFAULT_DNS
+              valueFrom:
+                configMapKeyRef:
+                  name: wireguard-global-config
+                  key: default_dns
+          volumeMounts:
+            - mountPath: /etc/wireguard
+              name: config
+            - mountPath: /opt/wg-easy-defaults
+              name: wg-easy-defaults
+              readOnly: true
         - name: iptables-nft-shims
           image: ghcr.io/wg-easy/wg-easy:15.2.2
           imagePullPolicy: IfNotPresent
@@ -48,11 +72,18 @@ spec:
                 secretKeyRef:
                   name: wireguard-env
                   key: WG_PORT
-            - name: WG_ALLOWED_IPS
+            - name: INIT_ENABLED
+              value: "true"
+            - name: INIT_ALLOWED_IPS
               valueFrom:
-                secretKeyRef:
-                  name: wireguard-env
-                  key: WG_ALLOWED_IPS
+                configMapKeyRef:
+                  name: wireguard-global-config
+                  key: default_allowed_ips
+            - name: INIT_DNS
+              valueFrom:
+                configMapKeyRef:
+                  name: wireguard-global-config
+                  key: default_dns
           image: ghcr.io/wg-easy/wg-easy:15.2.2
           imagePullPolicy: IfNotPresent
           ports:
@@ -106,6 +137,9 @@ spec:
               name: config
       restartPolicy: Always
       volumes:
+        - name: wg-easy-defaults
+          configMap:
+            name: wireguard-global-config
         - name: wg-hooks-bin
           emptyDir: {}
         - name: config

--- a/kubernetes/infra/network/vpn/global-config.yaml
+++ b/kubernetes/infra/network/vpn/global-config.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wireguard-global-config
+  namespace: wireguard
+data:
+  default_allowed_ips: "192.168.40.0/24"
+  default_dns: "1.1.1.1,2606:4700:4700::1111"
+  reconcile-wg-easy-defaults.mjs: |
+    import { constants } from "node:fs";
+    import { access } from "node:fs/promises";
+    import { createRequire } from "node:module";
+
+    const dbPath = process.env.WG_EASY_DB_PATH || "/etc/wireguard/wg-easy.db";
+    const configId = process.env.WG_EASY_CONFIG_ID || "wg0";
+    const allowedIps = parseCsvEnv("WG_EASY_DEFAULT_ALLOWED_IPS");
+    const dns = parseCsvEnv("WG_EASY_DEFAULT_DNS");
+
+    await main();
+
+    async function main() {
+      try {
+        await access(dbPath, constants.F_OK);
+      } catch (error) {
+        if (error?.code === "ENOENT") {
+          console.log("wg-easy database not found; defaults will be reconciled on a later restart");
+          return;
+        }
+
+        throw error;
+      }
+
+      const requireFromApp = createRequire("/app/server/package.json");
+      const { createClient } = requireFromApp("@libsql/client");
+      const db = createClient({ url: `file:${dbPath}` });
+
+      try {
+        const current = await db.execute({
+          sql: "SELECT default_allowed_ips, default_dns FROM user_configs_table WHERE id = ?",
+          args: [configId],
+        });
+        const row = current.rows[0];
+
+        if (!row) {
+          console.log("wg-easy wg0 config row not found; leaving defaults unchanged");
+          return;
+        }
+
+        const desiredAllowedIps = JSON.stringify(allowedIps);
+        const desiredDns = JSON.stringify(dns);
+        const assignments = [];
+        const args = [];
+
+        if (!sameJsonArray(row.default_allowed_ips, allowedIps)) {
+          assignments.push("default_allowed_ips = ?");
+          args.push(desiredAllowedIps);
+        }
+
+        if (!sameJsonArray(row.default_dns, dns)) {
+          assignments.push("default_dns = ?");
+          args.push(desiredDns);
+        }
+
+        if (assignments.length === 0) {
+          console.log("wg-easy global defaults already up to date");
+          return;
+        }
+
+        args.push(configId);
+        await db.execute({
+          sql: `UPDATE user_configs_table SET ${assignments.join(", ")} WHERE id = ?`,
+          args,
+        });
+        console.log("Updated wg-easy global defaults");
+      } catch (error) {
+        console.error(`Failed to reconcile wg-easy global defaults: ${error?.message || error}`);
+        process.exitCode = 1;
+      } finally {
+        if (typeof db.close === "function") {
+          await db.close();
+        }
+      }
+    }
+
+    function parseCsvEnv(name) {
+      const value = process.env[name];
+      if (!value) {
+        throw new Error(`${name} must be set`);
+      }
+
+      return value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+    }
+
+    function sameJsonArray(rawValue, desired) {
+      if (typeof rawValue !== "string") {
+        return false;
+      }
+
+      try {
+        const parsed = JSON.parse(rawValue);
+        return Array.isArray(parsed) && arraysEqual(parsed, desired);
+      } catch {
+        return false;
+      }
+    }
+
+    function arraysEqual(left, right) {
+      return left.length === right.length && left.every((value, index) => value === right[index]);
+    }

--- a/kubernetes/infra/network/vpn/kustomization.yaml
+++ b/kubernetes/infra/network/vpn/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./global-config.yaml
   - ./secret.yaml
   - ./pvc.yaml
   - ./deployment.yaml

--- a/kubernetes/infra/network/vpn/secret.yaml
+++ b/kubernetes/infra/network/vpn/secret.yaml
@@ -7,7 +7,6 @@ type: Opaque
 stringData:
   WG_HOST: ENC[AES256_GCM,data:BVAkK52CsMVgwsBqJA==,iv:sU/1/4bC5c4dloasSaQf16KuRHx8wxbkHjoHyJTLKSM=,tag:xz2F7310O8o8UC2eGiQ/ag==,type:str]
   WG_PORT: ENC[AES256_GCM,data:R4yOSyQ=,iv:G8UT/Hg/eP/rWKfdsSimFc2q5Mep0IgLVh0C9FQMXD0=,tag:qqT3xsqQ058E45sPRspwgA==,type:str]
-  WG_ALLOWED_IPS: ENC[AES256_GCM,data:ZulHRfOWEcEbMRnQTPNTrME5kv2aaeOUsm36qFg=,iv:3S79ZpgFp0LMoYg25L9mahpmASC2xb0wsu9Iyovxybo=,tag:tZOTzEBlERSCitb1nW7/aA==,type:str]
 sops:
   age:
     - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
@@ -20,6 +19,6 @@ sops:
         drsISfRDi0wfPNQiBlV+47znoZCwMw+EXwtioLMYS6kWZlsk88WHSw==
         -----END AGE ENCRYPTED FILE-----
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-05-12T02:50:57Z"
-  mac: ENC[AES256_GCM,data:qca2jYsMcMiTv58c57Tb3PiGqWKFxPwZIwmrL0QX62nAZ5GCjajuh5/9f+2EX86RbKWCIDSNTgWoBJemlOvklM20idgL16t2Fzg2YmjH1M3Fy5b5+AV6S4zvl7s+QJaqHHvm2+0NKIyU15SaQpQ7CrjuLEfnVFMT/0cTYgYAwzY=,iv:92Rb4nG2GRXa02KrRt1Dmb/hOkdyJ5ZTjGCxTwuf71w=,tag:8fBsBqD1ecjYcpDczw9+HA==,type:str]
+  lastmodified: "2026-05-12T04:28:54Z"
+  mac: ENC[AES256_GCM,data:qh5yMwTS1Hl3m2Lev4X6ie12h1WOx/G0+asw8a6vJ5hAW3uKs4jpChrXEkVsR07NGEDt6ALzD2D8ITksN5Wwkq/Jo744lgDQ0y3kOC2/iHStz1TBKIOGKT4V48+NduGVicUNUP+iYJxlWb6urQChCk99X6amswpzQzDiJj86isU=,iv:+ExTypN0xPP8V7DmznurJC7YkoxF+wjN+wryNstXEGc=,tag:0RMbq1C2qNoGYtV+WZTeMQ==,type:str]
   version: 3.10.2


### PR DESCRIPTION
## Summary

Persist wg-easy v15 global client routing defaults through GitOps-managed bootstrap environment variables and an initContainer that reconciles the SQLite row before the main container starts.

## Important Changes

- Added `wireguard-global-config` with the desired global AllowedIPs, DNS defaults, and a Node/libsql reconciliation script.
- Added the `wg-easy-defaults` initContainer and v15 `INIT_*` bootstrap env vars to the WireGuard Deployment.
- Removed stale `WG_ALLOWED_IPS` wiring from the Deployment and encrypted Secret manifest.
- Updated the WireGuard runbook with defaults management, non-secret verification, and existing-client regeneration guidance.
- Refreshed the generated architecture document to include the new VPN ConfigMap.

## Documentation Impact

Updated `docs/runbooks/wireguard.md` and regenerated `docs/architecture.md`.

## Verification

- `kubectl kustomize kubernetes/infra/network/vpn`
- `kubectl kustomize kubernetes/clusters/production`
- `python3 tools/architecture/render.py --check`
- Workflow marker, plan, and owner attestation validation commands
- `sops filestatus kubernetes/infra/network/vpn/secret.yaml`
- `sops --decrypt kubernetes/infra/network/vpn/secret.yaml >/dev/null`
- Embedded Node module syntax check
- `pre-commit run --files ...`

## Workflow Notes

Implemented by `implementation-agent-wireguard-global-defaults` and approved by separate verifier `verifier-agent-wireguard-global-defaults` for the exact PR HEAD.
