### PR TITLE
feat(vpn): add WireGuard DNS service

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
 | `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
 | `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
-| `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./httproute.yaml` |
+| `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./vpn-dns.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |

--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -5,7 +5,8 @@ Use this runbook to check the `wg-easy` deployment that provides VPN access to t
 ## Client Routing Defaults
 
 Global wg-easy client defaults are managed in `kubernetes/infra/network/vpn/global-config.yaml`.
-The desired global `AllowedIPs` default is `192.168.40.0/24`; the desired global DNS defaults are `1.1.1.1` and `2606:4700:4700::1111`.
+The desired global `AllowedIPs` default is `192.168.40.0/24`; the desired global DNS default is `192.168.40.250`.
+That DNS address is the `vpn-dns` LoadBalancer service on the external service plane.
 
 wg-easy v15 stores these defaults in `/etc/wireguard/wg-easy.db`.
 The `wg-easy-defaults` initContainer runs before the main `wireguard` container and reconciles the `user_configs_table` row with `id = "wg0"` without querying or printing client secrets.
@@ -13,6 +14,19 @@ The main container also receives `INIT_ENABLED`, `INIT_ALLOWED_IPS`, and `INIT_D
 
 Existing clients keep the per-client values copied when they were created.
 If a client has the old route or DNS values, regenerate or edit that client once after the global defaults are corrected.
+
+## VPN DNS
+
+The `vpn-dns` CoreDNS service runs in the `wireguard` namespace and requests external LoadBalancer IP `192.168.40.250` from the Cilium external pool.
+It exposes DNS on TCP and UDP port 53 and is selected into that pool with the `homelab.petebeegle.com/exposure: external` service label.
+
+CoreDNS provides split-DNS behavior for VPN clients:
+
+- `*.lab.petebeegle.com` A queries return `192.168.40.241`.
+- All other queries forward to UniFi DNS at `192.168.1.1`.
+
+wg-easy copies the global DNS default into each client when the client is created.
+Existing clients that still use the previous DNS values must be edited or regenerated so their WireGuard profile uses `192.168.40.250`.
 
 Verify the stored defaults without selecting secret-bearing columns:
 

--- a/kubernetes/infra/network/vpn/global-config.yaml
+++ b/kubernetes/infra/network/vpn/global-config.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: wireguard
 data:
   default_allowed_ips: "192.168.40.0/24"
-  default_dns: "1.1.1.1,2606:4700:4700::1111"
+  default_dns: "192.168.40.250"
   reconcile-wg-easy-defaults.mjs: |
     import { constants } from "node:fs";
     import { access } from "node:fs/promises";

--- a/kubernetes/infra/network/vpn/kustomization.yaml
+++ b/kubernetes/infra/network/vpn/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./pvc.yaml
   - ./deployment.yaml
   - ./service.yaml
+  - ./vpn-dns.yaml
   - ./httproute.yaml

--- a/kubernetes/infra/network/vpn/vpn-dns.yaml
+++ b/kubernetes/infra/network/vpn/vpn-dns.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vpn-dns-config
+  namespace: wireguard
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health {
+            lameduck 5s
+        }
+        ready
+        template IN A lab.petebeegle.com {
+            match ^(.+\.)lab\.petebeegle\.com\.$
+            answer "{{ .Name }} 60 IN A 192.168.40.241"
+            fallthrough
+        }
+        forward . 192.168.1.1
+        cache 300
+        reload
+        loadbalance
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vpn-dns
+  namespace: wireguard
+spec:
+  replicas: 2
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vpn-dns
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vpn-dns
+    spec:
+      containers:
+        - name: coredns
+          image: registry.k8s.io/coredns/coredns:v1.12.4
+          imagePullPolicy: IfNotPresent
+          args:
+            - -conf
+            - /etc/coredns/Corefile
+          ports:
+            - containerPort: 53
+              name: dns-udp
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+            - containerPort: 8080
+              name: health
+              protocol: TCP
+            - containerPort: 8181
+              name: ready
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: health
+            periodSeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: ready
+            periodSeconds: 10
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/coredns
+              name: config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: vpn-dns-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpn-dns
+  namespace: wireguard
+  labels:
+    homelab.petebeegle.com/exposure: external
+  annotations:
+    io.cilium/lb-ipam-ips: 192.168.40.250
+spec:
+  type: LoadBalancer
+  ports:
+    - name: dns-udp
+      port: 53
+      protocol: UDP
+      targetPort: dns-udp
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: dns-tcp
+  selector:
+    app.kubernetes.io/name: vpn-dns


### PR DESCRIPTION
## Summary

Add a WireGuard-specific CoreDNS service on the external service plane and point new wg-easy client DNS defaults at it.

Implementation was done by implementation worker `implementation-agent-wireguard-vpn-dns`.

## Important Changes

- Added `vpn-dns` CoreDNS ConfigMap, Deployment, and LoadBalancer Service in the existing `wireguard` namespace.
- Exposed DNS on TCP and UDP port 53 with Cilium external pool label `homelab.petebeegle.com/exposure: external` and requested IP `192.168.40.250`.
- Configured CoreDNS so `*.lab.petebeegle.com` A queries answer `192.168.40.241`, while all other queries forward to UniFi DNS `192.168.1.1`.
- Preserved WireGuard `default_allowed_ips` as `192.168.40.0/24` and changed `default_dns` to `192.168.40.250`.

## Documentation Impact

- Updated `docs/runbooks/wireguard.md` with the VPN DNS service, split-DNS behavior, expected client defaults, and existing-client edit/regeneration requirement.
- Regenerated `docs/architecture.md` with the new VPN manifest relationship.

## Tests

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- `kubectl kustomize kubernetes/infra/network/vpn`
- `python3 tools/architecture/render.py --check`
- `git diff --cached --check`
- `pre-commit run --all-files`

## Verification Notes

Implementation was performed by implementation worker `019e1ab4-58c7-7fb3-9c48-688f47c438d9` / `implementation-agent-wireguard-vpn-dns`.
Verifier approval was recorded by verifier worker `019e1ab8-f12f-7742-b675-24251efb9273` / `verifier-agent-wireguard-vpn-dns` for `4f4f72e10cd9a27f723e5b083d89615b67c01bd8`.
