### PR TITLE
Implementation: dev-pod-readiness-tests

### DIFF
--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -128,7 +128,7 @@ Branch environments are for app-scoped validation on the development cluster. Us
 <app>-${branch_slug}.development.lab.petebeegle.com
 ```
 
-Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch-scoped app resources, and then removes the temporary branch Flux resources unless `--keep` is set.
+Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, checks the whoami Service and HTTPRoute, and then removes the temporary branch Flux resources unless `--keep` is set.
 
 The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
 
@@ -154,6 +154,14 @@ Run Terraform apply first when the development cluster base may need to be creat
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --terraform-apply
 ```
 
+Include a sequential development base reconcile from the target branch when validating cluster-scoped changes before the branch app test:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --include-cluster-base
+```
+
+With `--include-cluster-base`, the tool temporarily points the development `flux-system` GitRepository at `--branch`, reconciles the root `flux-system` Kustomization, re-pins the source to the branch, reconciles `crds`, `cert-manager`, `nfs-csi`, `cilium`, `certs`, `gateway`, and `app-whoami` in order, waits for active pods across the cluster to report Ready, and restores the `flux-system` GitRepository to `main` even when validation fails.
+
 Use a custom kubeconfig:
 
 ```sh
@@ -174,7 +182,7 @@ kubectl --kubeconfig ~/.kube/homelab-development.config wait namespace/whoami-ex
 kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gitrepository.source.toolkit.fluxcd.io/branch-example-change
 ```
 
-This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the Deployment rolls out, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. It does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
+This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
 
 Local manifest verification does not require pushing a branch:
 
@@ -201,7 +209,7 @@ The shared gateway base at `kubernetes/infra/network/gateway` must stay environm
 
 ## Cluster-Scoped Testing
 
-Test cluster-scoped changes sequentially on the development base. CRDs, controllers, Gateway API shared objects, storage classes, and other cluster-wide resources should not be tested in parallel branch environments because they share reconciliation and ownership boundaries.
+Test cluster-scoped changes sequentially on the development base. CRDs, controllers, Gateway API shared objects, storage classes, and other cluster-wide resources should not be tested in parallel branch environments because they share reconciliation and ownership boundaries. Use `--include-cluster-base` with the branch verifier when the target branch changes shared development base resources and the branch app acceptance should run after that live base reconcile.
 
 ## Cleanup
 

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -1,9 +1,15 @@
 # Development Tools
 
-`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. V1 supports `whoami` only.
+`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. V1 supports `whoami` only. It verifies the branch namespace, active pod readiness, the whoami Service, and the HTTPRoute.
 
 Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+Use `--include-cluster-base` to first reconcile the development base from `--branch` in the known order and restore the `flux-system` GitRepository to `main` before the tool exits:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push --include-cluster-base
 ```

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -33,6 +34,51 @@ READY_HTTPROUTE = """{
   }
 }"""
 
+READY_PODS = json.dumps(
+    {
+        "items": [
+            {
+                "metadata": {"name": "whoami-example-change-7d9c4", "namespace": "whoami-example-change"},
+                "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}]},
+            }
+        ]
+    }
+)
+
+MIXED_PODS = json.dumps(
+    {
+        "items": [
+            {
+                "metadata": {"name": "complete", "namespace": "whoami-example-change"},
+                "status": {"phase": "Succeeded", "conditions": [{"type": "Ready", "status": "False"}]},
+            },
+            {
+                "metadata": {
+                    "name": "deleting",
+                    "namespace": "whoami-example-change",
+                    "deletionTimestamp": "2026-05-15T00:00:00Z",
+                },
+                "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "False"}]},
+            },
+            {
+                "metadata": {"name": "active", "namespace": "whoami-example-change"},
+                "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}]},
+            },
+        ]
+    }
+)
+
+NO_ACTIVE_PODS = json.dumps(
+    {
+        "items": [
+            {
+                "metadata": {"name": "complete", "namespace": "whoami-example-change"},
+                "status": {"phase": "Succeeded"},
+            }
+        ]
+    }
+)
+
 
 TEMPLATE = """---
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -60,10 +106,20 @@ spec:
 class FakeRunner:
     quiet = True
 
-    def __init__(self, *, plan_returncode: int = 0, fail_on_rollout: bool = False, timeout_on: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        plan_returncode: int = 0,
+        fail_on: str | None = None,
+        timeout_on: str | None = None,
+        pods_json: str = READY_PODS,
+        cluster_pods_json: str = READY_PODS,
+    ) -> None:
         self.plan_returncode = plan_returncode
-        self.fail_on_rollout = fail_on_rollout
+        self.fail_on = fail_on
         self.timeout_on = timeout_on
+        self.pods_json = pods_json
+        self.cluster_pods_json = cluster_pods_json
         self.calls: list[tuple[list[str], dict[str, object]]] = []
 
     def __call__(self, args: list[str], **kwargs: object) -> SimpleNamespace:
@@ -71,11 +127,15 @@ class FakeRunner:
         command = " ".join(args)
         if self.timeout_on and self.timeout_on in command:
             raise subprocess.TimeoutExpired(args, kwargs.get("timeout"))
+        if self.fail_on and self.fail_on in command:
+            return SimpleNamespace(returncode=1, stdout="")
         if args[0] == "terraform" and "plan" in args:
             return SimpleNamespace(returncode=self.plan_returncode, stdout="")
-        if self.fail_on_rollout and "rollout status" in command:
-            return SimpleNamespace(returncode=1, stdout="")
-        if args[-2:] == ["-o", "json"]:
+        if args[-5:] == ["get", "pods", "--all-namespaces", "-o", "json"]:
+            return SimpleNamespace(returncode=0, stdout=self.cluster_pods_json)
+        if args[-4:] == ["get", "pods", "-o", "json"]:
+            return SimpleNamespace(returncode=0, stdout=self.pods_json)
+        if args[-4:] == ["get", "httproute", "whoami-example-change", "-o"] or args[-2:] == ["-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=READY_HTTPROUTE)
         return SimpleNamespace(returncode=0, stdout="")
 
@@ -158,7 +218,10 @@ class VerifyBranchDeployTest(unittest.TestCase):
         )
         self.assertTrue(any("terraform -chdir=" in command and " apply -input=false -no-color -auto-approve" in command for command in commands))
         self.assertTrue(any("flux --kubeconfig /tmp/kubeconfig reconcile source git branch-example-change" in command for command in commands))
-        self.assertTrue(any("rollout status deployment/whoami-example-change" in command for command in commands))
+        self.assertTrue(any("get pods -o json" in command for command in commands))
+        self.assertTrue(any("wait pod/whoami-example-change-7d9c4 --for=condition=Ready" in command for command in commands))
+        self.assertTrue(any("get service whoami-example-change" in command for command in commands))
+        self.assertTrue(any("get httproute whoami-example-change -o json" in command for command in commands))
         self.assertTrue(any("delete kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change" in command for command in commands))
         self.assertTrue(any("wait namespace/whoami-example-change --for=delete" in command for command in commands))
         self.assertTrue(any("delete gitrepository.source.toolkit.fluxcd.io/branch-example-change" in command for command in commands))
@@ -187,11 +250,95 @@ class VerifyBranchDeployTest(unittest.TestCase):
         with self.assertRaisesRegex(verify.VerificationError, "Accepted and ResolvedRefs"):
             verify.assert_httproute_ready(missing_resolved_refs, route_name="whoami-example-change")
 
+    def test_pod_readiness_waits_for_active_pods(self) -> None:
+        runner = FakeRunner()
+        config = self._config()
+
+        verify.wait_for_active_pods_ready(
+            config,
+            runner=runner,
+            namespace=config.namespace,
+            require_non_terminated=True,
+            context=f"namespace {config.namespace}",
+        )
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertEqual(commands[0], "kubectl --kubeconfig /tmp/kubeconfig -n whoami-example-change get pods -o json")
+        self.assertTrue(any("wait pod/whoami-example-change-7d9c4 --for=condition=Ready" in command for command in commands))
+
+    def test_pod_readiness_ignores_completed_and_deleting_pods(self) -> None:
+        runner = FakeRunner(pods_json=MIXED_PODS)
+        config = self._config()
+
+        verify.wait_for_active_pods_ready(
+            config,
+            runner=runner,
+            namespace=config.namespace,
+            require_non_terminated=True,
+            context=f"namespace {config.namespace}",
+        )
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("wait pod/active --for=condition=Ready" in command for command in commands))
+        self.assertFalse(any("wait pod/complete" in command for command in commands))
+        self.assertFalse(any("wait pod/deleting" in command for command in commands))
+
+    def test_branch_app_pods_require_at_least_one_non_terminated_pod(self) -> None:
+        runner = FakeRunner(pods_json=NO_ACTIVE_PODS)
+
+        with self.assertRaisesRegex(verify.VerificationError, "no non-terminated pods"):
+            verify.assert_whoami(self._config(), runner=runner)
+
+    def test_whoami_assert_preserves_service_and_route_checks(self) -> None:
+        runner = FakeRunner()
+        config = self._config()
+
+        verify.assert_whoami(config, runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("get service whoami-example-change" in command for command in commands))
+        self.assertTrue(any("get httproute whoami-example-change -o json" in command for command in commands))
+
+    def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
+        runner = FakeRunner(cluster_pods_json=READY_PODS)
+
+        verify.verify_cluster_base(self._config(include_cluster_base=True), runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        branch_patch_indices = [
+            index
+            for index, command in enumerate(commands)
+            if "patch gitrepository.source.toolkit.fluxcd.io/flux-system" in command and '"branch": "codex/example-change"' in command
+        ]
+        self.assertEqual(len(branch_patch_indices), 2)
+        root_index = self._index_containing(commands, "reconcile kustomization flux-system")
+        child_indices = [
+            self._index_containing(commands, f"reconcile kustomization {name}")
+            for name in verify.DEVELOPMENT_BASE_KUSTOMIZATIONS
+        ]
+        self.assertLess(branch_patch_indices[0], root_index)
+        self.assertLess(root_index, branch_patch_indices[1])
+        self.assertEqual(child_indices, sorted(child_indices))
+        self.assertTrue(any("get pods --all-namespaces -o json" in command for command in commands))
+        self.assertTrue(any("wait pod/whoami-example-change-7d9c4 --for=condition=Ready" in command for command in commands))
+        self.assertTrue(any('"branch": "main"' in command for command in commands))
+        self.assertGreater(commands[-2].find("reconcile kustomization flux-system"), -1)
+
+    def test_cluster_base_restores_main_on_failure(self) -> None:
+        runner = FakeRunner(fail_on="reconcile kustomization gateway")
+
+        with self.assertRaisesRegex(verify.VerificationError, "command failed"):
+            verify.verify_cluster_base(self._config(include_cluster_base=True), runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any('"branch": "main"' in command for command in commands))
+        self.assertTrue(any("reconcile kustomization flux-system" in command for command in commands[-2:]))
+
     def test_cleanup_is_attempted_after_activation_failure_unless_keep_is_set(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "terraform" / "development").mkdir(parents=True)
-            runner = FakeRunner(fail_on_rollout=True)
+            runner = FakeRunner(fail_on="wait pod/whoami-example-change-7d9c4")
 
             with self.assertRaises(verify.VerificationError):
                 verify.run_acceptance(self._config(), runner=runner, repo_root=root, template_text=TEMPLATE)
@@ -203,7 +350,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "terraform" / "development").mkdir(parents=True)
-            runner = FakeRunner(fail_on_rollout=True)
+            runner = FakeRunner(fail_on="wait pod/whoami-example-change-7d9c4")
 
             with self.assertRaises(verify.VerificationError):
                 verify.run_acceptance(self._config(keep=True), runner=runner, repo_root=root, template_text=TEMPLATE)
@@ -222,15 +369,32 @@ class VerifyBranchDeployTest(unittest.TestCase):
         text += "\n"
         text += (REPO_ROOT / "docs/runbooks/development-cluster.md").read_text(encoding="utf-8")
 
-        for flag in ("--app", "--branch", "--slug", "--push", "--terraform-apply", "--kubeconfig", "--timeout", "--keep"):
+        for flag in (
+            "--app",
+            "--branch",
+            "--slug",
+            "--push",
+            "--terraform-apply",
+            "--include-cluster-base",
+            "--kubeconfig",
+            "--timeout",
+            "--keep",
+        ):
             self.assertIn(flag, text)
             self.assertIn(flag, option_strings)
+
+    def _index_containing(self, commands: list[str], needle: str) -> int:
+        for index, command in enumerate(commands):
+            if needle in command:
+                return index
+        self.fail(f"missing command containing {needle!r}")
 
     def _config(
         self,
         *,
         push: bool = False,
         terraform_apply: bool = False,
+        include_cluster_base: bool = False,
         keep: bool = False,
     ) -> verify.AppConfig:
         return verify.AppConfig(
@@ -241,6 +405,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
             timeout=verify.parse_duration("2m"),
             push=push,
             terraform_apply=terraform_apply,
+            include_cluster_base=include_cluster_base,
             keep=keep,
         )
 

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -20,6 +20,15 @@ DEFAULT_KUBECONFIG = Path("~/.kube/homelab-development.config").expanduser()
 DEFAULT_TIMEOUT = "10m"
 FLUX_NAMESPACE = "flux-system"
 SUPPORTED_APPS = {"whoami"}
+DEVELOPMENT_BASE_KUSTOMIZATIONS = (
+    "crds",
+    "cert-manager",
+    "nfs-csi",
+    "cilium",
+    "certs",
+    "gateway",
+    "app-whoami",
+)
 
 BRANCH_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
 SLUG_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,54}[a-z0-9])?$")
@@ -41,6 +50,7 @@ class AppConfig:
     timeout: Duration
     push: bool
     terraform_apply: bool
+    include_cluster_base: bool
     keep: bool
 
     @property
@@ -137,6 +147,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--slug", required=True, type=validate_slug)
     parser.add_argument("--push", action="store_true", help="Push current HEAD to origin as --branch before activation.")
     parser.add_argument("--terraform-apply", action="store_true", help="Run terraform apply after a successful plan.")
+    parser.add_argument(
+        "--include-cluster-base",
+        action="store_true",
+        help="Temporarily reconcile the development base from --branch before branch app verification.",
+    )
     parser.add_argument("--kubeconfig", type=Path, default=DEFAULT_KUBECONFIG)
     parser.add_argument("--timeout", type=parse_duration, default=parse_duration(DEFAULT_TIMEOUT))
     parser.add_argument("--keep", action="store_true", help="Keep branch Flux resources for debugging.")
@@ -158,6 +173,9 @@ def run_acceptance(
             push_branch(config, runner=runner, repo_root=repo_root)
 
         run_terraform(config, runner=runner, repo_root=repo_root)
+
+        if config.include_cluster_base:
+            verify_cluster_base(config, runner=runner)
 
         rendered = render_activation_template(
             template_text
@@ -285,13 +303,135 @@ def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
     )
 
 
+def verify_cluster_base(config: AppConfig, *, runner: Runner) -> None:
+    failure: BaseException | None = None
+    try:
+        pin_flux_system_source(config, branch=config.branch, runner=runner)
+        reconcile_flux_system_source(config, runner=runner)
+        reconcile_flux_kustomization(config, "flux-system", runner=runner)
+
+        pin_flux_system_source(config, branch=config.branch, runner=runner)
+        reconcile_flux_system_source(config, runner=runner)
+        for kustomization in DEVELOPMENT_BASE_KUSTOMIZATIONS:
+            reconcile_flux_kustomization(config, kustomization, runner=runner)
+
+        wait_for_active_pods_ready(
+            config,
+            runner=runner,
+            namespace=None,
+            require_non_terminated=False,
+            context="development cluster",
+        )
+    except BaseException as exc:
+        failure = exc
+    finally:
+        try:
+            restore_flux_system_source(config, runner=runner)
+        except BaseException as restore_exc:
+            if failure is None:
+                failure = restore_exc
+            else:
+                failure = VerificationError(f"{failure}; additionally failed to restore flux-system GitRepository: {restore_exc}")
+
+    if failure is not None:
+        raise failure
+
+
+def pin_flux_system_source(config: AppConfig, *, branch: str, runner: Runner) -> None:
+    patch = json.dumps({"spec": {"ref": {"branch": branch}}})
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "patch",
+            "gitrepository.source.toolkit.fluxcd.io/flux-system",
+            "--type=merge",
+            "-p",
+            patch,
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+
+
+def reconcile_flux_system_source(config: AppConfig, *, runner: Runner) -> None:
+    run_command(
+        flux(
+            config,
+            "reconcile",
+            "source",
+            "git",
+            "flux-system",
+            "--namespace",
+            FLUX_NAMESPACE,
+            "--timeout",
+            config.timeout.raw,
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "wait",
+            "gitrepository.source.toolkit.fluxcd.io/flux-system",
+            "--for=condition=Ready",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+
+
+def restore_flux_system_source(config: AppConfig, *, runner: Runner) -> None:
+    pin_flux_system_source(config, branch="main", runner=runner)
+    reconcile_flux_system_source(config, runner=runner)
+    reconcile_flux_kustomization(config, "flux-system", runner=runner)
+
+
+def reconcile_flux_kustomization(config: AppConfig, name: str, *, runner: Runner) -> None:
+    run_command(
+        flux(
+            config,
+            "reconcile",
+            "kustomization",
+            name,
+            "--namespace",
+            FLUX_NAMESPACE,
+            "--with-source",
+            "--timeout",
+            config.timeout.raw,
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+    run_command(
+        kubectl(
+            config,
+            "-n",
+            FLUX_NAMESPACE,
+            "wait",
+            f"kustomization.kustomize.toolkit.fluxcd.io/{name}",
+            "--for=condition=Ready",
+            f"--timeout={config.timeout.raw}",
+        ),
+        runner=runner,
+        timeout=config.timeout,
+    )
+
+
 def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
     name = config.namespace
     run_command(kubectl(config, "get", "namespace", name), runner=runner, timeout=config.timeout)
-    run_command(
-        kubectl(config, "-n", name, "rollout", "status", f"deployment/{name}", f"--timeout={config.timeout.raw}"),
+    wait_for_active_pods_ready(
+        config,
         runner=runner,
-        timeout=config.timeout,
+        namespace=name,
+        require_non_terminated=True,
+        context=f"namespace {name}",
     )
     run_command(kubectl(config, "-n", name, "get", "service", name), runner=runner, timeout=config.timeout)
     route = run_command(
@@ -301,6 +441,91 @@ def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
         capture_output=True,
     )
     assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=name)
+
+
+def wait_for_active_pods_ready(
+    config: AppConfig,
+    *,
+    runner: Runner,
+    namespace: str | None,
+    require_non_terminated: bool,
+    context: str,
+) -> None:
+    if namespace is None:
+        pod_list = run_command(
+            kubectl(config, "get", "pods", "--all-namespaces", "-o", "json"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+        )
+    else:
+        pod_list = run_command(
+            kubectl(config, "-n", namespace, "get", "pods", "-o", "json"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+        )
+
+    pods = parse_pods(str(getattr(pod_list, "stdout", "")), context=context)
+    non_terminated = [pod for pod in pods if not is_pod_deleting(pod) and pod_phase(pod) not in {"Succeeded", "Failed"}]
+    if require_non_terminated and not non_terminated:
+        raise VerificationError(f"{context} has no non-terminated pods")
+
+    for pod in pods:
+        if is_pod_deleting(pod) or pod_phase(pod) == "Succeeded":
+            continue
+        name = pod_name(pod)
+        pod_namespace = pod_namespace_name(pod, default=namespace)
+        if pod_namespace is None:
+            raise VerificationError(f"{context} pod {name} did not include a namespace")
+        run_command(
+            kubectl(config, "-n", pod_namespace, "wait", f"pod/{name}", "--for=condition=Ready", f"--timeout={config.timeout.raw}"),
+            runner=runner,
+            timeout=config.timeout,
+        )
+
+
+def parse_pods(pods_json: str, *, context: str) -> list[dict[str, object]]:
+    try:
+        pod_list = json.loads(pods_json)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"{context} pods did not return valid JSON: {exc}") from exc
+
+    items = pod_list.get("items")
+    if not isinstance(items, list):
+        raise VerificationError(f"{context} pods JSON did not contain an items list")
+    return [pod for pod in items if isinstance(pod, dict)]
+
+
+def is_pod_deleting(pod: dict[str, object]) -> bool:
+    metadata = pod.get("metadata", {})
+    return isinstance(metadata, dict) and bool(metadata.get("deletionTimestamp"))
+
+
+def pod_phase(pod: dict[str, object]) -> str:
+    status = pod.get("status", {})
+    if not isinstance(status, dict):
+        return ""
+    phase = status.get("phase")
+    return str(phase) if phase is not None else ""
+
+
+def pod_name(pod: dict[str, object]) -> str:
+    metadata = pod.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise VerificationError("pod did not include metadata")
+    name = metadata.get("name")
+    if not name:
+        raise VerificationError("pod did not include metadata.name")
+    return str(name)
+
+
+def pod_namespace_name(pod: dict[str, object], *, default: str | None) -> str | None:
+    metadata = pod.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return default
+    namespace = metadata.get("namespace")
+    return str(namespace) if namespace else default
 
 
 def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
@@ -405,6 +630,7 @@ def config_from_args(args: argparse.Namespace) -> AppConfig:
         timeout=args.timeout,
         push=args.push,
         terraform_apply=args.terraform_apply,
+        include_cluster_base=args.include_cluster_base,
         keep=args.keep,
     )
 


### PR DESCRIPTION
## Summary
## Summary

Add generic pod readiness verification to the development branch deploy helper and introduce `--include-cluster-base` for sequential live reconciliation of the development base from the target branch.

## Important Changes

- Replaced the hard-coded `rollout status deployment/whoami-<slug>` assertion with namespace pod discovery from JSON and Ready waits for every active, non-deleting pod.
- Branch app verification now confirms the branch namespace exists, requires at least one non-terminated app pod, and preserves the whoami Service and HTTPRoute checks.
- Added `--include-cluster-base` to temporarily pin the development `flux-system` GitRepository to `--branch`, reconcile `flux-system`, re-pin to the branch, reconcile `crds`, `cert-manager`, `nfs-csi`, `cilium`, `certs`, `gateway`, and `app-whoami` in order, wait active cluster pods, then restore the GitRepository to `main`.
- Extended unit tests for pod readiness, ignored completed/deleting pods, missing app pods, route preservation, cluster-base command order, restore behavior on success and failure, and docs flag coverage.

## Documentation Impact

Updated `docs/runbooks/development-cluster.md` and `tools/development/README.md` for generic pod readiness behavior and the new `--include-cluster-base` flag.

## Verification

- `python3 -m compileall -q tools/development/verify_branch_deploy.py tools/development/tests/test_verify_branch_deploy.py`
- `python3 -m unittest tools.development.tests.test_verify_branch_deploy`
- `pre-commit run trailing-whitespace --files docs/runbooks/development-cluster.md tools/development/README.md tools/development/verify_branch_deploy.py tools/development/tests/test_verify_branch_deploy.py`
- `pre-commit run end-of-file-fixer --files docs/runbooks/development-cluster.md tools/development/README.md tools/development/verify_branch_deploy.py tools/development/tests/test_verify_branch_deploy.py`
- `pre-commit run check-merge-conflict --files docs/runbooks/development-cluster.md tools/development/README.md tools/development/verify_branch_deploy.py tools/development/tests/test_verify_branch_deploy.py`
- `git diff --check`
- `python3 tools/architecture/render.py --check`
- Verifier approval recorded for exact HEAD `504111687dac666759ab36c5e29d67d13a85c446` by `verifier-agent-dev-pod-readiness-tests`.


## Changes
- docs/runbooks/development-cluster.md
- tools/development/README.md
- tools/development/tests/test_verify_branch_deploy.py
- tools/development/verify_branch_deploy.py

## Commits
- 5041116 feat: verify development pod readiness

## Verification
- Verified HEAD: `504111687dac666759ab36c5e29d67d13a85c446`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
