### PR TITLE
feat: add public cloudflared gateway

### DIFF
--- a/.codex/runbooks/cloudflare-tunnels.md
+++ b/.codex/runbooks/cloudflare-tunnels.md
@@ -31,3 +31,20 @@ Create a proxied `CNAME` route for the tunnel:
 ```sh
 cloudflared tunnel route dns my-tunnel example.com
 ```
+
+## Route Public Apps
+
+Public Cloudflare hostnames should enter Kubernetes through `gateway/public`.
+Do not point cloudflared ingress rules directly at app Services.
+
+For each public hostname:
+
+1. Add a cloudflared ingress rule that sends the hostname to the public Gateway:
+
+   ```yaml
+   - hostname: app.petebeegle.com
+     service: http://cilium-gateway-public.gateway.svc.cluster.local:80
+   ```
+
+2. Add an app-owned `HTTPRoute` with `parentRefs` set to `gateway/public` and `sectionName: http-gateway`.
+3. Keep the final cloudflared fallback rule as `service: http_status:404`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,12 +85,12 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/monitoring/snmp-exporter` | `repositories.yaml`, `deployment.yaml`, `service.yaml`, `servicemonitor.yaml` |
 | `kubernetes/infra/network/certs` | `./issuer.yaml` |
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
-| `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
+| `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gatewayclass-public-nodeport.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./gateway-public.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
 | `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
 | `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./vpn-dns.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
-| `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |
+| `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml`, `httproute-public.yaml` |
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
 | `kubernetes/apps/renovate` | `app.yaml`, `secret.yaml` |
@@ -103,6 +103,7 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
+| `HTTPRoute` | `foundryvtt/foundryvtt-public` | `foundry2.petebeegle.com` | `gateway/public/http-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}, synology.petebeegle.com` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway` | `grafana:80` |

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -6,7 +6,7 @@ Use this runbook to add a Kubernetes app managed by Flux.
 
 - App name and namespace.
 - Deployment style: raw manifests or HelmRelease.
-- Exposure model: no route, Gateway-terminated `HTTPRoute`, or `TLSRoute` passthrough.
+- Exposure model: no route, LAN-only `internal` Gateway route, VPN-only `external` Gateway route, Cloudflare-open `public` Gateway route, or `TLSRoute` passthrough.
 - Storage needs, especially whether PVCs require `nfs-csi-storage`.
 - Secret needs; if present, also follow `docs/runbooks/add-secret.md`.
 
@@ -15,7 +15,7 @@ Use this runbook to add a Kubernetes app managed by Flux.
 1. Create `kubernetes/apps/<app-name>/`.
 2. Add `namespace.yaml` or include the Namespace in `app.yaml`.
 3. Add the workload manifest or HelmRelease.
-4. Add `httproute.yaml` for Gateway-terminated HTTP(S), or `tlsroute.yaml` for TLS passthrough.
+4. Add `httproute.yaml` for Gateway-terminated HTTP(S), `httproute-public.yaml` for Cloudflare-open HTTP exposure, or `tlsroute.yaml` for TLS passthrough.
 5. Add `kustomization.yaml` listing the app resources.
 6. Add `kubernetes/clusters/production/apps/<app-name>.yaml` as a Flux Kustomization.
 7. Add the new cluster-layer file to `kubernetes/clusters/production/apps/kustomization.yaml`.
@@ -99,6 +99,37 @@ spec:
           port: <port>
           weight: 1
 ```
+
+## Public Cloudflare HTTPRoute Template
+
+Use the public Gateway only for hostnames intentionally opened through Cloudflare Tunnel. Cloudflared forwards matching public DNS names to `gateway/public` over in-cluster HTTP, and the app owns the `HTTPRoute` that selects the backend Service.
+
+```yaml
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: <app-name>-public
+  namespace: <app-name>
+spec:
+  parentRefs:
+    - name: public
+      namespace: gateway
+      sectionName: http-gateway
+  hostnames:
+    - <public-hostname>
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: <service-name>
+          port: <port>
+          weight: 1
+```
+
+Add or update the corresponding `ConfigMap/cloudflared` ingress rule so the public hostname targets `http://cilium-gateway-public.gateway.svc.cluster.local:80`, not the app Service directly.
 
 ## External Service HTTPRoute Template
 

--- a/kubernetes/apps/cloudflare-tunnels/deployment.yaml
+++ b/kubernetes/apps/cloudflare-tunnels/deployment.yaml
@@ -103,8 +103,8 @@ data:
     # from the internet to cloudflared, run `cloudflared tunnel route dns <tunnel> <hostname>`.
     # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
     ingress:
-    # The first rule proxies traffic to the httpbin sample Service defined in app.yaml
+    # Public hostnames enter the cluster through gateway/public, then route by HTTPRoute.
     - hostname: foundry2.petebeegle.com
-      service: http://foundryvtt.foundryvtt:80
+      service: http://cilium-gateway-public.gateway.svc.cluster.local:80
     # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
     - service: http_status:404

--- a/kubernetes/apps/foundryvtt/httproute-public.yaml
+++ b/kubernetes/apps/foundryvtt/httproute-public.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foundryvtt-public
+  namespace: foundryvtt
+spec:
+  parentRefs:
+    - name: public
+      namespace: gateway
+      sectionName: http-gateway
+  hostnames:
+    - foundry2.petebeegle.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: foundryvtt
+          port: 80
+          weight: 1

--- a/kubernetes/apps/foundryvtt/kustomization.yaml
+++ b/kubernetes/apps/foundryvtt/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - httproute.yaml
+  - httproute-public.yaml

--- a/kubernetes/infra/network/gateway/gateway-public.yaml
+++ b/kubernetes/infra/network/gateway/gateway-public.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public
+  namespace: gateway
+spec:
+  gatewayClassName: cilium-public-nodeport
+  listeners:
+    - protocol: HTTP
+      port: 80
+      name: http-gateway
+      hostname: "*.petebeegle.com"
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/infra/network/gateway/gatewayclass-public-nodeport.yaml
+++ b/kubernetes/infra/network/gateway/gatewayclass-public-nodeport.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumGatewayClassConfig
+metadata:
+  name: public-nodeport
+  namespace: gateway
+spec:
+  service:
+    type: NodePort
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: cilium-public-nodeport
+spec:
+  controllerName: io.cilium/gateway-controller
+  description: Cilium GatewayClass for Cloudflare Tunnel public origins.
+  parametersRef:
+    group: cilium.io
+    kind: CiliumGatewayClassConfig
+    name: public-nodeport
+    namespace: gateway

--- a/kubernetes/infra/network/gateway/kustomization.yaml
+++ b/kubernetes/infra/network/gateway/kustomization.yaml
@@ -4,9 +4,11 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./certificate.yaml
+  - ./gatewayclass-public-nodeport.yaml
   - ./gateway-internal.yaml
   - ./gateway-passthrough.yaml
   - ./gateway-external.yaml
   - ./gateway-external-passthrough.yaml
+  - ./gateway-public.yaml
   - ./https-redirect.yaml
   - ./referencegrant.yaml


### PR DESCRIPTION
## Summary

Add a public Cloudflare Tunnel Gateway path and document how public hostnames enter the cluster through `gateway/public`.

## Important Changes

- Added a dedicated public Gateway and GatewayClass wiring for Cloudflare Tunnel traffic.
- Routed the public FoundryVTT hostname through an app-owned `HTTPRoute`.
- Updated app guidance and generated architecture docs with the public Cloudflare Gateway pattern.
- Kept `.codex/runbooks/cloudflare-tunnels.md` focused on Cloudflare Tunnel operations, including forwarding public hostnames to `gateway/public`, without duplicating the broader Gateway taxonomy.

## Documentation Impact

- Updated `.codex/runbooks/cloudflare-tunnels.md` for Cloudflare-specific routing guidance.
- Broader Gateway exposure guidance remains in `docs/runbooks/add-app.md` and generated `docs/architecture.md`.

## Verification

- Implementation owner and verifier subagents completed the workflow; verifier approved exact HEAD `55bde1ed008750592d918ed8e14636b64c2dc5f1`.
