### PR TITLE
Implementation: gateway-split-docs

### DIFF
--- a/.codex/runbooks/cloudflare-tunnels.md
+++ b/.codex/runbooks/cloudflare-tunnels.md
@@ -35,7 +35,7 @@ cloudflared tunnel route dns my-tunnel example.com
 ## Route Public Apps
 
 Public Cloudflare hostnames should enter Kubernetes through `gateway/public`.
-Do not point cloudflared ingress rules directly at app Services.
+Cloudflared forwards public traffic to the public Gateway over HTTP, and the app-owned `HTTPRoute` selects the backend Service. Do not point cloudflared ingress rules directly at app Services.
 
 For each public hostname:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,10 @@ Primary dependency chain:
 - Apps live in directories under `kubernetes/apps/` with a local Kustomization file, workload or HelmRelease manifests, optional secret manifests, and optional Gateway routes.
 - Apps are activated by Flux Kustomization files under `kubernetes/clusters/production/apps/`, then listed from `kubernetes/clusters/production/apps/kustomization.yaml`.
 - Shared manifests use variables such as `${cluster_domain}` and `${nfs_server}`.
-- Internal HTTP exposure uses `HTTPRoute` parent `gateway/internal`, section `https-gateway`.
-- External TLS passthrough uses `TLSRoute` against the passthrough Gateway for hosts outside the cluster.
+- LAN HTTP exposure uses `HTTPRoute` parent `gateway/internal`, section `https-gateway`.
+- WireGuard service-plane HTTP exposure uses `HTTPRoute` parent `gateway/external`, section `https-gateway`; this is not internet-public exposure.
+- Internet-public HTTP exposure enters through Cloudflare Tunnel to `gateway/public`, section `http-gateway`; public apps also need a cloudflared ingress rule.
+- LAN TLS passthrough uses `TLSRoute` parent `gateway/passthrough` for backends that terminate TLS themselves; `gateway/external-passthrough` is reserved for the same pattern on the WireGuard service plane.
 - Synology CSI runs in the `dataplane` namespace and must be healthy before PVC-backed workloads can schedule.
 
 ## Before Pushing Kubernetes Changes

--- a/docs/decisions/cilium-gateway-api-ingress.md
+++ b/docs/decisions/cilium-gateway-api-ingress.md
@@ -7,7 +7,7 @@ scope:
   - cilium
 authority: binding
 created: 2026-05-09
-last_verified: 2026-05-10
+last_verified: 2026-05-14
 supersedes: []
 superseded_by:
 ---
@@ -22,20 +22,24 @@ Use Cilium Gateway API for cluster ingress. Do not add traditional Kubernetes In
 
 - Cilium provides Gateway API support, L2 load balancer IP advertisement, and kube-proxy replacement in one networking layer.
 - Gateway API separates shared listener configuration from app-owned routes.
-- Existing apps use `HTTPRoute` for Gateway-terminated HTTPS and `TLSRoute` for passthrough to external services that terminate TLS themselves.
+- Existing apps use `HTTPRoute` for Gateway-terminated HTTPS or Cloudflare Tunnel HTTP routing, and `TLSRoute` for passthrough to services that terminate TLS themselves.
 - Cilium Gateway routes forward HTTP traffic to `HTTPRoute` backends. Use an explicit in-cluster proxy when an external backend must be contacted over HTTPS but cannot present a certificate trusted for the public hostname.
+- Cloudflare Tunnel public hostnames use a dedicated HTTP Gateway so app-owned routes still select the backend Service instead of pointing cloudflared directly at app Services.
 
 ## Consequences
 
-- Internal HTTP apps attach to Gateway `internal` in namespace `gateway`, section `https-gateway`.
+- LAN HTTP apps attach to Gateway `internal` in namespace `gateway`, section `https-gateway`.
+- WireGuard service-plane HTTP apps attach to Gateway `external` in namespace `gateway`, section `https-gateway`; this is not internet-public exposure.
+- Internet-public HTTP apps attach to Gateway `public` in namespace `gateway`, section `http-gateway`, and require a matching cloudflared ingress rule that targets `http://cilium-gateway-public.gateway.svc.cluster.local:80`.
 - Hostnames should use `${cluster_domain}` in shared manifests.
 - Cilium settings such as `kubeProxyReplacement: true` and L2 announcements are ingress-critical.
 - Use `HTTPRoute` when the cluster should provide the trusted certificate, normalize a public hostname, or hide a backend port.
-- Use `TLSRoute` passthrough only when the target should terminate TLS itself and presents an acceptable certificate for the hostname.
-- TLS passthrough targets terminate TLS themselves and do not need cert-manager certificates.
+- Use `TLSRoute` passthrough only when the target should terminate TLS itself and presents an acceptable certificate for the hostname. LAN passthrough uses Gateway `passthrough`; WireGuard service-plane passthrough uses Gateway `external-passthrough`.
+- TLS passthrough targets terminate TLS themselves and do not need cert-manager certificates. Passthrough route readiness also depends on the route being included in the app Kustomization, DNS outside this repo when applicable, and backend SNI/certificate behavior.
 
 ## Operational Notes
 
 - If a Gateway does not receive an IP, check Cilium L2 announcement and IP pool resources.
-- If TLS is failing for internal routes, verify cert-manager Certificates and the wildcard Secret.
+- If TLS is failing for Gateway-terminated routes, verify cert-manager Certificates and the wildcard Secret.
+- If passthrough is failing, verify `TLSRoute` attachment on the target Gateway, DNS to the correct Gateway address, and the backend TLS handshake with the expected SNI.
 - Verify routes with `kubectl get httproute -A` or `kubectl get tlsroute -A` and inspect `Accepted` and `Programmed` conditions.

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -6,7 +6,7 @@ Use this runbook to add a Kubernetes app managed by Flux.
 
 - App name and namespace.
 - Deployment style: raw manifests or HelmRelease.
-- Exposure model: no route, LAN-only `internal` Gateway route, VPN-only `external` Gateway route, Cloudflare-open `public` Gateway route, or `TLSRoute` passthrough.
+- Exposure model: no route, LAN-only `internal` Gateway route, WireGuard service-plane `external` Gateway route, internet-public Cloudflare `public` Gateway route, or `TLSRoute` passthrough.
 - Storage needs, especially whether PVCs require `nfs-csi-storage`.
 - Secret needs; if present, also follow `docs/runbooks/add-secret.md`.
 
@@ -15,11 +15,19 @@ Use this runbook to add a Kubernetes app managed by Flux.
 1. Create `kubernetes/apps/<app-name>/`.
 2. Add `namespace.yaml` or include the Namespace in `app.yaml`.
 3. Add the workload manifest or HelmRelease.
-4. Add `httproute.yaml` for Gateway-terminated HTTP(S), `httproute-public.yaml` for Cloudflare-open HTTP exposure, or `tlsroute.yaml` for TLS passthrough.
+4. Add `httproute.yaml` for Gateway-terminated HTTP(S), `httproute-public.yaml` for internet-public Cloudflare HTTP exposure, or `tlsroute.yaml` for TLS passthrough.
 5. Add `kustomization.yaml` listing the app resources.
 6. Add `kubernetes/clusters/production/apps/<app-name>.yaml` as a Flux Kustomization.
 7. Add the new cluster-layer file to `kubernetes/clusters/production/apps/kustomization.yaml`.
 8. Verify after Flux reconciles.
+
+## Choose Exposure
+
+- Use no route for jobs, private backends, and components reached only through in-cluster Services.
+- Use `gateway/internal` for LAN-only Gateway-terminated HTTP(S) on the `192.168.30.x` service plane.
+- Use `gateway/external` for WireGuard service-plane Gateway-terminated HTTP(S) on the `192.168.40.x` service plane. This is external to the LAN segment but not internet-public.
+- Use `gateway/public` only for internet-public hostnames intentionally opened through Cloudflare Tunnel. Public exposure needs both a cloudflared ingress rule and an app-owned `HTTPRoute`.
+- Use `gateway/passthrough` only when a LAN-reachable backend should terminate TLS itself. Use `gateway/external-passthrough` for the same pattern on the WireGuard service plane; it is reserved until a route needs it.
 
 ## HelmRelease Template
 
@@ -102,7 +110,7 @@ spec:
 
 ## Public Cloudflare HTTPRoute Template
 
-Use the public Gateway only for hostnames intentionally opened through Cloudflare Tunnel. Cloudflared forwards matching public DNS names to `gateway/public` over in-cluster HTTP, and the app owns the `HTTPRoute` that selects the backend Service.
+Use the public Gateway only for hostnames intentionally opened through Cloudflare Tunnel. Cloudflared forwards matching public DNS names to `gateway/public` over in-cluster HTTP, and the app owns the `HTTPRoute` that selects the backend Service. This Gateway does not terminate TLS; Cloudflare terminates public HTTPS before forwarding HTTP to the tunnel origin.
 
 ```yaml
 ---
@@ -129,9 +137,9 @@ spec:
           weight: 1
 ```
 
-Add or update the corresponding `ConfigMap/cloudflared` ingress rule so the public hostname targets `http://cilium-gateway-public.gateway.svc.cluster.local:80`, not the app Service directly.
+Add or update the corresponding `ConfigMap/cloudflared` ingress rule so the public hostname targets `http://cilium-gateway-public.gateway.svc.cluster.local:80`, not the app Service directly. Keep the final cloudflared fallback rule as `service: http_status:404`.
 
-## External Service HTTPRoute Template
+## Out-Of-Cluster Service HTTPRoute Template
 
 Use this pattern for a service outside the cluster when the internal Gateway should present the trusted certificate or hide the backend port.
 If the backend only accepts HTTPS and cannot present a certificate trusted for the public hostname, add an in-cluster proxy and point the `HTTPRoute` at the proxy. Do not rely on `appProtocol: https` alone to make the Gateway originate HTTPS upstream.
@@ -190,7 +198,7 @@ For HTTPS-only external backends with untrusted certificates or backend redirect
 
 ## WireGuard External HTTPRoute Template
 
-Use this pattern for services that should be reachable on the `192.168.40.x` service plane through WireGuard.
+Use this pattern for services that should be reachable on the `192.168.40.x` service plane through WireGuard. This `external` Gateway is VPN/service-plane exposure, not internet-public exposure.
 
 ```yaml
 ---
@@ -217,10 +225,10 @@ spec:
           weight: 1
 ```
 
-## External TLSRoute Template
+## LAN TLSRoute Passthrough Template
 
 Use this pattern only when the external service should terminate TLS itself and already presents an acceptable certificate for the hostname on the internal `192.168.30.x` passthrough Gateway.
-Define the backing `Service` and `EndpointSlice` with the target TLS port, as shown in the external HTTPRoute example.
+Define the backing `Service` and `EndpointSlice` with the target TLS port, as shown in the out-of-cluster HTTPRoute example. Also confirm the `TLSRoute` file is listed in the app Kustomization, DNS outside this repo points the hostname at the passthrough Gateway when applicable, and the backend accepts the expected SNI.
 
 ```yaml
 ---
@@ -241,9 +249,9 @@ spec:
           port: <tls-port>
 ```
 
-## WireGuard External TLSRoute Template
+## WireGuard TLSRoute Passthrough Template
 
-Use this pattern for TLS passthrough services that should be reachable on the `192.168.40.x` service plane through WireGuard.
+Use this pattern for TLS passthrough services that should be reachable on the `192.168.40.x` service plane through WireGuard. `gateway/external-passthrough` is reserved for this pattern; validate route attachment, DNS, and backend SNI before treating a new route as ready.
 
 ```yaml
 ---
@@ -276,6 +284,8 @@ resources:
   - app.yaml
   - httproute.yaml
 ```
+
+List `httproute-public.yaml` or `tlsroute.yaml` here when the app uses those exposure files.
 
 For large Helm values, create `values.yaml`, generate a ConfigMap, and reference it with `valuesFrom`.
 
@@ -313,7 +323,9 @@ Add `- name: nfs-csi` under `dependsOn` when the app uses NFS-backed PVCs.
 kubectl get kustomization -A
 kubectl get helmrelease -n <app-name>
 kubectl get pods -n <app-name>
+kubectl get gateway -n gateway
 kubectl get httproute -n <app-name>
+kubectl get tlsroute -n <app-name>
 ```
 
-Expected route conditions are `Accepted=True` and `Programmed=True`.
+Expected route conditions are `Accepted=True` and `Programmed=True`. For public apps, also verify the matching cloudflared ingress rule targets `http://cilium-gateway-public.gateway.svc.cluster.local:80`. For passthrough routes, verify the route attaches to the selected Gateway and the backend TLS handshake works with the route hostname as SNI.


### PR DESCRIPTION
## Summary
# Gateway Split Documentation Cleanup

## Summary

- Updated agent guidance, the Cilium Gateway API ADR, the add-app runbook, and the Cloudflare Tunnel runbook to describe the internal/external/public Gateway split.
- Clarified that `external` is the WireGuard service plane, `public` is Cloudflare Tunnel ingress through `gateway/public`, and passthrough patterns require route inclusion, DNS, and backend SNI validation.
- No Kubernetes manifests, DNS, Pi-hole, Flux, Terraform, or generated architecture files were changed.

## Documentation Impact

- Documentation-only implementation.
- `docs/architecture.md` was checked and left unchanged because no source manifests changed.

## Verification

- `python3 tools/architecture/render.py --check`
- `rg -n "Internal HTTP exposure|External TLS passthrough uses|VPN-only|Cloudflare-open|External TLSRoute Template|WireGuard External TLSRoute" AGENTS.md docs .codex/runbooks` returned no matches.
- Reviewed changed Markdown against the Gateway names and section names in `origin/main`.

## Workflow Notes

- Runtime policy allowed subagents only when explicitly requested, so implementation and verification were performed locally; this is the required self-verification fallback record.


## Changes
- .codex/runbooks/cloudflare-tunnels.md
- AGENTS.md
- docs/decisions/cilium-gateway-api-ingress.md
- docs/runbooks/add-app.md

## Commits
- f6ca10d docs: clarify gateway exposure split

## Verification
- Verified HEAD: `f6ca10d8cdcf249b69d1f7e559dd342fbd720087`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
