### PR TITLE
fix: tune public gateway programmed alert

### DIFF
--- a/.codex/runbooks/cloudflare-tunnels.md
+++ b/.codex/runbooks/cloudflare-tunnels.md
@@ -37,6 +37,18 @@ cloudflared tunnel route dns my-tunnel example.com
 Public Cloudflare hostnames should enter Kubernetes through `gateway/public`.
 Cloudflared forwards public traffic to the public Gateway over HTTP, and the app-owned `HTTPRoute` selects the backend Service. Do not point cloudflared ingress rules directly at app Services.
 
+The `gateway/public` Gateway intentionally uses a Cilium NodePort service so it
+stays an in-cluster Cloudflare origin instead of receiving a LAN-advertised
+LoadBalancer IP. Cilium may report this Gateway as `Programmed=False` with
+`reason=AddressNotAssigned`; that condition is expected only for
+`gateway/public` while its service remains NodePort.
+
+Cloudflare can also apply remotely managed tunnel ingress configuration. When
+debugging a public hostname, compare the repo-managed `ConfigMap/cloudflared`
+with cloudflared pod logs and Cloudflare-side tunnel settings. The expected
+origin is `http://cilium-gateway-public.gateway.svc.cluster.local:80`; direct
+origins such as `http://foundryvtt.foundryvtt:80` bypass `gateway/public`.
+
 For each public hostname:
 
 1. Add a cloudflared ingress rule that sends the hostname to the public Gateway:

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml
@@ -31,7 +31,12 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(gatewayapi_gateway_status_condition{type="Programmed"} == bool 0) OR vector(0)
+            expr: >-
+              sum(
+                (gatewayapi_gateway_status_condition{type="Programmed"} == bool 0)
+                unless on(exported_namespace, name, type)
+                gatewayapi_gateway_status_condition{type="Programmed",exported_namespace="gateway",name="public",reason="AddressNotAssigned"}
+              ) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:


### PR DESCRIPTION
## Summary

- Tuned `Gateway Not Programmed` so the intentional `gateway/public` NodePort Gateway does not alert for `Programmed=False` with `reason=AddressNotAssigned`.
- Documented that `gateway/public` intentionally remains NodePort and that public tunnel debugging should check Cloudflare remote ingress for direct app-service origins.

## Important Changes

- The alert exclusion is scoped to `exported_namespace="gateway"`, `name="public"`, `type="Programmed"`, and `reason="AddressNotAssigned"`.
- Other unprogrammed Gateways still alert, and `gateway/public` will alert if its failure reason changes.
- No LoadBalancer IP was allocated and `gateway/public` was not changed from NodePort.

## Documentation Impact

- Updated `.codex/runbooks/cloudflare-tunnels.md` with the expected public Gateway NodePort status and remote Cloudflare ingress check.

## Verification

- `pre-commit run yamllint --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml`
- `pre-commit run trailing-whitespace --files .codex/runbooks/cloudflare-tunnels.md kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml`
- `pre-commit run end-of-file-fixer --files .codex/runbooks/cloudflare-tunnels.md kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml`
- `pre-commit run k8svalidate --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-gateway-cilium.yaml`
- `python3 tools/architecture/render.py --check`
- `git diff --check`
- Live production Mimir check: old expression evaluated to `1`; new expression evaluated to `0`.
- Live production Gateway check: only `gateway/public` is `Programmed=False`, with `reason=AddressNotAssigned`.
- Live in-cluster HTTP check: `Host: foundry2.petebeegle.com` through `cilium-gateway-public.gateway.svc.cluster.local:80` returned Foundry HTML via Envoy.

## TDD And Smoke Evidence

- Risk tier: medium.
- TDD exception: no useful red test seam exists for this PromQL-only `GrafanaAlertRuleGroup` change; validation used focused linting, Kubernetes manifest validation, and live Mimir query evaluation.
- Development smoke exception: this targets a production-only public Cloudflare Gateway, so development cluster smoke was not applicable. Read-only production checks were used instead.

## Subagent Fallback

- Implementation and verifier subagents were not used because the runtime tool policy only permits spawning subagents when the user explicitly requests delegation. Self-implementation and self-verification were used under the repository workflow fallback rule with separate owner and verifier identities/tokens.
