### PR TITLE
fix(renovate): repair dependency update pipelines

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -19,9 +19,7 @@ rules:
   empty-values: disable
   float-values: disable
   hyphens: enable
-  indentation:
-    ignore: |
-      kubernetes/clusters/*/flux-system/gotk-*.yaml
+  indentation: enable
   key-duplicates: enable
   key-ordering: disable
   line-length: disable
@@ -35,3 +33,4 @@ rules:
 
 ignore: |
   .github/
+  kubernetes/clusters/*/flux-system/gotk-*.yaml

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ sops secret.yaml
 
 ### Dependency Management (Renovate)
 - Renovate runs as a cronjob in the `renovate` namespace.
+- Flux component updates from generated `gotk-components.yaml` files are grouped
+  into one `fluxcd` PR.
+- Terraform dependency updates run `tools/renovate/update-terraform-docs.sh` to
+  refresh generated Terraform READMEs with pinned `terraform-docs` v0.23.0.
 
 Manual run:
 ```sh

--- a/docs/runbooks/renovate.md
+++ b/docs/runbooks/renovate.md
@@ -1,0 +1,33 @@
+---
+status: current
+scope:
+  - renovate
+  - dependency-management
+created: 2026-05-16
+last_verified: 2026-05-16
+---
+
+# Renovate
+
+Renovate runs in the `renovate` namespace and reads repository policy from
+`renovate.json`.
+
+## Flux Updates
+
+Flux component updates found in
+`kubernetes/clusters/**/flux-system/gotk-components.yaml` are grouped into a
+single `fluxcd` pull request. Generated `gotk-*.yaml` files are ignored by
+yamllint at the top-level `.yamllint.yaml` ignore scope; Kubernetes render and
+schema validation still run against the cluster kustomizations.
+
+## Terraform Docs
+
+Terraform dependency updates run
+`./tools/renovate/update-terraform-docs.sh` as a Renovate post-upgrade task. The
+script refreshes Terraform READMEs containing `<!-- BEGIN_TF_DOCS -->` with
+pinned `terraform-docs` v0.23.0, matching CI and pre-commit expectations.
+
+The self-hosted Renovate app allows only this exact command for Terraform docs
+regeneration. The script uses an existing `terraform-docs` only when it is
+v0.23.0; otherwise it downloads the pinned linux-amd64 release into a temporary
+directory and removes it before exiting.

--- a/kubernetes/apps/renovate/app.yaml
+++ b/kubernetes/apps/renovate/app.yaml
@@ -51,6 +51,9 @@ spec:
           "platform": "github",
           "repositories": ["petebeegle/homelab"],
           "baseBranches": ["main"],
+          "allowedCommands": [
+            "^\\./tools/renovate/update-terraform-docs\\.sh$"
+          ]
         }
     envFrom:
       - secretRef:

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,18 @@
   },
   "packageRules": [
     {
+      "groupName": "fluxcd",
+      "matchFileNames": [
+        "kubernetes/clusters/**/flux-system/gotk-components.yaml",
+        "kubernetes/clusters/**/flux-system/gotk-components.yml"
+      ],
+      "matchPackageNames": [
+        "fluxcd/flux2",
+        "ghcr.io/fluxcd/**",
+        "docker.io/fluxcd/**"
+      ]
+    },
+    {
       "groupName": "cilium",
       "matchPackageNames": [
         "cilium"
@@ -77,6 +89,24 @@
       "matchDatasources": [
         "helm"
       ]
+    },
+    {
+      "description": "Regenerate Terraform docs after Terraform dependency updates",
+      "matchManagers": [
+        "terraform"
+      ],
+      "matchFileNames": [
+        "terraform/**"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "./tools/renovate/update-terraform-docs.sh"
+        ],
+        "fileFilters": [
+          "terraform/**/README.md"
+        ],
+        "executionMode": "update"
+      }
     }
   ]
 }

--- a/tools/renovate/update-terraform-docs.sh
+++ b/tools/renovate/update-terraform-docs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly TERRAFORM_DOCS_VERSION="0.23.0"
+readonly TERRAFORM_DOCS_ARCHIVE="terraform-docs-v${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
+readonly TERRAFORM_DOCS_URL="https://github.com/terraform-docs/terraform-docs/releases/download/v${TERRAFORM_DOCS_VERSION}/${TERRAFORM_DOCS_ARCHIVE}"
+
+temp_dir=""
+terraform_docs_bin=""
+
+cleanup() {
+  if [[ -n "${temp_dir}" && -d "${temp_dir}" ]]; then
+    rm -rf "${temp_dir}"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  echo "update-terraform-docs: $*" >&2
+  exit 1
+}
+
+terraform_docs_version_matches() {
+  local bin="$1"
+  local version_output
+
+  version_output="$("${bin}" --version 2>/dev/null || true)"
+  [[ "${version_output}" == *" v${TERRAFORM_DOCS_VERSION} "* ]]
+}
+
+download_terraform_docs() {
+  command -v curl >/dev/null 2>&1 ||
+    fail "curl is required to download terraform-docs v${TERRAFORM_DOCS_VERSION}"
+  command -v tar >/dev/null 2>&1 ||
+    fail "tar is required to extract terraform-docs v${TERRAFORM_DOCS_VERSION}"
+
+  temp_dir="$(mktemp -d)"
+  local archive_path="${temp_dir}/${TERRAFORM_DOCS_ARCHIVE}"
+
+  echo "update-terraform-docs: downloading terraform-docs v${TERRAFORM_DOCS_VERSION}" >&2
+  curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+    -sSLo "${archive_path}" \
+    "${TERRAFORM_DOCS_URL}" ||
+    fail "failed to download ${TERRAFORM_DOCS_URL}"
+  tar -xzf "${archive_path}" -C "${temp_dir}" terraform-docs ||
+    fail "failed to extract ${TERRAFORM_DOCS_ARCHIVE}"
+  chmod +x "${temp_dir}/terraform-docs"
+
+  terraform_docs_version_matches "${temp_dir}/terraform-docs" ||
+    fail "downloaded terraform-docs is not v${TERRAFORM_DOCS_VERSION}"
+  terraform_docs_bin="${temp_dir}/terraform-docs"
+}
+
+select_terraform_docs() {
+  if command -v terraform-docs >/dev/null 2>&1; then
+    local candidate
+    candidate="$(command -v terraform-docs)"
+
+    if terraform_docs_version_matches "${candidate}"; then
+      terraform_docs_bin="${candidate}"
+      return
+    fi
+
+    echo "update-terraform-docs: ${candidate} is not v${TERRAFORM_DOCS_VERSION}; using pinned download" >&2
+  else
+    echo "update-terraform-docs: terraform-docs not found; using pinned download" >&2
+  fi
+
+  download_terraform_docs
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" ||
+  fail "must be run from inside the homelab git repository"
+cd "${repo_root}"
+
+select_terraform_docs
+
+mapfile -d '' readmes < <(
+  find terraform -path '*/README.md' -type f -print0 |
+    sort -z
+)
+
+if [[ "${#readmes[@]}" -eq 0 ]]; then
+  echo "update-terraform-docs: no Terraform README files found"
+  exit 0
+fi
+
+updated=0
+for readme in "${readmes[@]}"; do
+  if ! grep -q '<!-- BEGIN_TF_DOCS -->' "${readme}"; then
+    continue
+  fi
+
+  module_dir="$(dirname "${readme}")"
+  "${terraform_docs_bin}" markdown table \
+    --output-file README.md \
+    --output-mode inject \
+    "${module_dir}"
+  updated=$((updated + 1))
+done
+
+if [[ "${updated}" -eq 0 ]]; then
+  echo "update-terraform-docs: no generated Terraform README files found"
+else
+  echo "update-terraform-docs: refreshed ${updated} Terraform README files"
+fi


### PR DESCRIPTION
## Summary

Repair Renovate dependency update pipelines for generated Flux manifests and
Terraform documentation.

## Changes

- Moved generated Flux `gotk-*.yaml` lint handling to the top-level yamllint
  ignore scope while leaving Kubernetes render and schema validation active.
- Added a Renovate `fluxcd` group for Flux component updates from cluster
  `gotk-components` manifests.
- Added `tools/renovate/update-terraform-docs.sh` and a Terraform Renovate
  post-upgrade task that refreshes generated Terraform READMEs with pinned
  `terraform-docs` v0.23.0, downloading the pinned linux-amd64 release into a
  temporary directory when the runtime does not already provide that version.
- Allowed the exact Terraform docs post-upgrade command in the self-hosted
  Renovate app configuration.

## Documentation Impact

- Updated the README dependency management notes.
- Added `docs/runbooks/renovate.md` covering Flux grouping, generated Flux YAML
  lint behavior, and Terraform docs regeneration.

## Validation

- `bash -n tools/renovate/update-terraform-docs.sh`
- `tools/renovate/update-terraform-docs.sh`
- `PATH=/usr/bin:/bin tools/renovate/update-terraform-docs.sh`
- `npx --yes --package renovate@latest renovate-config-validator`
- `pre-commit run --all-files`
- `terraform fmt -check -recursive terraform`
- Terraform `init -backend=false` and `validate` for production, development,
  external/grafana, external/nexus, and external/synology roots
- `kubectl kustomize kubernetes/clusters/production > /tmp/homelab-production.yaml`
- `kubectl kustomize kubernetes/clusters/development > /tmp/homelab-development.yaml`
- Temporary `kubeconform v0.7.0` check: 100 resources, 44 valid, 0 invalid,
  0 errors, 56 skipped due missing CRD schemas
- `pre-commit run yamllint --files` for generated Flux `gotk-components.yaml`
  files
- `python3 tools/architecture/render.py --check`

Verifier approval was recorded and validated for
`1db53db8536364941086a1a690d787820c330e66` before push and PR creation.
