### PR TITLE
Implementation: add-flux-kube-helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,17 @@ The development environment starts at `kubernetes/clusters/development`, uses `d
 
 Production Terraform writes operator config to `~/.kube/homelab-production.config` and `~/.talos/homelab-production.config` by default instead of overwriting `~/.kube/config` or `~/.talos/config`. Export `KUBECONFIG` and `TALOSCONFIG` to those cluster-specific files for local production workflows, or override the Terraform output path variables if you intentionally want the old global locations.
 
-For opt-in kubectl shortcuts that do not mutate the shell's active `KUBECONFIG`, source the shared helper:
+For opt-in kubectl and Flux shortcuts that do not mutate the shell's active `KUBECONFIG`, source the shared helper:
 
 ```sh
 . scripts/kube-aliases.sh
 kd get nodes
 kp get nodes
+fd get kustomizations
+fp get all -A
 ```
 
-The `kd` helper runs kubectl with `~/.kube/homelab-development.config`; `kp` runs kubectl with `~/.kube/homelab-production.config`. Devcontainer startup installs this source line in `~/.aliases.zsh` automatically:
+The `kd` and `fd` helpers use `~/.kube/homelab-development.config`; `kp` and `fp` use `~/.kube/homelab-production.config`. Devcontainer startup installs this source line in `~/.aliases.zsh` automatically:
 
 ```sh
 [ -f /workspaces/homelab/scripts/kube-aliases.sh ] && . /workspaces/homelab/scripts/kube-aliases.sh

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -83,11 +83,12 @@ export KUBECONFIG=~/.kube/homelab-development.config
 export TALOSCONFIG=~/.talos/homelab-development.config
 ```
 
-For kubectl-only development checks, source the opt-in shortcuts and use `kd` without changing the shell's active `KUBECONFIG`:
+For development checks, source the opt-in shortcuts and use `kd` or `fd` without changing the shell's active `KUBECONFIG`:
 
 ```sh
 . scripts/kube-aliases.sh
 kd get nodes -o wide
+fd get kustomizations
 ```
 
 ## Flux Bootstrap
@@ -113,10 +114,10 @@ flux bootstrap github \
 After bootstrap, check the base:
 
 ```sh
-flux get kustomizations
-kubectl get nodes -o wide
-kubectl get gateway -n gateway
-kubectl get httproute -A
+fd get kustomizations
+kd get nodes -o wide
+kd get gateway -n gateway
+kd get httproute -A
 ```
 
 ## Branch Environments

--- a/scripts/kube-aliases.sh
+++ b/scripts/kube-aliases.sh
@@ -1,6 +1,6 @@
-# Source this file from Bash or Zsh to add opt-in kubectl shortcuts.
+# Source this file from Bash or Zsh to add opt-in kubectl and Flux shortcuts.
 #
-# These helpers set KUBECONFIG only for the kubectl process they start.
+# These helpers set KUBECONFIG only for the command process they start.
 
 kd() {
   KUBECONFIG="${HOME}/.kube/homelab-development.config" kubectl "$@"
@@ -8,4 +8,12 @@ kd() {
 
 kp() {
   KUBECONFIG="${HOME}/.kube/homelab-production.config" kubectl "$@"
+}
+
+fd() {
+  KUBECONFIG="${HOME}/.kube/homelab-development.config" flux "$@"
+}
+
+fp() {
+  KUBECONFIG="${HOME}/.kube/homelab-production.config" flux "$@"
 }


### PR DESCRIPTION
## Summary
Adds opt-in Flux kubeconfig helpers beside the existing kubectl helpers.

Important changes:
- Added `fd` and `fp` functions to `scripts/kube-aliases.sh` for development and production Flux commands.
- Updated README examples to show `kd`, `kp`, `fd`, and `fp` together.
- Updated the development cluster runbook to use `fd get kustomizations` and `kd` checks after bootstrap while keeping explicit bootstrap kubeconfig export guidance.

Documentation impact:
- Updated README.md and docs/runbooks/development-cluster.md because the operator helper workflow changed.

Verification:
- `bash -n scripts/kube-aliases.sh`
- `. scripts/kube-aliases.sh && type kd kp fd fp`
- `pre-commit run --files scripts/kube-aliases.sh README.md docs/runbooks/development-cluster.md`

Workflow note:
- Runtime policy prevented spawning separate implementation/verifier subagents because the user did not explicitly request delegation. Self-implementation and self-verification fallback was used under the repository runbook allowance for higher-priority runtime policy blocks.


## Changes
- README.md
- docs/runbooks/development-cluster.md
- scripts/kube-aliases.sh

## Commits
- 79be109 feat(cli): add flux kubeconfig helpers

## Verification
- Verified HEAD: `79be109dd286aa2d4af5085609fecce7852da07a`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
