### PR TITLE
fix(yamllint): ignore generated Flux indentation

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -19,7 +19,9 @@ rules:
   empty-values: disable
   float-values: disable
   hyphens: enable
-  indentation: enable
+  indentation:
+    ignore: |
+      kubernetes/clusters/production/flux-system/gotk-*.yaml
   key-duplicates: enable
   key-ordering: disable
   line-length: disable


### PR DESCRIPTION
## Summary

Scope yamllint's indentation rule so generated Flux bootstrap manifests can keep Flux/Renovate's emitted block-sequence indentation.

## Important Changes

- Updated `.yamllint.yaml` to ignore only the `indentation` rule for `kubernetes/clusters/production/flux-system/gotk-*.yaml`.
- Kept all other yamllint rules active for generated Flux manifests.
- Left Flux manifests and human-authored YAML unchanged.

## Documentation Impact

No documentation changed. This is a linter compatibility tweak for generated files and does not change repo behavior or operator workflow.

## Verification

- `pre-commit run yamllint --all-files`
- Applied the new config in a temporary checkout of PR 197 and verified `pre-commit run yamllint --files kubernetes/clusters/production/flux-system/gotk-components.yaml` passes.
- `pre-commit run --all-files`

## Workflow Notes

- Self-verification fallback used because higher-priority runtime policy blocks spawning implementation or verifier subagents unless the user explicitly requests delegated subagent work.
