### PR TITLE
Implementation: tdd-smoke-workflow

### DIFF
--- a/.codex/agents/repo_migration_worker.toml
+++ b/.codex/agents/repo_migration_worker.toml
@@ -9,7 +9,8 @@ All code changes must use the mandatory implementation workflow:
 - Create your branch from origin/main with the name codex/<implementation>.
 - If the planner staged secrets at /workspaces/homelab/.codex/tmp/implementation-secrets/<implementation>, install them into identical repo-relative paths in your clone before running commands that need them.
 - Before changing tracked files, record .codex/tmp/active-implementation in the clone with implementation, branch, base, role=implementation, clone_path, owner_role=implementation-agent, and owner_agent fields. Validate the marker with tools/codex-harness/validate_active_implementation.py when in doubt.
-- If you are the implementation owner/integrator, you own tracked-file edits, commits, .codex/tmp/active-implementation, .codex/tmp/pr-summary.md, and final branch state. Helper agents may research, test, verify, or prepare patch recommendations, but should not directly mutate tracked files in the shared clone.
+- Before changing tracked files, record .codex/tmp/implementation-plan.yaml with tests, verification, and risks that declare the risk-tiered TDD and development smoke expectations, or explain why they do not apply.
+- If you are the implementation owner/integrator, you own tracked-file edits, commits, .codex/tmp/active-implementation, .codex/tmp/implementation-plan.yaml, .codex/tmp/implementation-owner-attestation.yaml, .codex/tmp/pr-summary.md, and final branch state. Helper agents may research, test, verify, run smoke checks, or prepare patch recommendations, but should not directly mutate tracked files in the shared clone.
 - Leave the planner checkout untouched.
 
 Work in narrow, reversible slices:
@@ -18,6 +19,9 @@ Work in narrow, reversible slices:
 - Do not revert or overwrite changes you did not make.
 - Use deterministic transforms where possible.
 - Consider documentation impact for every change. Update stale docs, generated docs, decision records, runbooks, or agent guidance when behavior changes; otherwise record why no docs changed in .codex/tmp/pr-summary.md.
+- Use risk-tiered TDD guidance from docs/runbooks/implementation-workflow.md. For medium and high risk behavior changes, prefer a test-helper lane to identify or prepare failing tests before implementation; document exceptions when a failing test is not useful or feasible.
+- Use a smoke-helper lane for medium and high risk app or cluster changes when development cluster validation is expected. Smoke evidence should name the app, branch, branch_slug, exact HEAD, smoke profile or documented exception, commands run, result, and cleanup status.
+- Keep TDD and smoke evidence advisory in v1. Do not add hard harness gates or tool behavior changes unless explicitly asked in the implementation scope.
 - For Kubernetes or Terraform source changes, rely on the deterministic architecture check. If python3 tools/architecture/render.py --check fails, run python3 tools/architecture/render.py --write and commit the generated docs/architecture.md update.
 - Validate each migration slice with the smallest relevant checks.
 - Leave clear notes about assumptions, skipped areas, and follow-up work.

--- a/.codex/agents/verifier.toml
+++ b/.codex/agents/verifier.toml
@@ -12,6 +12,11 @@ Focus on correctness and operational safety:
 - Confirm Kubernetes and Flux changes preserve dependency order, namespaces, Gateway references, and StorageClass expectations.
 - Confirm documentation impact was considered: docs, generated docs, runbooks, decision records, or agent guidance were updated when behavior changed, or .codex/tmp/pr-summary.md explains why no docs changed.
 - Confirm generated architecture is fresh when Kubernetes or Terraform sources changed by checking python3 tools/architecture/render.py --check.
+- Audit the implementation plan's declared tests, verification, risks, risk-tiered TDD expectations, and development smoke expectations. Confirm evidence exists for declared checks or that exceptions are explicit and reasonable.
+- For TDD evidence, check whether the claimed failing test, added test, local render test, or documented exception matches the risk tier and changed files. Rerun or spot-check stale, incomplete, or suspicious evidence before sign-off.
+- For development smoke evidence, confirm the report or PR summary names the app, branch, branch_slug, exact HEAD, smoke profile or documented exception, command output summary, result, and cleanup status. The smoke HEAD must match the branch HEAD under review unless the evidence is explicitly marked stale and ignored.
+- For new apps, confirm development coverage addressed workload readiness, routes, storage, secrets, branch overlay behavior, and an app-specific probe, or that the implementation documents why a development smoke profile is not available yet.
+- Confirm the current workflow remains single-owner: helper lanes may provide test or smoke evidence, but the implementation owner owns tracked edits, local workflow files, commits, and final branch state.
 - Prefer concrete file and command references over broad summaries.
 - Report blockers first, then residual risks, then successful checks.
 """

--- a/docs/decisions/tdd-and-development-smoke-evidence.md
+++ b/docs/decisions/tdd-and-development-smoke-evidence.md
@@ -1,0 +1,46 @@
+---
+id: ADR-0013
+status: accepted
+scope:
+  - codex-harness
+  - implementation-workflow
+  - development-cluster
+  - agent-operations
+authority: binding
+created: 2026-05-16
+last_verified: 2026-05-16
+supersedes: []
+superseded_by:
+---
+
+# TDD And Development Smoke Evidence
+
+## Decision
+
+Implementation plans, PR summaries, and verifier review should use risk-tiered TDD and development smoke evidence for repository changes.
+
+This evidence is advisory in v1. Owners and verifiers must document expectations, results, and exceptions, but the harness must not add hard gates for TDD or smoke testing until the practice proves stable across routine work.
+
+The existing single-owner implementation model remains binding. Test-helper and smoke-helper lanes may research, run commands, prepare recommendations, and report evidence, but the implementation owner remains responsible for tracked edits, commits, local workflow files, `.codex/tmp/pr-summary.md`, and final branch state.
+
+## Rationale
+
+- TDD expectations should scale with operational risk instead of forcing the same process onto docs-only changes and cluster-wide changes.
+- Development smoke tests are valuable only when their evidence identifies the app, branch, exact `HEAD`, profile, result, and cleanup state.
+- The current branch deployment verifier is intentionally narrow, with automated support for `whoami` only while a config-driven app profile model is developed.
+- Hard gates would be brittle before the team has enough examples of useful tests, smoke profiles, and valid exceptions.
+- Preserving the single-owner model keeps responsibility clear even when helper lanes contribute evidence.
+
+## Consequences
+
+- Implementation plans should describe TDD, smoke expectations, and known exceptions in the tests, verification, and risks sections.
+- PR summaries should include commands run, smoke reports or exceptions, documentation impact, and whether generated architecture changed.
+- Verifiers should audit declared tests and smoke evidence against the risk tier, spot-check stale or incomplete evidence, and record residual risk when live validation is unavailable.
+- New app work should add or select a smoke profile when practical, or document why development smoke coverage is deferred.
+- Hard harness gates, automated profile enforcement, and non-`whoami` deployment verifier behavior are deferred to future implementations.
+
+## Operational Notes
+
+- Use `docs/runbooks/implementation-workflow.md` for risk tiers and helper lane expectations.
+- Use `docs/runbooks/development-cluster.md` for smoke report shape, touched-app smoke coverage, and `--include-cluster-base` guidance.
+- Use `docs/runbooks/add-app.md` when adding development coverage for a new app.

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -20,7 +20,8 @@ Use this runbook to add a Kubernetes app managed by Flux.
 6. Add `kubernetes/clusters/production/apps/<app-name>.yaml` as a Flux Kustomization.
 7. Add the new cluster-layer file to `kubernetes/clusters/production/apps/kustomization.yaml`.
 8. If the app should be testable in branch environments, add a branch-aware overlay that uses `branch_slug` in names, namespaces, hostnames, and PVC names.
-9. Verify after Flux reconciles.
+9. Add or select a development smoke profile for the app, or document why the app cannot be smoke-tested in development yet.
+10. Verify after Flux reconciles.
 
 ## Choose Exposure
 
@@ -333,6 +334,21 @@ For raw manifests, create an overlay such as `kubernetes/apps/<app-name>/branch/
 Cluster-layer branch activations should live under a reviewed development path, point their `sourceRef` at a branch-specific `GitRepository`, set `postBuild.substitute.branch_slug`, and remain `suspend: true` until the referenced branch exists. See `kubernetes/clusters/development/branches/` and `kubernetes/apps/whoami/branch/` for the initial template.
 
 Cluster-scoped changes, including CRDs, controllers, Gateway API shared objects, and storage classes, are tested sequentially on the development base. Do not fan those changes out through parallel branch environments.
+
+## Development Testing
+
+New production apps are not considered complete until development testing is addressed. Prefer adding or selecting a config-driven smoke profile as described in `docs/runbooks/development-cluster.md`. If the app cannot be tested in development yet, record a documented exception in the implementation plan and PR summary with the missing dependency and follow-up needed.
+
+For each new app, validate the applicable items before production activation is considered complete:
+
+- Workload readiness: Deployments, StatefulSets, DaemonSets, or HelmRelease-managed pods become Ready in the development branch namespace.
+- Routes: `HTTPRoute` or `TLSRoute` attaches to the intended Gateway and reports healthy conditions expected for that route type.
+- Storage: PVCs use `nfs-csi-storage` unless intentionally exempted, bind successfully, mount into the workload, and clean up with the branch namespace unless retained for debugging.
+- Secrets: Secret references render with the expected names, required development secret/config files are staged when needed, and secret contents are never logged.
+- Branch overlay: Namespaces, workload names, hostnames, PVC names, and route references use `branch_slug` and can coexist with the development base.
+- App-specific probes: Exercise a meaningful health endpoint, login-free HTTP path, protocol handshake, or command that proves the app is serving more than a scheduled pod.
+
+When `tools/development/verify_branch_deploy.py` supports the selected profile, run it against the exact branch `HEAD` that will be reviewed. Until profile expansion supports the app, record manual smoke commands and observations instead of changing harness behavior inside the app PR.
 
 ## Verification
 

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -6,7 +6,7 @@ scope:
   - flux
 authority: operational
 created: 2026-05-14
-last_verified: 2026-05-15
+last_verified: 2026-05-16
 ---
 
 # Development Cluster
@@ -130,6 +130,8 @@ Branch environments are for app-scoped validation on the development cluster. Us
 
 Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, checks the whoami Service and HTTPRoute, and then removes the temporary branch Flux resources unless `--keep` is set.
 
+The current deployment verifier is intentionally limited to the `whoami` smoke path while the app profile model is expanded. Treat non-`whoami` app smoke as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile as an exception rather than adding ad hoc harness behavior.
+
 The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
 
 ### Live App Acceptance
@@ -184,6 +186,40 @@ kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gi
 
 This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
 
+### Touched-App Smoke Matrix
+
+For each implementation that changes app behavior, manifests, Gateway routing, storage, secrets references, or branch overlays, list touched apps in the implementation plan or PR summary and choose one smoke path per app:
+
+| Change type | Minimum development smoke evidence |
+| --- | --- |
+| Branch overlay only | Render the branch overlay locally; when supported, run `verify_branch_deploy.py` for the app profile. |
+| Workload, Service, or route | Confirm workload readiness, Service presence, and `HTTPRoute` or `TLSRoute` attachment in a development branch namespace. |
+| PVC or storage | Confirm PVC binds with `nfs-csi-storage`, the pod mounts it, and cleanup removes branch PVCs unless retained for debugging. |
+| Secret reference | Confirm referenced Secret names render correctly and required staged development secrets exist; do not log secret values. |
+| Cluster-scoped base dependency | Run a sequential development base reconcile with `--include-cluster-base`, then run the app smoke if an app is affected. |
+| Public or external exposure | Confirm the Gateway route attaches and record any Cloudflare, WireGuard, or out-of-cluster dependency that development cannot fully prove. |
+
+### Smoke Profiles
+
+The target model is a config-driven smoke profile per app. A profile should name the app, branch overlay path, activation template, expected namespace, workloads, Services, routes, PVCs, app-specific probes, cleanup expectations, and any required development-only secret/config prerequisites. Profiles should allow the verifier to choose consistent checks without hard-coding each app into the harness.
+
+Until profile expansion lands, use `whoami` as the only automated profile and document either:
+
+- `smoke_profile: whoami` with the exact `verify_branch_deploy.py` command and result.
+- `smoke_profile: manual` with commands and observations for the touched app.
+- `smoke_profile: none` with the reason, such as docs-only, unavailable development cluster, missing app branch overlay, or production-only integration.
+
+An exact-`HEAD` smoke report should include:
+
+- implementation name, app name, branch, branch slug, and exact commit SHA tested;
+- smoke profile name or documented exception;
+- whether `--push`, `--terraform-apply`, `--include-cluster-base`, or `--keep` was used;
+- readiness, route, storage, secret-reference, and app-specific probe results that apply to the app;
+- cleanup status, including any namespaces, Flux resources, or PVCs intentionally left behind;
+- timestamp and kubeconfig or context used, without secret contents.
+
+If a smoke report names a different `HEAD` than the branch under review, treat it as stale. Rerun the smoke, record why rerun was impossible, or explicitly mark the stale report as ignored. Remove or supersede stale local reports before handoff so the verifier does not mistake them for current evidence.
+
 Local manifest verification does not require pushing a branch:
 
 ```sh
@@ -211,9 +247,13 @@ The shared gateway base at `kubernetes/infra/network/gateway` must stay environm
 
 Test cluster-scoped changes sequentially on the development base. CRDs, controllers, Gateway API shared objects, storage classes, and other cluster-wide resources should not be tested in parallel branch environments because they share reconciliation and ownership boundaries. Use `--include-cluster-base` with the branch verifier when the target branch changes shared development base resources and the branch app acceptance should run after that live base reconcile.
 
+Use `--include-cluster-base` when the implementation changes resources under `kubernetes/clusters/development`, shared CRDs, controller installs, Gateway base objects, Cilium, cert-manager, NFS CSI, Flux dependency ordering, or any app dependency that must exist before a branch overlay can be meaningful. Do not use it for docs-only changes or isolated app overlay edits where the development base from `main` is already sufficient.
+
 ## Cleanup
 
 Remove app branch activations by deleting their cluster-layer Flux manifests and allowing Flux to prune them. Confirm namespaces and PVCs are gone before reusing a `branch_slug`.
+
+For kept or failed branch smokes, record cleanup status in the smoke report. Before reusing a slug, delete stale branch `Kustomization` and `GitRepository` objects, wait for the branch namespace to disappear, and check for leftover PVCs or app-owned resources. If cleanup fails, leave the evidence visible to the verifier with the resource names and reason.
 
 To retire the whole development cluster:
 

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -5,7 +5,7 @@ scope:
   - implementation-workflow
 authority: binding
 created: 2026-05-10
-last_verified: 2026-05-12
+last_verified: 2026-05-16
 ---
 
 # Implementation Workflow
@@ -19,13 +19,13 @@ Use this runbook for every repository code change. The binding decision is `docs
 3. If ignored local secrets or configs are required, stage them under `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout, preserving repo-relative paths and never logging contents.
 4. Clone the repo into `/workspaces/homelab-ideas/<implementation>` and create `codex/<implementation>` from `origin/main`.
 5. Before tracked edits, create `.codex/tmp/active-implementation` with `implementation`, `branch`, `base`, `role`, `clone_path`, `owner_role`, and `owner_agent`.
-6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks.
+6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development smoke expectations for the implementation, or explain why they do not apply.
 7. Before tracked edits, create `.codex/tmp/implementation-owner-attestation.yaml` with implementation identity, role, concrete `agent_id`, clone path, `created_at`, and matching delegation token evidence under `.codex/tmp/delegation-tokens/`.
 8. Validate the marker, plan, and owner attestation.
 9. Make tracked-file changes only in the sibling clone.
 10. Update docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no docs change, record why in `.codex/tmp/pr-summary.md`.
 11. Commit with conventional commits.
-12. Run relevant checks and request verifier review.
+12. Run relevant checks, collect TDD and development smoke evidence expected by the plan, and request verifier review.
 13. Record verifier approval for the exact `HEAD` SHA in `.codex/tmp/verifier-approved`.
 14. Record `.codex/tmp/verifier-attestation.yaml` with verifier identity, separate delegation token evidence, and `approved_head` equal to the exact `HEAD` SHA. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
 15. Write `.codex/tmp/pr-summary.md` from the plan and final result.
@@ -147,3 +147,49 @@ python3 tools/codex-harness/validate_workflow_attestations.py \
 Use implementation and verifier subagents by default whenever runtime tooling exposes them. Self-implementation or self-verification is acceptable only when subagent tooling is unavailable or higher-priority runtime policy blocks delegation, and the fallback must be recorded in `.codex/tmp/pr-summary.md`.
 
 Multiple helpers may contribute through the single integrator model. Helpers may inspect, test, verify, or recommend patches, but one implementation owner applies tracked-file edits and owns final branch state.
+
+## Risk-Tiered TDD And Smoke Evidence
+
+TDD and development smoke evidence is advisory in v1. It is still expected for normal work, but it is documented and reviewed rather than enforced by hard harness gates. See `docs/decisions/tdd-and-development-smoke-evidence.md`.
+
+Declare a risk tier in the plan:
+
+- `docs-only`: documentation, generated docs, decisions, runbooks, or agent guidance only.
+- `low`: narrow code or manifest changes with local-only behavior and low operational blast radius.
+- `medium`: app behavior, Kubernetes manifests, Flux wiring, Terraform module logic, storage, secrets references, or Gateway routes.
+- `high`: cluster-scoped controllers, CRDs, networking, storage classes, authentication, production traffic paths, secret handling, or changes that can affect multiple apps.
+
+TDD expectations by tier:
+
+- `docs-only`: no code TDD required; run relevant doc, harness, or repo tests that guard the edited guidance when available.
+- `low`: add or update the smallest unit test that fails before the fix when the codebase has a reasonable test seam; otherwise document the exception.
+- `medium`: prefer a red-green flow for behavior changes, including local render tests or focused unit tests for Kubernetes/Terraform tooling where applicable.
+- `high`: use a test-helper lane by default to identify or prepare failing tests before implementation, plus broader verification after the change. If no useful failing test can be made, record why.
+
+Development smoke expectations by tier:
+
+- `docs-only`: no live development smoke required.
+- `low`: smoke only when the changed path affects live app rendering or operator commands.
+- `medium`: use a smoke-helper lane by default for touched apps or explain why local verification is enough.
+- `high`: run development cluster smoke for the affected app or base path when credentials and cluster health allow it; otherwise record the blocker and the safest substitute evidence.
+
+## Helper Lanes
+
+Use helper lanes without breaking the single-owner model:
+
+- `test-helper`: researches risk, proposes or runs failing tests, and reports command output or patch recommendations. The implementation owner remains the only role that applies tracked-file edits.
+- `smoke-helper`: prepares or runs development cluster smoke checks, captures exact branch and `HEAD` evidence, and recommends cleanup. The implementation owner remains responsible for final branch state and PR notes.
+
+Helper output belongs in `.codex/tmp/pr-summary.md` or an equivalent local note when it affects verifier review. Include commands, outcomes, skipped checks, and exceptions. Do not create verifier approval files from helper lanes.
+
+## Evidence Audit
+
+Before requesting verifier review, the implementation owner should audit:
+
+- The plan declares the intended TDD and smoke expectations for the risk tier.
+- Any skipped failing test, missing smoke profile, unavailable development cluster, or other exception is recorded with a reason.
+- Test evidence includes the exact commands run and pass/fail result.
+- Development smoke evidence includes app name, branch, branch slug, exact `HEAD`, smoke profile or documented exception, report path if one was produced, cleanup status, and whether stale reports were ignored or removed.
+- Parent/process evidence is internally consistent: active marker, plan, owner attestation, delegation token, branch, clone path, and PR summary all point at the same implementation.
+
+Verifier review should audit the same evidence. If declared TDD or smoke evidence is stale, missing, or inconsistent with the risk tier, the verifier should request a rerun, run a spot check, or record the residual risk before sign-off.


### PR DESCRIPTION
## Summary
## Summary

Document risk-tiered TDD and development smoke-testing expectations for homelab implementation work without adding hard harness gates or tool behavior changes.

## Important Changes

- Added advisory TDD and development smoke evidence guidance to the implementation workflow, including risk tiers, test-helper and smoke-helper lanes, owner evidence audit, verifier evidence audit, and parent/process audit expectations.
- Expanded development cluster guidance with a touched-app smoke matrix, config-driven smoke profile model, exact-HEAD report shape, `--include-cluster-base` usage, stale report handling, cleanup expectations, and the current `whoami`-only status of `verify_branch_deploy.py`.
- Updated add-app guidance so new apps must add/select a development smoke profile or document an exception, and validate readiness, routes, storage, secrets, branch overlays, and app-specific probes before production activation is complete.
- Updated implementation owner/helper and verifier agent guidance for advisory risk-tiered TDD, helper lanes, exact-HEAD smoke evidence, exceptions, and stale evidence spot checks.
- Added ADR-0013 for advisory v1 TDD and development smoke evidence, preserving the binding single-owner model and deferring hard harness gates until the practice stabilizes.

## Documentation Impact

Documentation, decision records, and agent guidance are the substance of this implementation. No generated architecture refresh was needed because no Kubernetes or Terraform source changed.

## Tests Run

- `python3 -m unittest discover -s tools/codex-harness/tests` - passed, 58 tests.
- `python3 -m unittest discover -s tools/development/tests` - passed, 18 tests.

## Notes And Risks

- This is docs/guidance only; no hard enforcement was added.
- Development smoke automation remains `whoami`-only until a future profile expansion.
- No verifier approval files were created.


## Changes
- .codex/agents/repo_migration_worker.toml
- .codex/agents/verifier.toml
- docs/decisions/tdd-and-development-smoke-evidence.md
- docs/runbooks/add-app.md
- docs/runbooks/development-cluster.md
- docs/runbooks/implementation-workflow.md

## Commits
- 676beef docs: document risk-tiered tdd smoke workflow

## Verification
- Verified HEAD: `676beef2443d80244e971066f27fe3c2538d9779`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
