### PR TITLE
Implementation: deterministic-dev-deploy-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           TERRAFORM_DOCS_VERSION: "0.23.0"
         run: |
           set -euo pipefail
-          curl -sSLo terraform-docs.tar.gz \
+          curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors -sSLo terraform-docs.tar.gz \
             "https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
           tar -xzf terraform-docs.tar.gz terraform-docs
           sudo install -m 0755 terraform-docs /usr/local/bin/terraform-docs
@@ -190,7 +190,17 @@ jobs:
           node-version: "24.15.0"
 
       - name: Install Agnix
-        run: npm install --global agnix@0.25.0
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if npm install --global agnix@0.25.0; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              exit 1
+            fi
+            sleep 10
+          done
 
       - name: Validate agent instructions
         run: agnix .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,26 @@ jobs:
       - name: Validate Terraform root modules
         run: |
           set -euo pipefail
+
+          terraform_init_with_retry() {
+            local dir="$1"
+            local attempt
+
+            for attempt in 1 2 3; do
+              if terraform -chdir="${dir}" init -backend=false -input=false -no-color; then
+                return 0
+              fi
+
+              if [ "${attempt}" -eq 3 ]; then
+                echo "::error::terraform init failed for ${dir} after ${attempt} attempts"
+                return 1
+              fi
+
+              echo "terraform init failed for ${dir}; retrying in 10 seconds (attempt $((attempt + 1))/3)"
+              sleep 10
+            done
+          }
+
           for dir in \
             terraform/production \
             terraform/development \
@@ -100,7 +120,7 @@ jobs:
             terraform/external/synology
           do
             echo "::group::${dir}"
-            terraform -chdir="${dir}" init -backend=false -input=false -no-color
+            terraform_init_with_retry "${dir}"
             terraform -chdir="${dir}" validate -no-color
             echo "::endgroup::"
           done

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -120,7 +120,53 @@ Branch environments are for app-scoped validation on the development cluster. Us
 <app>-${branch_slug}.development.lab.petebeegle.com
 ```
 
-The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. To activate one, copy it into a reviewed cluster-layer path, set the real branch name and slug, and unsuspend both the `GitRepository` and Flux `Kustomization`.
+Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch-scoped app resources, and then removes the temporary branch Flux resources unless `--keep` is set.
+
+The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
+
+### Live App Acceptance
+
+Prerequisites:
+
+- The development cluster exists and the base Flux path is healthy.
+- `terraform`, `kubectl`, and `flux` are installed locally.
+- The default kubeconfig exists at `~/.kube/homelab-development.config`, or pass `--kubeconfig <path>`.
+- The branch named by `--branch` is available on origin. Use `--push` to push the current HEAD to origin as that branch before activation.
+- `--slug` is deterministic and DNS-safe: lowercase letters, numbers, and hyphens; starts and ends with an alphanumeric character; and is short enough for `whoami-${branch_slug}` Kubernetes names.
+
+Normal live verification:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+Run Terraform apply first when the development cluster base may need to be created or repaired:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --terraform-apply
+```
+
+Use a custom kubeconfig:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --kubeconfig ~/.kube/alternate-development.config
+```
+
+Keep the branch environment for debugging:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --keep --timeout 20m
+```
+
+When `--keep` is not set, cleanup is attempted after activation even if verification fails. Cleanup deletes the branch `Kustomization`, waits for the branch namespace to be pruned, and then deletes the branch `GitRepository`. If `--keep` is set, manually delete the Flux resources and confirm the namespace is gone before reusing the slug:
+
+```sh
+kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change
+kubectl --kubeconfig ~/.kube/homelab-development.config wait namespace/whoami-example-change --for=delete --timeout=10m
+kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gitrepository.source.toolkit.fluxcd.io/branch-example-change
+```
+
+This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the Deployment rolls out, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. It does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
 
 Local manifest verification does not require pushing a branch:
 
@@ -144,10 +190,6 @@ The live branch environment path does require a pushed branch when Flux reconcil
 ## Gateway Environment Overlays
 
 The shared gateway base at `kubernetes/infra/network/gateway` must stay environment-neutral: only `${cluster_domain}`, `*.${cluster_domain}`, `${wildcard_cert_name}`, and shared Gateway plumbing belong there. Production-only hostnames, certificates, listeners, and redirects such as Synology, Proxmox, and Unifi belong in additive overlays under `kubernetes/clusters/production/overlays/gateway`. The development cluster points directly at the shared base so local renders do not need deletion patches for production-only Gateway state.
-
-## Future Enhancements
-
-A small helper script or CLI should eventually create and remove branch environments from a branch name and slug. That tool can copy the activation template, fill `branch_name` and `branch_slug`, unsuspend or suspend the Flux resources, and clean up the activation when the branch test is done.
 
 ## Cluster-Scoped Testing
 

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -1,0 +1,9 @@
+# Development Tools
+
+`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. V1 supports `whoami` only.
+
+Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools" / "development" / "verify_branch_deploy.py"
+
+spec = importlib.util.spec_from_file_location("verify_branch_deploy", MODULE_PATH)
+verify = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["verify_branch_deploy"] = verify
+spec.loader.exec_module(verify)
+
+
+READY_HTTPROUTE = """{
+  "status": {
+    "parents": [
+      {
+        "conditions": [
+          {"type": "Accepted", "status": "True"},
+          {"type": "ResolvedRefs", "status": "True"}
+        ]
+      }
+    ]
+  }
+}"""
+
+
+TEMPLATE = """---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: branch-${branch_slug}
+  namespace: flux-system
+spec:
+  suspend: true
+  ref:
+    branch: ${branch_name}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: branch-whoami-${branch_slug}
+  namespace: flux-system
+spec:
+  suspend: true
+  sourceRef:
+    name: branch-${branch_slug}
+"""
+
+
+class FakeRunner:
+    quiet = True
+
+    def __init__(self, *, plan_returncode: int = 0, fail_on_rollout: bool = False, timeout_on: str | None = None) -> None:
+        self.plan_returncode = plan_returncode
+        self.fail_on_rollout = fail_on_rollout
+        self.timeout_on = timeout_on
+        self.calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def __call__(self, args: list[str], **kwargs: object) -> SimpleNamespace:
+        self.calls.append((args, kwargs))
+        command = " ".join(args)
+        if self.timeout_on and self.timeout_on in command:
+            raise subprocess.TimeoutExpired(args, kwargs.get("timeout"))
+        if args[0] == "terraform" and "plan" in args:
+            return SimpleNamespace(returncode=self.plan_returncode, stdout="")
+        if self.fail_on_rollout and "rollout status" in command:
+            return SimpleNamespace(returncode=1, stdout="")
+        if args[-2:] == ["-o", "json"]:
+            return SimpleNamespace(returncode=0, stdout=READY_HTTPROUTE)
+        return SimpleNamespace(returncode=0, stdout="")
+
+    @property
+    def commands(self) -> list[list[str]]:
+        return [call[0] for call in self.calls]
+
+
+class VerifyBranchDeployTest(unittest.TestCase):
+    def test_slug_validation_accepts_dns_safe_slug(self) -> None:
+        self.assertEqual(verify.validate_slug("example-change"), "example-change")
+        self.assertEqual(verify.validate_slug("a1"), "a1")
+
+    def test_slug_validation_rejects_non_deterministic_or_dns_unsafe_slug(self) -> None:
+        for slug in ("Example", "-example", "example-", "example_change", "a" * 57):
+            with self.subTest(slug=slug):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    verify.validate_slug(slug)
+
+    def test_template_rendering_substitutes_branch_and_unsuspends_flux_objects(self) -> None:
+        rendered = verify.render_activation_template(TEMPLATE, branch="codex/example-change", slug="example-change")
+
+        self.assertIn("name: branch-example-change", rendered)
+        self.assertIn("branch: codex/example-change", rendered)
+        self.assertEqual(rendered.count("suspend: false"), 2)
+        self.assertNotIn("${", rendered)
+
+    def test_timeout_parsing_supports_seconds_minutes_and_composites(self) -> None:
+        self.assertEqual(verify.parse_duration("300").raw, "300s")
+        self.assertEqual(verify.parse_duration("10m").seconds, 600)
+        self.assertEqual(verify.parse_duration("1h30m5s").seconds, 5405)
+        with self.assertRaises(argparse.ArgumentTypeError):
+            verify.parse_duration("soon")
+
+    def test_run_command_wraps_subprocess_timeout(self) -> None:
+        config = self._config()
+        runner = FakeRunner(timeout_on="rollout")
+
+        with self.assertRaisesRegex(verify.VerificationError, "timed out"):
+            verify.run_command(
+                verify.kubectl(config, "-n", config.namespace, "rollout", "status", f"deployment/{config.namespace}"),
+                runner=runner,
+                timeout=config.timeout,
+            )
+
+    def test_acceptance_command_sequence_uses_push_terraform_apply_reconcile_assert_and_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "terraform" / "development").mkdir(parents=True)
+            runner = FakeRunner(plan_returncode=2)
+            config = self._config(push=True, terraform_apply=True)
+
+            verify.run_acceptance(config, runner=runner, repo_root=root, template_text=TEMPLATE)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertIn("git push origin HEAD:refs/heads/codex/example-change", commands[0])
+        self.assertTrue(any("terraform -chdir=" in command and " init -input=false -no-color" in command for command in commands))
+        self.assertTrue(
+            any("terraform -chdir=" in command and " plan -detailed-exitcode -input=false -no-color" in command for command in commands)
+        )
+        self.assertTrue(any("terraform -chdir=" in command and " apply -input=false -no-color -auto-approve" in command for command in commands))
+        self.assertTrue(any("flux --kubeconfig /tmp/kubeconfig reconcile source git branch-example-change" in command for command in commands))
+        self.assertTrue(any("rollout status deployment/whoami-example-change" in command for command in commands))
+        self.assertTrue(any("delete kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change" in command for command in commands))
+        self.assertTrue(any("wait namespace/whoami-example-change --for=delete" in command for command in commands))
+        self.assertTrue(any("delete gitrepository.source.toolkit.fluxcd.io/branch-example-change" in command for command in commands))
+
+    def test_apply_uses_rendered_activation_stdin(self) -> None:
+        runner = FakeRunner()
+        config = self._config()
+        rendered = verify.render_activation_template(TEMPLATE, branch=config.branch, slug=config.slug)
+
+        verify.apply_activation(config, rendered, runner=runner)
+
+        command, kwargs = runner.calls[0]
+        self.assertEqual(command, ["kubectl", "--kubeconfig", "/tmp/kubeconfig", "apply", "-f", "-"])
+        self.assertEqual(kwargs["input"], rendered)
+
+    def test_httproute_assert_requires_accepted_and_resolved_refs_on_one_parent(self) -> None:
+        missing_resolved_refs = """{
+          "status": {
+            "parents": [
+              {"conditions": [{"type": "Accepted", "status": "True"}]},
+              {"conditions": [{"type": "ResolvedRefs", "status": "True"}]}
+            ]
+          }
+        }"""
+
+        with self.assertRaisesRegex(verify.VerificationError, "Accepted and ResolvedRefs"):
+            verify.assert_httproute_ready(missing_resolved_refs, route_name="whoami-example-change")
+
+    def test_cleanup_is_attempted_after_activation_failure_unless_keep_is_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "terraform" / "development").mkdir(parents=True)
+            runner = FakeRunner(fail_on_rollout=True)
+
+            with self.assertRaises(verify.VerificationError):
+                verify.run_acceptance(self._config(), runner=runner, repo_root=root, template_text=TEMPLATE)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("delete kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change" in command for command in commands))
+        self.assertTrue(any("delete gitrepository.source.toolkit.fluxcd.io/branch-example-change" in command for command in commands))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "terraform" / "development").mkdir(parents=True)
+            runner = FakeRunner(fail_on_rollout=True)
+
+            with self.assertRaises(verify.VerificationError):
+                verify.run_acceptance(self._config(keep=True), runner=runner, repo_root=root, template_text=TEMPLATE)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertFalse(any("delete kustomization.kustomize.toolkit.fluxcd.io" in command for command in commands))
+
+    def test_readme_and_runbook_examples_reference_real_cli_flags(self) -> None:
+        parser = verify.build_parser()
+        option_strings = {
+            option
+            for action in parser._actions
+            for option in action.option_strings
+        }
+        text = (REPO_ROOT / "tools/development/README.md").read_text(encoding="utf-8")
+        text += "\n"
+        text += (REPO_ROOT / "docs/runbooks/development-cluster.md").read_text(encoding="utf-8")
+
+        for flag in ("--app", "--branch", "--slug", "--push", "--terraform-apply", "--kubeconfig", "--timeout", "--keep"):
+            self.assertIn(flag, text)
+            self.assertIn(flag, option_strings)
+
+    def _config(
+        self,
+        *,
+        push: bool = False,
+        terraform_apply: bool = False,
+        keep: bool = False,
+    ) -> verify.AppConfig:
+        return verify.AppConfig(
+            app="whoami",
+            branch="codex/example-change",
+            slug="example-change",
+            kubeconfig=Path("/tmp/kubeconfig"),
+            timeout=verify.parse_duration("2m"),
+            push=push,
+            terraform_apply=terraform_apply,
+            keep=keep,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -85,6 +85,26 @@ class FakeRunner:
 
 
 class VerifyBranchDeployTest(unittest.TestCase):
+    def test_branch_validation_accepts_common_git_branch_name(self) -> None:
+        self.assertEqual(verify.validate_branch("codex/example-change"), "codex/example-change")
+
+    def test_branch_validation_rejects_git_invalid_patterns(self) -> None:
+        for branch in (
+            "bad..branch",
+            ".bad",
+            "good/.bad",
+            "bad.",
+            "good/bad.",
+            "good/bad.lock",
+            "bad//branch",
+            "bad@{branch",
+            "bad branch",
+            "-bad",
+        ):
+            with self.subTest(branch=branch):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    verify.validate_branch(branch)
+
     def test_slug_validation_accepts_dns_safe_slug(self) -> None:
         self.assertEqual(verify.validate_slug("example-change"), "example-change")
         self.assertEqual(verify.validate_slug("a1"), "a1")

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -95,9 +95,13 @@ def validate_app(app: str) -> str:
 def validate_branch(branch: str) -> str:
     if not branch or branch.startswith("/") or branch.endswith("/") or "//" in branch:
         raise argparse.ArgumentTypeError("branch must be a non-empty Git branch name")
-    if branch.startswith("-") or not BRANCH_PATTERN.fullmatch(branch):
+    if branch.startswith("-"):
+        raise argparse.ArgumentTypeError("branch must not start with '-'")
+    if ".." in branch or branch.endswith(".") or "@{" in branch:
+        raise argparse.ArgumentTypeError("branch must be valid for git check-ref-format --branch")
+    if not BRANCH_PATTERN.fullmatch(branch):
         raise argparse.ArgumentTypeError("branch may contain only letters, numbers, '.', '_', '-', and '/'")
-    if any(part in {"", ".", ".."} or part.endswith(".lock") for part in branch.split("/")):
+    if any(part.startswith(".") or part.endswith(".lock") for part in branch.split("/")):
         raise argparse.ArgumentTypeError("branch contains an invalid path component")
     return branch
 

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Verify an app-scoped branch deployment on the development cluster."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_KUBECONFIG = Path("~/.kube/homelab-development.config").expanduser()
+DEFAULT_TIMEOUT = "10m"
+FLUX_NAMESPACE = "flux-system"
+SUPPORTED_APPS = {"whoami"}
+
+BRANCH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,54}[a-z0-9])?$")
+DURATION_PATTERN = re.compile(r"^(?:(?P<hours>\d+)h)?(?:(?P<minutes>\d+)m)?(?:(?P<seconds>\d+)s)?$")
+
+
+@dataclass(frozen=True)
+class Duration:
+    raw: str
+    seconds: int
+
+
+@dataclass(frozen=True)
+class AppConfig:
+    app: str
+    branch: str
+    slug: str
+    kubeconfig: Path
+    timeout: Duration
+    push: bool
+    terraform_apply: bool
+    keep: bool
+
+    @property
+    def git_repository(self) -> str:
+        return f"branch-{self.slug}"
+
+    @property
+    def kustomization(self) -> str:
+        return f"branch-{self.app}-{self.slug}"
+
+    @property
+    def namespace(self) -> str:
+        return f"{self.app}-{self.slug}"
+
+
+class VerificationError(RuntimeError):
+    """Raised when validation or a live verification step fails."""
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str] | SimpleNamespace]
+
+
+def parse_duration(value: str) -> Duration:
+    if not value:
+        raise argparse.ArgumentTypeError("duration must not be empty")
+    if value.isdigit():
+        seconds = int(value)
+        if seconds <= 0:
+            raise argparse.ArgumentTypeError("duration must be greater than zero")
+        return Duration(raw=f"{seconds}s", seconds=seconds)
+
+    match = DURATION_PATTERN.fullmatch(value)
+    if not match:
+        raise argparse.ArgumentTypeError("duration must look like 300s, 10m, 1h, or 1h30m")
+
+    seconds = (
+        int(match.group("hours") or 0) * 3600
+        + int(match.group("minutes") or 0) * 60
+        + int(match.group("seconds") or 0)
+    )
+    if seconds <= 0:
+        raise argparse.ArgumentTypeError("duration must be greater than zero")
+    return Duration(raw=value, seconds=seconds)
+
+
+def validate_app(app: str) -> str:
+    if app not in SUPPORTED_APPS:
+        raise argparse.ArgumentTypeError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(SUPPORTED_APPS))}")
+    return app
+
+
+def validate_branch(branch: str) -> str:
+    if not branch or branch.startswith("/") or branch.endswith("/") or "//" in branch:
+        raise argparse.ArgumentTypeError("branch must be a non-empty Git branch name")
+    if branch.startswith("-") or not BRANCH_PATTERN.fullmatch(branch):
+        raise argparse.ArgumentTypeError("branch may contain only letters, numbers, '.', '_', '-', and '/'")
+    if any(part in {"", ".", ".."} or part.endswith(".lock") for part in branch.split("/")):
+        raise argparse.ArgumentTypeError("branch contains an invalid path component")
+    return branch
+
+
+def validate_slug(slug: str) -> str:
+    if not SLUG_PATTERN.fullmatch(slug):
+        raise argparse.ArgumentTypeError(
+            "slug must be a deterministic DNS-safe label: lowercase letters, numbers, hyphens, "
+            "start and end with alphanumeric characters, and be at most 56 characters"
+        )
+    return slug
+
+
+def render_activation_template(template_text: str, *, branch: str, slug: str) -> str:
+    validate_branch(branch)
+    validate_slug(slug)
+
+    rendered = template_text.replace("${branch_name}", branch).replace("${branch_slug}", slug)
+    rendered = re.sub(r"(^\s*suspend:\s*)true(\s*)$", r"\1false\2", rendered, flags=re.MULTILINE)
+    if "${" in rendered:
+        raise VerificationError("rendered activation still contains an unsubstituted placeholder")
+    if rendered.count("suspend: false") < 2:
+        raise VerificationError("rendered activation did not unsuspend both Flux resources")
+    return rendered
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify a whoami branch environment on the homelab development cluster."
+    )
+    parser.add_argument("--app", required=True, type=validate_app, choices=sorted(SUPPORTED_APPS))
+    parser.add_argument("--branch", required=True, type=validate_branch)
+    parser.add_argument("--slug", required=True, type=validate_slug)
+    parser.add_argument("--push", action="store_true", help="Push current HEAD to origin as --branch before activation.")
+    parser.add_argument("--terraform-apply", action="store_true", help="Run terraform apply after a successful plan.")
+    parser.add_argument("--kubeconfig", type=Path, default=DEFAULT_KUBECONFIG)
+    parser.add_argument("--timeout", type=parse_duration, default=parse_duration(DEFAULT_TIMEOUT))
+    parser.add_argument("--keep", action="store_true", help="Keep branch Flux resources for debugging.")
+    return parser
+
+
+def run_acceptance(
+    config: AppConfig,
+    *,
+    runner: Runner = subprocess.run,
+    repo_root: Path = REPO_ROOT,
+    template_text: str | None = None,
+) -> None:
+    activated = False
+    failure: BaseException | None = None
+
+    try:
+        if config.push:
+            push_branch(config, runner=runner, repo_root=repo_root)
+
+        run_terraform(config, runner=runner, repo_root=repo_root)
+
+        rendered = render_activation_template(
+            template_text
+            if template_text is not None
+            else (repo_root / "kubernetes/clusters/development/branches/whoami-template.yaml").read_text(encoding="utf-8"),
+            branch=config.branch,
+            slug=config.slug,
+        )
+        apply_activation(config, rendered, runner=runner)
+        activated = True
+
+        reconcile_flux(config, runner=runner)
+        assert_whoami(config, runner=runner)
+    except BaseException as exc:
+        failure = exc
+    finally:
+        if activated and not config.keep:
+            try:
+                cleanup_branch_environment(config, runner=runner)
+            except BaseException as cleanup_exc:
+                if failure is None:
+                    failure = cleanup_exc
+                else:
+                    print(f"cleanup failed after primary error: {cleanup_exc}", file=sys.stderr)
+
+    if failure is not None:
+        raise failure
+
+
+def push_branch(config: AppConfig, *, runner: Runner, repo_root: Path) -> None:
+    run_command(
+        ["git", "push", "origin", f"HEAD:refs/heads/{config.branch}"],
+        runner=runner,
+        cwd=repo_root,
+        timeout=config.timeout,
+    )
+
+
+def run_terraform(config: AppConfig, *, runner: Runner, repo_root: Path) -> None:
+    terraform_dir = "terraform/development"
+    terraform = "terraform"
+    run_command(
+        [terraform, f"-chdir={terraform_dir}", "init", "-input=false", "-no-color"],
+        runner=runner,
+        cwd=repo_root,
+        timeout=config.timeout,
+    )
+    run_command(
+        [terraform, f"-chdir={terraform_dir}", "validate", "-no-color"],
+        runner=runner,
+        cwd=repo_root,
+        timeout=config.timeout,
+    )
+    run_command(
+        [terraform, f"-chdir={terraform_dir}", "plan", "-detailed-exitcode", "-input=false", "-no-color"],
+        runner=runner,
+        cwd=repo_root,
+        timeout=config.timeout,
+        success_codes=(0, 2),
+    )
+    if config.terraform_apply:
+        run_command(
+            [terraform, f"-chdir={terraform_dir}", "apply", "-input=false", "-no-color", "-auto-approve"],
+            runner=runner,
+            cwd=repo_root,
+            timeout=config.timeout,
+        )
+
+
+def apply_activation(config: AppConfig, rendered: str, *, runner: Runner) -> None:
+    run_command(
+        kubectl(config, "apply", "-f", "-"),
+        runner=runner,
+        timeout=config.timeout,
+        input_text=rendered,
+    )
+
+
+def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
+    run_command(
+        flux(config, "reconcile", "source", "git", config.git_repository, "--namespace", FLUX_NAMESPACE, "--timeout", config.timeout.raw),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "wait",
+            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            "--for=condition=Ready",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        flux(
+            config,
+            "reconcile",
+            "kustomization",
+            config.kustomization,
+            "--namespace",
+            FLUX_NAMESPACE,
+            "--with-source",
+            "--timeout",
+            config.timeout.raw,
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "wait",
+            f"kustomization.kustomize.toolkit.fluxcd.io/{config.kustomization}",
+            "--for=condition=Ready",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+
+
+def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
+    name = config.namespace
+    run_command(kubectl(config, "get", "namespace", name), runner=runner, timeout=config.timeout)
+    run_command(
+        kubectl(config, "-n", name, "rollout", "status", f"deployment/{name}", f"--timeout={config.timeout.raw}"),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(kubectl(config, "-n", name, "get", "service", name), runner=runner, timeout=config.timeout)
+    route = run_command(
+        kubectl(config, "-n", name, "get", "httproute", name, "-o", "json"),
+        runner=runner,
+        timeout=config.timeout,
+        capture_output=True,
+    )
+    assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=name)
+
+
+def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
+    try:
+        route = json.loads(route_json)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"HTTPRoute {route_name} did not return valid JSON: {exc}") from exc
+
+    parents = route.get("status", {}).get("parents", [])
+    for parent in parents:
+        conditions = parent.get("conditions", [])
+        if all(
+            any(condition.get("type") == condition_type and condition.get("status") == "True" for condition in conditions)
+            for condition_type in ("Accepted", "ResolvedRefs")
+        ):
+            return
+    raise VerificationError(f"HTTPRoute {route_name} has no parent with Accepted and ResolvedRefs conditions")
+
+
+def cleanup_branch_environment(config: AppConfig, *, runner: Runner) -> None:
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "delete",
+            f"kustomization.kustomize.toolkit.fluxcd.io/{config.kustomization}",
+            "--ignore-not-found=true",
+            "--wait=true",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(config, "wait", f"namespace/{config.namespace}", "--for=delete", f"--timeout={config.timeout.raw}"),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "delete",
+            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            "--ignore-not-found=true",
+            "--wait=true",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+
+
+def kubectl(config: AppConfig, *args: str) -> list[str]:
+    return ["kubectl", "--kubeconfig", str(config.kubeconfig), *args]
+
+
+def flux(config: AppConfig, *args: str) -> list[str]:
+    return ["flux", "--kubeconfig", str(config.kubeconfig), *args]
+
+
+def run_command(
+    args: Sequence[str],
+    *,
+    runner: Runner,
+    timeout: Duration,
+    cwd: Path | None = None,
+    input_text: str | None = None,
+    capture_output: bool = False,
+    success_codes: tuple[int, ...] = (0,),
+) -> subprocess.CompletedProcess[str] | SimpleNamespace:
+    if not getattr(runner, "quiet", False):
+        print("+ " + shlex.join(str(arg) for arg in args))
+    try:
+        result = runner(
+            [str(arg) for arg in args],
+            cwd=str(cwd) if cwd is not None else None,
+            input=input_text,
+            text=True,
+            capture_output=capture_output,
+            timeout=timeout.seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise VerificationError(f"command timed out after {timeout.raw}: {shlex.join(str(arg) for arg in args)}") from exc
+
+    returncode = int(getattr(result, "returncode", 0))
+    if returncode not in success_codes:
+        raise VerificationError(
+            f"command failed with exit code {returncode}: {shlex.join(str(arg) for arg in args)}"
+        )
+    return result
+
+
+def config_from_args(args: argparse.Namespace) -> AppConfig:
+    return AppConfig(
+        app=args.app,
+        branch=args.branch,
+        slug=args.slug,
+        kubeconfig=args.kubeconfig.expanduser(),
+        timeout=args.timeout,
+        push=args.push,
+        terraform_apply=args.terraform_apply,
+        keep=args.keep,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    config = config_from_args(args)
+    try:
+        run_acceptance(config)
+    except VerificationError as exc:
+        print(f"verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
## Summary

Add `tools/development/verify_branch_deploy.py`, a documented live development-cluster acceptance helper for app-scoped `whoami` branch environments.

## Important Changes

- Validates supported app, Git branch, deterministic DNS-safe slug, and timeout values.
- Verifier follow-up strengthened Git branch validation to reject invalid ref names such as `bad..branch`.
- Optionally pushes current HEAD to origin as the requested branch with `--push`.
- Runs Terraform development init, validate, and plan; accepts plan exit codes 0 and 2; runs apply only with `--terraform-apply`.
- Renders `kubernetes/clusters/development/branches/whoami-template.yaml` with `branch_name` and `branch_slug`, unsuspends both Flux objects, applies the activation, reconciles Flux, checks namespace, Deployment rollout, Service, and HTTPRoute `Accepted`/`ResolvedRefs`.
- Cleans up the branch Kustomization, waits for namespace pruning, and deletes the branch GitRepository unless `--keep` is set.
- Adds unit tests with fake subprocess runners, so validation does not require a live cluster.

## Documentation Impact

Updated `docs/runbooks/development-cluster.md` with purpose, prerequisites, command examples, cleanup expectations, and proof boundaries. Added `tools/development/README.md` as a concise pointer to the runbook as operational authority.

## Verification

- `python3 -m unittest discover -s tools/codex-harness/tests`
- `python3 -m unittest discover -s tools/development/tests` (12 tests)
- `terraform fmt -check -recursive terraform`
- `kubectl kustomize kubernetes/clusters/development`

## Workflow Notes

Independent verifier approved exact HEAD `d80bbcc63100937213cef4f3adb94c41b82fce33`.


## Changes
- docs/runbooks/development-cluster.md
- tools/development/README.md
- tools/development/tests/test_verify_branch_deploy.py
- tools/development/verify_branch_deploy.py

## Commits
- d80bbcc fix: reject invalid branch deploy refs
- cb4251e feat: add deterministic branch deploy verifier

## Verification
- Verified HEAD: `d80bbcc63100937213cef4f3adb94c41b82fce33`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
