### PR TITLE
fix(wireguard): use libsql esm import for defaults

### DIFF
--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -17,9 +17,8 @@ If a client has the old route or DNS values, regenerate or edit that client once
 Verify the stored defaults without selecting secret-bearing columns:
 
 ```bash
-kubectl -n wireguard exec deploy/wireguard -- sh -ec 'cd /app/server && node -e '"'"'
-const { createRequire } = require("node:module");
-const { createClient } = createRequire("/app/server/package.json")("@libsql/client");
+kubectl -n wireguard exec deploy/wireguard -- sh -ec 'node --input-type=module -e '"'"'
+import { createClient } from "/app/server/node_modules/@libsql/client/lib-esm/node.js";
 const db = createClient({ url: "file:/etc/wireguard/wg-easy.db" });
 (async () => {
   const result = await db.execute({
@@ -36,6 +35,8 @@ const db = createClient({ url: "file:/etc/wireguard/wg-easy.db" });
 });
 '"'"''
 ```
+
+If the `wg-easy-defaults` initContainer fails with `Cannot find module` for `@libsql/client/lib-cjs/node.js`, confirm the ConfigMap script imports `createClient` from `/app/server/node_modules/@libsql/client/lib-esm/node.js`. The `ghcr.io/wg-easy/wg-easy:15.2.2` image ships that ESM build, but not the CJS build.
 
 ## Client API Returns 500
 

--- a/kubernetes/infra/network/vpn/global-config.yaml
+++ b/kubernetes/infra/network/vpn/global-config.yaml
@@ -10,7 +10,7 @@ data:
   reconcile-wg-easy-defaults.mjs: |
     import { constants } from "node:fs";
     import { access } from "node:fs/promises";
-    import { createRequire } from "node:module";
+    import { createClient } from "/app/server/node_modules/@libsql/client/lib-esm/node.js";
 
     const dbPath = process.env.WG_EASY_DB_PATH || "/etc/wireguard/wg-easy.db";
     const configId = process.env.WG_EASY_CONFIG_ID || "wg0";
@@ -31,8 +31,6 @@ data:
         throw error;
       }
 
-      const requireFromApp = createRequire("/app/server/package.json");
-      const { createClient } = requireFromApp("@libsql/client");
       const db = createClient({ url: "file:" + dbPath });
 
       try {


### PR DESCRIPTION
## Summary

Fix the wg-easy defaults initContainer by importing libsql from the ESM file path shipped in `ghcr.io/wg-easy/wg-easy:15.2.2`.

## Important Changes

- Updated `kubernetes/infra/network/vpn/global-config.yaml` so `reconcile-wg-easy-defaults.mjs` imports `createClient` from `/app/server/node_modules/@libsql/client/lib-esm/node.js`.
- Removed the now-unused `createRequire` import and `requireFromApp("@libsql/client")` path.
- Updated `docs/runbooks/wireguard.md` with an ESM-based verification snippet and a concise module-resolution troubleshooting note.

## Documentation Impact

Updated the WireGuard runbook with troubleshooting guidance for `wg-easy-defaults` module resolution failures.

## Verification

- Owner workflow marker, plan, and attestation validations passed.
- Targeted and production kustomize renders passed.
- Architecture check passed.
- Embedded Node script syntax validation passed.
- Forbidden-pattern check confirmed no Flux substitution syntax, backticks, or CJS libsql resolution remains in the ConfigMap script.
- Targeted pre-commit passed.
- Separate verifier approval passed for the exact PR HEAD.

## Workflow Notes

Implemented by `implementation-agent-wireguard-libsql-esm-fix` and approved by separate verifier `verifier-agent-wireguard-libsql-esm-fix` for the exact PR HEAD.

## Live Recovery

A temporary live ConfigMap patch using the same ESM import path was applied and the stuck WireGuard pod was restarted; `Deployment/wireguard` returned to `1/1` Ready. This PR makes that recovery durable in Git.
