### PR TITLE
Implementation: codex-workflow-observability

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -5,7 +5,7 @@ hooks = true
 
 [[hooks.UserPromptSubmit.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/user_prompt_submit.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase user_prompt_submit --hook repo_change_intent --session-start -- \"$root/.codex/hooks/user_prompt_submit.sh\"'"
 timeout = 10
 statusMessage = "Checking repository change intent"
 
@@ -31,25 +31,25 @@ matcher = "^Bash$"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/implementation_workflow_guard.sh\" --record'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook implementation_workflow_record -- \"$root/.codex/hooks/implementation_workflow_guard.sh\" --record'"
 timeout = 10
 statusMessage = "Recording implementation workflow state"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/sops_guard.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook sops_guard -- \"$root/.codex/hooks/sops_guard.sh\"'"
 timeout = 30
 statusMessage = "Checking SOPS safety"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/terraform_plan.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook terraform_plan_guard -- \"$root/.codex/hooks/terraform_plan.sh\"'"
 timeout = 120
 statusMessage = "Checking Terraform apply safety"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/implementation_workflow_guard.sh\" --preflight-bash'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook implementation_workflow_preflight_bash -- \"$root/.codex/hooks/implementation_workflow_guard.sh\" --preflight-bash'"
 timeout = 30
 statusMessage = "Checking implementation workflow for mutating commands"
 
@@ -58,13 +58,13 @@ matcher = "^(apply_patch|Edit|MultiEdit|Write)$"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/implementation_workflow_guard.sh\" --record'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook implementation_workflow_record -- \"$root/.codex/hooks/implementation_workflow_guard.sh\" --record'"
 timeout = 10
 statusMessage = "Recording implementation workflow state"
 
 [[hooks.PreToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/implementation_workflow_guard.sh\" --preflight-mutation'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase pre_tool --hook implementation_workflow_preflight_mutation -- \"$root/.codex/hooks/implementation_workflow_guard.sh\" --preflight-mutation'"
 timeout = 30
 statusMessage = "Checking implementation workflow before editing"
 
@@ -73,25 +73,25 @@ matcher = "^(Bash|apply_patch|Edit|MultiEdit|Write)$"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/implementation_workflow_guard.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase post_tool --hook implementation_workflow_guard -- \"$root/.codex/hooks/implementation_workflow_guard.sh\"'"
 timeout = 30
 statusMessage = "Checking implementation workflow"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/sops_guard.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase post_tool --hook sops_guard -- \"$root/.codex/hooks/sops_guard.sh\"'"
 timeout = 60
 statusMessage = "Checking secret files"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/pre_commit_check.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase post_tool --hook pre_commit_check -- \"$root/.codex/hooks/pre_commit_check.sh\"'"
 timeout = 300
 statusMessage = "Running pre-commit checks"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/flux_reminder.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase post_tool --hook flux_reminder -- \"$root/.codex/hooks/flux_reminder.sh\"'"
 timeout = 10
 statusMessage = "Checking Flux follow-up"
 
@@ -99,12 +99,12 @@ statusMessage = "Checking Flux follow-up"
 
 [[hooks.Stop.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/hooks/stop_self_verify.sh\"'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase stop --hook stop_self_verify -- \"$root/.codex/hooks/stop_self_verify.sh\"'"
 timeout = 120
 statusMessage = "Running Codex harness self-check"
 
 [[hooks.Stop.hooks]]
 type = "command"
-command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec \"$root/.codex/scripts/create_implementation_pr.sh\" --auto'"
+command = "bash -lc 'root=$(git rev-parse --show-toplevel) && exec python3 \"$root/.codex/scripts/codex_observe.py\" --phase stop --hook create_implementation_pr --session-end -- \"$root/.codex/scripts/create_implementation_pr.sh\" --auto'"
 timeout = 300
 statusMessage = "Creating implementation PR"

--- a/.codex/scripts/codex_observe.py
+++ b/.codex/scripts/codex_observe.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_OTEL_ENDPOINT = "https://otel.lab.petebeegle.com/v1/metrics"
+DEFAULT_TIMEOUT_SECONDS = 1.0
+DEFAULT_FAILURE_COOLDOWN_SECONDS = 60.0
+NANOSECONDS_PER_SECOND = 1_000_000_000
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = sys.stdin.buffer.read()
+    root = repo_root()
+    labels = safe_labels(
+        payload=payload,
+        root=root,
+        phase=args.phase,
+        hook=args.hook,
+    )
+
+    session_start = time.time()
+    if args.session_start:
+        record_session_start(root=root, labels=labels, started_at=session_start)
+
+    started = time.time()
+    started_ns = time.time_ns()
+    status = "success"
+    return_code = 0
+    try:
+        completed = subprocess.run(args.command, input=payload, check=False)
+        return_code = completed.returncode
+        if return_code != 0:
+            status = "failure"
+    except FileNotFoundError as exc:
+        status = "failure"
+        return_code = 127
+        print(f"Codex observability: command not found: {exc.filename}", file=sys.stderr)
+
+    ended = time.time()
+    ended_ns = time.time_ns()
+    duration = max(0.0, ended - started)
+    labels["status"] = status
+
+    metrics = hook_metrics(root=root, labels=labels, duration=duration, started_ns=started_ns, ended_ns=ended_ns)
+    if args.session_end:
+        metrics.extend(session_metrics(root=root, labels=labels, ended_at=ended, ended_ns=ended_ns))
+
+    emit_metrics(root=root, labels=labels, metrics=metrics)
+    return return_code
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Wrap a Codex hook and emit best-effort workflow telemetry.")
+    parser.add_argument("--phase", required=True)
+    parser.add_argument("--hook", required=True)
+    parser.add_argument("--session-start", action="store_true")
+    parser.add_argument("--session-end", action="store_true")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a wrapped command is required after --")
+    return args
+
+
+def repo_root() -> Path:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return Path(completed.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return Path.cwd()
+
+
+def safe_labels(*, payload: bytes, root: Path, phase: str, hook: str) -> dict[str, str]:
+    branch = git_output(root, ["git", "branch", "--show-current"]) or "unknown"
+    return {
+        "repo": root.name or "unknown",
+        "branch": sanitize_label(branch),
+        "implementation": sanitize_label(implementation_name(root=root, branch=branch)),
+        "phase": sanitize_label(phase),
+        "hook": sanitize_label(hook),
+        "tool_name": sanitize_label(tool_name_from_payload(payload)),
+    }
+
+
+def implementation_name(*, root: Path, branch: str) -> str:
+    marker = root / ".codex" / "tmp" / "active-implementation"
+    if marker.exists():
+        try:
+            for line in marker.read_text(encoding="utf-8").splitlines():
+                if line.startswith("implementation="):
+                    return line.split("=", 1)[1].strip() or "unknown"
+        except OSError:
+            pass
+    if branch.startswith("codex/"):
+        return branch.split("/", 1)[1]
+    return "unknown"
+
+
+def tool_name_from_payload(payload: bytes) -> str:
+    try:
+        data = json.loads(payload.decode("utf-8")) if payload.strip() else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "unknown"
+    if not isinstance(data, dict):
+        return "unknown"
+    for key in ("tool_name", "tool", "name"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    tool_input = data.get("tool_input")
+    if isinstance(tool_input, dict):
+        value = tool_input.get("name")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def sanitize_label(value: str) -> str:
+    cleaned = "".join(char if char.isalnum() or char in "._/-" else "_" for char in value.strip())
+    return cleaned[:120] or "unknown"
+
+
+def git_output(root: Path, command: list[str]) -> str:
+    try:
+        completed = subprocess.run(command, cwd=root, check=True, capture_output=True, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+    return completed.stdout.strip()
+
+
+def hook_metrics(
+    *,
+    root: Path,
+    labels: dict[str, str],
+    duration: float,
+    started_ns: int,
+    ended_ns: int,
+) -> list[dict[str, Any]]:
+    return [
+        gauge_metric("codex_workflow_hook_duration_seconds", duration, labels, ended_ns),
+        counter_metric(root, "codex_workflow_hook_runs_total", 1, labels, started_ns, ended_ns),
+    ]
+
+
+def session_metrics(*, root: Path, labels: dict[str, str], ended_at: float, ended_ns: int) -> list[dict[str, Any]]:
+    started_at = read_session_started_at(root)
+    if started_at is None:
+        return []
+    duration = max(0.0, ended_at - started_at)
+    session_labels = {key: labels[key] for key in ("repo", "branch", "implementation", "status")}
+    return [
+        gauge_metric("codex_workflow_session_duration_seconds", duration, session_labels, ended_ns),
+        counter_metric(
+            root,
+            "codex_workflow_session_runs_total",
+            1,
+            session_labels,
+            int(started_at * NANOSECONDS_PER_SECOND),
+            ended_ns,
+        ),
+    ]
+
+
+def record_session_start(*, root: Path, labels: dict[str, str], started_at: float) -> None:
+    try:
+        observability_dir(root).mkdir(parents=True, exist_ok=True)
+        state = {
+            "started_at": started_at,
+            "repo": labels["repo"],
+            "branch": labels["branch"],
+            "implementation": labels["implementation"],
+        }
+        (observability_dir(root) / "session-start.json").write_text(
+            json.dumps(state, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+
+
+def read_session_started_at(root: Path) -> float | None:
+    path = observability_dir(root) / "session-start.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    value = data.get("started_at")
+    return float(value) if isinstance(value, (float, int)) else None
+
+
+def emit_metrics(*, root: Path, labels: dict[str, str], metrics: list[dict[str, Any]]) -> None:
+    if os.environ.get("CODEX_OBSERVABILITY_DISABLED") == "1":
+        return
+
+    metrics = [*prior_delivery_failure_metrics(root=root, labels=labels), *metrics]
+    if not metrics:
+        return
+
+    if telemetry_in_cooldown(root):
+        spool_event(root=root, labels=labels, reason="delivery cooldown active")
+        return
+
+    endpoint = os.environ.get("CODEX_OTEL_ENDPOINT", DEFAULT_OTEL_ENDPOINT)
+    timeout = env_float("CODEX_OTEL_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS)
+    body = json.dumps(otlp_payload(metrics)).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout):
+            pass
+        clear_delivery_cooldown(root)
+        clear_delivery_failures(root)
+    except (OSError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        record_delivery_cooldown(root)
+        spool_event(root=root, labels=labels, reason=str(exc))
+
+
+def prior_delivery_failure_metrics(*, root: Path, labels: dict[str, str]) -> list[dict[str, Any]]:
+    failure_labels = {key: labels[key] for key in ("repo", "branch", "implementation")}
+    failure_labels["status"] = "failure"
+    stored = stored_counter_metric(root, "codex_workflow_telemetry_delivery_failures_total", failure_labels)
+    return [stored] if stored else []
+
+
+def clear_delivery_failures(root: Path) -> None:
+    try:
+        spool_path(root).unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def telemetry_in_cooldown(root: Path) -> bool:
+    try:
+        data = json.loads(cooldown_path(root).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    next_attempt_at = data.get("next_attempt_at")
+    return isinstance(next_attempt_at, (float, int)) and time.time() < float(next_attempt_at)
+
+
+def record_delivery_cooldown(root: Path) -> None:
+    cooldown = env_float("CODEX_OTEL_FAILURE_COOLDOWN_SECONDS", DEFAULT_FAILURE_COOLDOWN_SECONDS)
+    try:
+        observability_dir(root).mkdir(parents=True, exist_ok=True)
+        cooldown_path(root).write_text(
+            json.dumps({"next_attempt_at": time.time() + max(0.0, cooldown)}, sort_keys=True),
+            encoding="utf-8",
+        )
+    except OSError:
+        return
+
+
+def clear_delivery_cooldown(root: Path) -> None:
+    try:
+        cooldown_path(root).unlink()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+
+
+def spool_event(*, root: Path, labels: dict[str, str], reason: str) -> None:
+    failure_labels = {key: labels[key] for key in ("repo", "branch", "implementation")}
+    failure_labels["status"] = "failure"
+    increment_counter_state(
+        root,
+        "codex_workflow_telemetry_delivery_failures_total",
+        failure_labels,
+        1,
+        time.time_ns(),
+    )
+    try:
+        path = spool_path(root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "observed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "labels": labels,
+            "reason": reason[:240],
+        }
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True))
+            handle.write("\n")
+    except OSError:
+        return
+
+
+def observability_dir(root: Path) -> Path:
+    return root / ".codex" / "tmp" / "observability"
+
+
+def spool_path(root: Path) -> Path:
+    return observability_dir(root) / "events.jsonl"
+
+
+def counters_path(root: Path) -> Path:
+    return observability_dir(root) / "counters.json"
+
+
+def cooldown_path(root: Path) -> Path:
+    return observability_dir(root) / "otel-cooldown.json"
+
+
+def env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, ""))
+    except ValueError:
+        return default
+
+
+def otlp_payload(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "codex-workflow"}},
+                    ],
+                },
+                "scopeMetrics": [
+                    {
+                        "scope": {"name": "homelab.codex.workflow", "version": "1.0.0"},
+                        "metrics": metrics,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def gauge_metric(name: str, value: float, labels: dict[str, str], time_unix_nano: int) -> dict[str, Any]:
+    return {
+        "name": name,
+        "gauge": {
+            "dataPoints": [
+                {
+                    "attributes": attributes(labels),
+                    "timeUnixNano": str(time_unix_nano),
+                    "asDouble": value,
+                }
+            ]
+        },
+    }
+
+
+def counter_metric(
+    root: Path,
+    name: str,
+    value: int,
+    labels: dict[str, str],
+    start_time_unix_nano: int,
+    time_unix_nano: int,
+) -> dict[str, Any]:
+    state = increment_counter_state(root, name, labels, value, start_time_unix_nano)
+    return counter_metric_data(
+        name,
+        state["value"],
+        labels,
+        state["start_time_unix_nano"],
+        time_unix_nano,
+    )
+
+
+def stored_counter_metric(root: Path, name: str, labels: dict[str, str]) -> dict[str, Any] | None:
+    counters = load_counters(root)
+    state = counters.get(counter_key(name, labels))
+    if not isinstance(state, dict):
+        return None
+    value = state.get("value")
+    start_time = state.get("start_time_unix_nano")
+    if not isinstance(value, int) or not isinstance(start_time, int):
+        return None
+    return counter_metric_data(name, value, labels, start_time, time.time_ns())
+
+
+def counter_metric_data(
+    name: str,
+    value: int,
+    labels: dict[str, str],
+    start_time_unix_nano: int,
+    time_unix_nano: int,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "sum": {
+            "aggregationTemporality": 2,
+            "isMonotonic": True,
+            "dataPoints": [
+                {
+                    "attributes": attributes(labels),
+                    "startTimeUnixNano": str(start_time_unix_nano),
+                    "timeUnixNano": str(time_unix_nano),
+                    "asInt": str(value),
+                }
+            ],
+        },
+    }
+
+
+def attributes(labels: dict[str, str]) -> list[dict[str, Any]]:
+    return [{"key": key, "value": {"stringValue": value}} for key, value in sorted(labels.items())]
+
+
+def increment_counter_state(
+    root: Path,
+    name: str,
+    labels: dict[str, str],
+    amount: int,
+    start_time_unix_nano: int,
+) -> dict[str, int]:
+    counters = load_counters(root)
+    key = counter_key(name, labels)
+    state = counters.get(key)
+    if not isinstance(state, dict):
+        state = {"value": 0, "start_time_unix_nano": start_time_unix_nano}
+    value = state.get("value", 0)
+    start_time = state.get("start_time_unix_nano", start_time_unix_nano)
+    if not isinstance(value, int):
+        value = 0
+    if not isinstance(start_time, int):
+        start_time = start_time_unix_nano
+    next_state = {"value": value + amount, "start_time_unix_nano": start_time}
+    counters[key] = next_state
+    save_counters(root, counters)
+    return next_state
+
+
+def load_counters(root: Path) -> dict[str, dict[str, int]]:
+    try:
+        data = json.loads(counters_path(root).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_counters(root: Path, counters: dict[str, dict[str, int]]) -> None:
+    try:
+        observability_dir(root).mkdir(parents=True, exist_ok=True)
+        counters_path(root).write_text(json.dumps(counters, sort_keys=True), encoding="utf-8")
+    except OSError:
+        return
+
+
+def counter_key(name: str, labels: dict[str, str]) -> str:
+    return json.dumps({"name": name, "labels": labels}, sort_keys=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
 | `kubernetes/infra/monitoring/alloy` | `repositories.yaml`, `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-kubernetes.yaml`, `alert-rules-certificates.yaml`, `alert-rules-gateway-cilium.yaml`, `alert-rules-observability.yaml`, `alert-rules-apps.yaml`, `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml` |
-| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml` |
+| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-workflow-dashboard.yaml` |
 | `kubernetes/infra/monitoring/grafana` | `namespace.yaml`, `repositories.yaml`, `app.yaml`, `secret.yaml`, `grafana-env.yaml`, `gateway.yaml`, `grafana-instance.yaml`, `folders.yaml`, `dashboards`, `alerting` |
 | `kubernetes/infra/monitoring/kube-state-metrics` | `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring` | `namespace.yaml`, `kube-state-metrics`, `snmp-exporter`, `pretty-discord-alerts` |

--- a/kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.json
@@ -1,0 +1,803 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStart": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Workflow Timing",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Most recent observed Codex workflow session duration.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(proxmox_codex_workflow_session_duration_seconds) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Latest Session Duration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of completed Codex workflow sessions observed in the selected range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(proxmox_codex_workflow_session_runs_total[$__range])) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Slowest observed hook durations by phase and hook.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, max by (phase, hook) (proxmox_codex_workflow_hook_duration_seconds))",
+          "legendFormat": "{{phase}} / {{hook}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Slowest Hooks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Hook execution volume by phase.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (phase) (increase(proxmox_codex_workflow_hook_runs_total[$__rate_interval]))",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Hook Runs By Phase",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Recent session durations over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (implementation, status) (proxmox_codex_workflow_session_duration_seconds)",
+          "legendFormat": "{{implementation}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Session Duration Over Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Known Slow Paths",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Pre-commit hook duration and run count.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "runs"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(proxmox_codex_workflow_hook_duration_seconds{hook=\"pre_commit_check\"})",
+          "legendFormat": "duration",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(proxmox_codex_workflow_hook_runs_total{hook=\"pre_commit_check\"}[$__rate_interval]))",
+          "legendFormat": "runs",
+          "refId": "B"
+        }
+      ],
+      "title": "Pre-commit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Implementation workflow guard duration and failed runs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failures"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (hook) (proxmox_codex_workflow_hook_duration_seconds{hook=~\"implementation_workflow.*\"})",
+          "legendFormat": "{{hook}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(proxmox_codex_workflow_hook_runs_total{hook=~\"implementation_workflow.*\",status=\"failure\"}[$__rate_interval]))",
+          "legendFormat": "failures",
+          "refId": "B"
+        }
+      ],
+      "title": "Workflow Guard",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Stop-phase self-check and automatic PR creation durations.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (hook, status) (proxmox_codex_workflow_hook_duration_seconds{phase=\"stop\"})",
+          "legendFormat": "{{hook}} / {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Stop Hooks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Telemetry delivery failures that were observed locally and reported on a later successful OTLP request.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(proxmox_codex_workflow_telemetry_delivery_failures_total[$__range])) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Telemetry Delivery Failures",
+      "type": "stat"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "codex",
+    "workflow",
+    "observability"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Codex Workflow",
+  "uid": "codex-workflow",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: codex-workflow
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "monitoring"
+  configMapRef:
+    name: codex-workflow-dashboard
+    key: dashboard.json

--- a/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
@@ -33,9 +33,16 @@ configMapGenerator:
       - dashboard.json=observability-health-dashboard.json
     options:
       disableNameSuffixHash: true
+  - name: codex-workflow-dashboard
+    namespace: grafana
+    files:
+      - dashboard.json=codex-workflow-dashboard.json
+    options:
+      disableNameSuffixHash: true
 resources:
   - proxmox-dashboard.yaml
   - flux-dashboard.yaml
   - kubernetes-dashboard.yaml
   - authentik-dashboard.yaml
   - observability-health-dashboard.yaml
+  - codex-workflow-dashboard.yaml

--- a/tools/codex-harness/tests/test_codex_observe.py
+++ b/tools/codex-harness/tests/test_codex_observe.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import http.server
+import importlib.util
+import json
+import os
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / ".codex" / "scripts" / "codex_observe.py"
+SPEC = importlib.util.spec_from_file_location("codex_observe", MODULE_PATH)
+assert SPEC is not None
+observer = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = observer
+SPEC.loader.exec_module(observer)
+
+
+class Receiver(http.server.BaseHTTPRequestHandler):
+    requests: list[dict[str, object]] = []
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.__class__.requests.append(
+            {
+                "path": self.path,
+                "content_type": self.headers.get("Content-Type"),
+                "body": body,
+            }
+        )
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+class ThreadedTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+class CodexObserveTest(unittest.TestCase):
+    def setUp(self) -> None:
+        Receiver.requests = []
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def run_observer(
+        self,
+        *command: str,
+        endpoint: str | None = None,
+        disabled: bool = False,
+        payload: bytes = b'{"tool_name":"Bash","command":"do not record this"}',
+    ) -> subprocess.CompletedProcess[bytes]:
+        env = os.environ.copy()
+        env["CODEX_OTEL_TIMEOUT_SECONDS"] = "0.2"
+        if endpoint is not None:
+            env["CODEX_OTEL_ENDPOINT"] = endpoint
+        if disabled:
+            env["CODEX_OBSERVABILITY_DISABLED"] = "1"
+        return subprocess.run(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "--phase",
+                "post_tool",
+                "--hook",
+                "unit_test_hook",
+                "--",
+                *command,
+            ],
+            cwd=self.root,
+            input=payload,
+            env=env,
+            check=False,
+            capture_output=True,
+        )
+
+    def test_successful_command_records_otlp_metrics(self) -> None:
+        with ThreadedTCPServer(("127.0.0.1", 0), Receiver) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            result = self.run_observer(
+                sys.executable,
+                "-c",
+                "print('ok')",
+                endpoint=f"http://127.0.0.1:{server.server_address[1]}/v1/metrics",
+            )
+            server.shutdown()
+            thread.join(timeout=2)
+
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.assertEqual(len(Receiver.requests), 1)
+        request = Receiver.requests[0]
+        self.assertEqual(request["path"], "/v1/metrics")
+        self.assertEqual(request["content_type"], "application/json")
+        body = json.loads(request["body"])
+        metrics = body["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+        metric_names = {metric["name"] for metric in metrics}
+        self.assertIn("codex_workflow_hook_duration_seconds", metric_names)
+        self.assertIn("codex_workflow_hook_runs_total", metric_names)
+
+    def test_failed_command_preserves_exit_code(self) -> None:
+        result = self.run_observer(
+            sys.executable,
+            "-c",
+            "raise SystemExit(42)",
+            disabled=True,
+        )
+
+        self.assertEqual(result.returncode, 42)
+
+    def test_otlp_failure_spools_event_without_failing_command(self) -> None:
+        result = self.run_observer(
+            sys.executable,
+            "-c",
+            "raise SystemExit(0)",
+            endpoint="http://127.0.0.1:9/v1/metrics",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        spool = self.root / ".codex" / "tmp" / "observability" / "events.jsonl"
+        self.assertTrue(spool.exists())
+        self.assertTrue((self.root / ".codex" / "tmp" / "observability" / "otel-cooldown.json").exists())
+        event = json.loads(spool.read_text(encoding="utf-8").splitlines()[0])
+        self.assertEqual(event["labels"]["hook"], "unit_test_hook")
+        self.assertEqual(event["labels"]["status"], "success")
+
+    def test_payload_parsing_keeps_only_safe_labels(self) -> None:
+        labels = observer.safe_labels(
+            payload=b'{"tool_name":"Bash","command":"sops -d secret.yaml","tool_input":{"cmd":"cat private"}}',
+            root=self.root,
+            phase="pre_tool",
+            hook="sops_guard",
+        )
+
+        self.assertEqual(
+            set(labels),
+            {"repo", "branch", "implementation", "phase", "hook", "tool_name"},
+        )
+        self.assertEqual(labels["tool_name"], "Bash")
+        rendered = json.dumps(labels)
+        self.assertNotIn("secret", rendered)
+        self.assertNotIn("private", rendered)
+        self.assertNotIn("sops -d", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds Codex workflow observability for hook and session latency.

Important changes:
- Added `.codex/scripts/codex_observe.py`, a dependency-free wrapper that preserves wrapped hook exit codes, forwards sanitized OTLP metrics to `CODEX_OTEL_ENDPOINT`, and writes fallback events under `.codex/tmp/observability/events.jsonl` when telemetry delivery fails.
- Wrapped Codex hook commands in `.codex/config.toml` so UserPromptSubmit, PreToolUse, PostToolUse, Stop self-check, and automatic PR creation emit workflow timing.
- Added a Grafana dashboard in the Monitoring folder for session duration, slow hooks, pre-commit, workflow guard, stop hooks, and telemetry delivery failures using the current `proxmox_codex_workflow_*` metric prefix.
- Added observer unit tests, including a local fake HTTP receiver for OTLP payload shape and failure/spool behavior.

Documentation impact:
- Refreshed generated `docs/architecture.md` so the new dashboard resource appears in the architecture map.
- No runbook changes were needed because the feature uses existing Codex hook configuration and existing Grafana dashboard provisioning.

Verification:
- `python3 -m unittest discover tools/codex-harness/tests`
- `pre-commit run --files .codex/config.toml .codex/scripts/codex_observe.py tools/codex-harness/tests/test_codex_observe.py kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.yaml kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.json kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml docs/architecture.md`
- `python3 tools/architecture/render.py --check`

Workflow note:
- Runtime policy prevented spawning separate implementation/verifier subagents because the user did not explicitly request delegation. Self-implementation and self-verification fallback was used under the repository runbook allowance for higher-priority runtime policy blocks.


## Changes
- .codex/config.toml
- .codex/scripts/codex_observe.py
- docs/architecture.md
- kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.json
- kubernetes/infra/monitoring/grafana/dashboards/codex-workflow-dashboard.yaml
- kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
- tools/codex-harness/tests/test_codex_observe.py

## Commits
- 846c6fe feat(codex): observe workflow hook latency

## Verification
- Verified HEAD: `846c6feda8e7a06f252421b342e19ff9a8dc8db5`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
