### PR TITLE
fix(devcontainer): rehydrate environment operator files

### DIFF
--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -15,19 +15,33 @@ tf_output_to_file() {
   local dir="$1"
   local output_key="$2"
   local output_file="$3"
+  local tmp_file
 
   mkdir -p "$(dirname "$output_file")"
-  if terraform -chdir="$dir" output -raw "$output_key" > "$output_file" 2>/dev/null; then
-    chmod 600 "$output_file"
+  tmp_file="$(mktemp "${output_file}.tmp.XXXXXX")"
+  if terraform -chdir="$dir" output -raw "$output_key" > "$tmp_file" 2>/dev/null; then
+    chmod 600 "$tmp_file"
+    mv "$tmp_file" "$output_file"
     return 0
   fi
+  rm -f "$tmp_file"
   return 1
 }
 
-# Kubeconfig from Terraform output
-if ! tf_output_to_file "terraform/cluster" "kubeconfig" ~/.kube/config; then
-  echo "WARNING: kubeconfig output is unavailable — run 'terraform apply' in terraform/cluster/ to provision it"
-fi
+# Operator files from Terraform outputs
+operator_files=(
+  "development|terraform/development|kubeconfig|${HOME}/.kube/homelab-development.config"
+  "development|terraform/development|talosconfig|${HOME}/.talos/homelab-development.config"
+  "production|terraform/production|kubeconfig|${HOME}/.kube/homelab-production.config"
+  "production|terraform/production|talosconfig|${HOME}/.talos/homelab-production.config"
+)
+
+for operator_file in "${operator_files[@]}"; do
+  IFS='|' read -r environment dir output_key output_file <<< "$operator_file"
+  if ! tf_output_to_file "$dir" "$output_key" "$output_file"; then
+    echo "WARNING: ${environment} ${output_key} output is unavailable from ${dir}; leaving ${output_file} unchanged"
+  fi
+done
 
 # Grafana MCP token
 GRAFANA_SERVICE_ACCOUNT_TOKEN=$(tfo -state=terraform/external/grafana/terraform.tfstate -raw mcp_token 2>/dev/null || true)

--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -25,7 +25,9 @@ tf_output_to_file() {
 }
 
 # Kubeconfig from Terraform output
-tf_output_to_file "terraform/cluster" "kubeconfig" ~/.kube/config
+if ! tf_output_to_file "terraform/cluster" "kubeconfig" ~/.kube/config; then
+  echo "WARNING: kubeconfig output is unavailable — run 'terraform apply' in terraform/cluster/ to provision it"
+fi
 
 # Grafana MCP token
 GRAFANA_SERVICE_ACCOUNT_TOKEN=$(tfo -state=terraform/external/grafana/terraform.tfstate -raw mcp_token 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Replaced obsolete `terraform/cluster` post-start hydration with development and production Terraform roots.
- Rehydrated both kubeconfig and talosconfig into cluster-specific operator file paths.
- Hardened Terraform output writes by writing to temp files first, preserving existing configs on output failure.

## Verification

- `bash -n .devcontainer/poststart.sh`
- `.devcontainer/poststart.sh` with missing outputs/providers: exits 0, warnings only, no sensitive config content in output
- `.devcontainer/poststart.sh` with local development/production Terraform state and initialized provider caches: refreshes all four operator files
- `stat -c '%a %n' ~/.kube/homelab-development.config ~/.talos/homelab-development.config ~/.kube/homelab-production.config ~/.talos/homelab-production.config`: all four files are mode `600`
- `git diff --check`

## Documentation Impact

No documentation changed. This aligns devcontainer startup behavior with the existing multi-environment README and development-cluster runbook guidance.

## Workflow Notes

Self-implementation and self-verification fallback were used because the current runtime policy only permits subagent spawning when the user explicitly asks for subagents, which blocks the repository preference to use implementation and verifier subagents by default.
