### PR TITLE
Expose Grafana and Authentik externally

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,11 +101,11 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
-| `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
+| `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
-| `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |
+| `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `grafana:80` |
 | `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |
 | `HTTPRoute` | `pihole/pihole-httproute` | `pihole.${cluster_domain}` | `gateway/internal/https-gateway` | `pihole-web:80` |

--- a/kubernetes/infra/authentik/httproute.yaml
+++ b/kubernetes/infra/authentik/httproute.yaml
@@ -9,6 +9,9 @@ spec:
     - name: internal
       namespace: gateway
       sectionName: https-gateway
+    - name: external
+      namespace: gateway
+      sectionName: https-gateway
   hostnames:
     - authentik.${cluster_domain}
   rules:

--- a/kubernetes/infra/monitoring/grafana/gateway.yaml
+++ b/kubernetes/infra/monitoring/grafana/gateway.yaml
@@ -9,6 +9,9 @@ spec:
     - name: internal
       namespace: gateway
       sectionName: https-gateway
+    - name: external
+      namespace: gateway
+      sectionName: https-gateway
   hostnames:
     - monitoring.${cluster_domain}
   rules:

--- a/kubernetes/infra/network/gateway/referencegrant.yaml
+++ b/kubernetes/infra/network/gateway/referencegrant.yaml
@@ -28,6 +28,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: grafana
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: authentik
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/kubernetes/infra/network/gateway/referencegrant.yaml
+++ b/kubernetes/infra/network/gateway/referencegrant.yaml
@@ -25,6 +25,9 @@ spec:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       namespace: wireguard
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: grafana
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway


### PR DESCRIPTION
## Summary

Expose Grafana and Authentik through the existing external Gateway while preserving their current hostnames and application configuration.

## Important Changes

- Added `gateway/external` `https-gateway` parent references to the Grafana `monitoring` HTTPRoute and Authentik HTTPRoute.
- Allowed the `grafana` and `authentik` namespaces to reference the shared Gateway through the existing `gateway/apps-to-internal-gateway` ReferenceGrant.
- Kept hostnames, certificates, DNS, Grafana `root_url`, Authentik OAuth callback URLs, secrets, and Helm values unchanged.

## Documentation Impact

Regenerated `docs/architecture.md` so the generated relationship map reflects the new external Gateway parent references. No new ADR or runbook was added because this follows the existing external Gateway pattern.

## Verification

- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- `kubectl kustomize kubernetes/infra/authentik`
- `kubectl kustomize kubernetes/infra/network/gateway`
- `python3 tools/architecture/render.py --check`

Verifier `verifier-agent-expose-grafana-authentik-external` approved exact HEAD `ab5cdc2117c6092b25961f0046a9181c15384c12` with no findings.
