### PR TITLE
Implementation: flux-bootstrap-bash-interpreter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 
 - Treat Git as the source of truth. Change desired state in this repo, then let Flux reconcile it.
 - Keep live-cluster changes temporary unless a runbook explicitly says otherwise.
+- Codex may run Terraform and Flux against the development cluster for validation and repair when a task calls for it. Production remains GitOps-first; development live changes must still be made durable through repository changes.
 - Commit only SOPS-encrypted secret manifests. Kubernetes Secret files use repo path names ending with the standard secret manifest filenames matched by `.sops.yaml`.
 - Use Gateway API with Cilium for ingress. Prefer `HTTPRoute` or `TLSRoute` resources instead of traditional Kubernetes Ingress resources.
 - Use StorageClass `nfs-csi-storage` for persistent app storage unless a decision record supersedes it.

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -6,7 +6,7 @@ scope:
   - flux
 authority: operational
 created: 2026-05-14
-last_verified: 2026-05-14
+last_verified: 2026-05-15
 ---
 
 # Development Cluster
@@ -56,6 +56,8 @@ Keep `kubernetes_version` at a version supported by `talos_version`. It defaults
 
 ## Terraform Apply
 
+Codex may run Terraform and Flux commands against the development cluster for validation and repair. Keep production GitOps-first and do not apply production Terraform for development validation. Any development live change that fixes or validates behavior must still be made durable through tracked repository changes.
+
 ```sh
 cd terraform/development
 terraform init
@@ -64,6 +66,8 @@ terraform apply
 ```
 
 If `terraform apply` fails because Talos rejects a Kubernetes version as too new, check `talos_version` and `kubernetes_version` together before retrying. Do not work around this with live-cluster edits; update the Terraform variables and re-apply through Git.
+
+If Terraform bootstrap fails with `/bin/sh: set: Illegal option -o pipefail`, the Flux bootstrap script is being executed by Terraform's default inline `local-exec` shell. The shared `terraform/scripts/flux-install.sh` script is Bash and requires `pipefail`, so the `terraform_data.bootstrap_script` provisioner must set `interpreter = ["/usr/bin/env", "bash", "-c"]`.
 
 The Talos bootstrap module writes cluster-specific operator files by default:
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -85,6 +85,8 @@ resource "terraform_data" "bootstrap_script" {
   depends_on = [module.talos_bootstrap]
 
   provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-c"]
+
     environment = {
       FLUX_BOOTSTRAP_PATH = var.flux_bootstrap_path
       GITHUB_TOKEN        = var.github_token

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -85,6 +85,8 @@ resource "terraform_data" "bootstrap_script" {
   depends_on = [module.talos_bootstrap]
 
   provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-c"]
+
     environment = {
       FLUX_BOOTSTRAP_PATH = var.flux_bootstrap_path
       GITHUB_TOKEN        = var.github_token


### PR DESCRIPTION
## Summary
# flux-bootstrap-bash-interpreter

## Summary

Fix Terraform's Flux bootstrap `local-exec` provisioners so the shared Bash script runs under Bash instead of Terraform's default inline `/bin/sh`.

## Important Changes

- Added `interpreter = ["/usr/bin/env", "bash", "-c"]` to `terraform_data.bootstrap_script` in both `terraform/production/main.tf` and `terraform/development/main.tf`.
- Left `terraform/scripts/flux-install.sh` as Bash with `set -euo pipefail`.
- Updated `AGENTS.md` and `docs/runbooks/development-cluster.md` to allow Codex Terraform/Flux validation and repair against the development cluster while keeping production GitOps-first.
- Added the troubleshooting note for `/bin/sh: set: Illegal option -o pipefail`, explaining that Terraform inline `local-exec` uses `/bin/sh` unless `interpreter` is set and the bootstrap script requires Bash `pipefail`.

## Documentation Impact

Docs changed because the operational rule changed and the failure mode now has a documented diagnosis/remediation path:

- `AGENTS.md`
- `docs/runbooks/development-cluster.md`

`docs/architecture.md` was not edited by hand; `python3 tools/architecture/render.py --check` passed.

## Checks

- Passed: workflow marker/plan/owner attestation validations before tracked edits.
- Passed: workflow marker/plan/owner attestation validations after commit.
- Passed: `terraform fmt -check -recursive terraform`
- Passed: `terraform -chdir=terraform/production init -input=false`
- Passed: `terraform -chdir=terraform/production validate`
- Passed: `terraform -chdir=terraform/development init -input=false`
- Passed: `terraform -chdir=terraform/development validate`
- Passed: `bash -n terraform/scripts/flux-install.sh`
- Passed: static assertion that both bootstrap provisioners include `interpreter = ["/usr/bin/env", "bash", "-c"]`
- Passed: `kubectl kustomize kubernetes/clusters/production`
- Passed: `kubectl kustomize kubernetes/clusters/development`
- Passed: `python3 tools/architecture/render.py --check`
- Passed: `pre-commit run --all-files`

## Live Development Validation

Used `KUBECONFIG=~/.kube/homelab-development.config` and `TALOSCONFIG=~/.talos/homelab-development.config`; both files were present.

- Passed: `terraform -chdir=terraform/development init -input=false`
- Passed with unsafe apply scope: `terraform -chdir=terraform/development plan -input=false -no-color -out=../../.codex/tmp/development-validation.tfplan`
- Plan summary: `Plan: 11 to add, 0 to change, 0 to destroy.`
- Plan resource actions included full development cluster/bootstrap creation, including `proxmox_virtual_environment_file.talos_iso`, `terraform_data.bootstrap_script`, `module.kubernetes_nodes["192.168.30.170"].proxmox_virtual_environment_vm.kubernetes_node`, Talos bootstrap resources, and generated local kubeconfig/talosconfig files.
- Skipped: `terraform -chdir=terraform/development apply` because the plan was not limited to the intended bootstrap/interpreter recovery and would attempt broad development-cluster creation from this fresh clone state.
- Passed: `KUBECONFIG=~/.kube/homelab-development.config kubectl get nodes -o wide`; node `k8s-premium-martin` was Ready at `192.168.30.170`.
- Flux diagnostics failed because Flux is not installed in the development cluster:
  - `flux get sources git -A`: `source.toolkit.fluxcd.io/v1: no matches for source.toolkit.fluxcd.io/v1`
  - `flux get kustomizations -A`: `kustomize.toolkit.fluxcd.io/v1: no matches for kustomize.toolkit.fluxcd.io/v1`
  - `flux check`: `gitrepositories.source.toolkit.fluxcd.io` CRD not found; no Flux controllers or Flux CRDs found in `flux-system`
- `kubectl get namespace flux-system` showed the namespace exists, but `kubectl get crd | rg 'fluxcd|toolkit'` found no Flux CRDs.

## Skipped Checks Or Blockers

- Skipped live development Terraform apply because the saved plan wanted broad cluster creation rather than a narrow bootstrap/interpreter repair.
- Skipped production apply by design.
- Verifier approval is pending; no push or PR was created.
- Runtime subagent tooling for a separate verifier was unavailable in this session, so the implementation owner ran self-checks and recorded this fallback. Exact-HEAD verifier approval is still required before push or PR creation.

## Commit

- Branch: `codex/flux-bootstrap-bash-interpreter`
- Commit: `a0b46ff7bcf3b4371fa447cb6f8b5592b8e568e7`


## Changes
- AGENTS.md
- docs/runbooks/development-cluster.md
- terraform/development/main.tf
- terraform/production/main.tf

## Commits
- a0b46ff fix(terraform): run flux bootstrap script with bash

## Verification
- Verified HEAD: `a0b46ff7bcf3b4371fa447cb6f8b5592b8e568e7`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
