### PR TITLE
fix(wireguard): avoid flux substitutions in defaults script

### DIFF
--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -53,6 +53,8 @@ kubectl -n wireguard logs deploy/wireguard --since=10m --all-containers=true
 
 On Talos, `wg-easy` default hooks may fail if they resolve to legacy `iptables` instead of nftables. The desired state provides `/opt/wg-hooks-bin/iptables` and `/opt/wg-hooks-bin/ip6tables` shims and prepends that directory to `PATH`, so the default hooks use `iptables-nft` and `ip6tables-nft`.
 
+Embedded scripts in ConfigMap data must avoid JavaScript template literals because Flux post-build substitution scans that syntax before applying manifests. Use string concatenation in those scripts instead.
+
 After Flux reconciles a fix or after a pod restart, verify:
 
 ```bash

--- a/kubernetes/infra/network/vpn/global-config.yaml
+++ b/kubernetes/infra/network/vpn/global-config.yaml
@@ -33,7 +33,7 @@ data:
 
       const requireFromApp = createRequire("/app/server/package.json");
       const { createClient } = requireFromApp("@libsql/client");
-      const db = createClient({ url: `file:${dbPath}` });
+      const db = createClient({ url: "file:" + dbPath });
 
       try {
         const current = await db.execute({
@@ -69,12 +69,12 @@ data:
 
         args.push(configId);
         await db.execute({
-          sql: `UPDATE user_configs_table SET ${assignments.join(", ")} WHERE id = ?`,
+          sql: "UPDATE user_configs_table SET " + assignments.join(", ") + " WHERE id = ?",
           args,
         });
         console.log("Updated wg-easy global defaults");
       } catch (error) {
-        console.error(`Failed to reconcile wg-easy global defaults: ${error?.message || error}`);
+        console.error("Failed to reconcile wg-easy global defaults: " + (error?.message || error));
         process.exitCode = 1;
       } finally {
         if (typeof db.close === "function") {
@@ -86,7 +86,7 @@ data:
     function parseCsvEnv(name) {
       const value = process.env[name];
       if (!value) {
-        throw new Error(`${name} must be set`);
+        throw new Error(name + " must be set");
       }
 
       return value


### PR DESCRIPTION
## Summary

Remove JavaScript template literals from the embedded WireGuard wg-easy defaults reconciliation script so Flux post-build substitution no longer interprets script text as substitution syntax.

## Important Changes

- Replaced template literals in `kubernetes/infra/network/vpn/global-config.yaml` with string concatenation.
- Added a short WireGuard runbook note warning against template literals in ConfigMap-embedded scripts.

## Documentation Impact

Updated `docs/runbooks/wireguard.md` with the embedded script guardrail.

## Verification

- Owner workflow marker, plan, and attestation validations passed.
- Targeted and production kustomize renders passed.
- Architecture check passed.
- Embedded Node script syntax validation passed.
- Targeted pre-commit passed.
- Separate verifier approval passed for the exact PR HEAD.

## Workflow Notes

Implemented by `implementation-agent-wireguard-envsubst-fix` and approved by separate verifier `verifier-agent-wireguard-envsubst-fix` for the exact PR HEAD.
