### PR TITLE
Implementation: synthetic-smoke

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
-- App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`.
+- App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`.
 
 ### Development
 
@@ -89,6 +89,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-renovate` | `./kubernetes/apps/renovate` | `gateway` | `cluster-vars` | `sops` |
+| `production` | `app-synthetics` | `./kubernetes/apps/synthetics` | `gateway`, `grafana`, `authentik`, `app-whoami`, `app-jellyfin`, `app-pihole`, `app-foundryvtt` | `cluster-vars` | `no` |
 | `production` | `app-valheim` | `./kubernetes/apps/valheim` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-whoami` | `./kubernetes/apps/whoami` | `gateway` | `cluster-vars` | `no` |
 | `development` | `app-whoami` | `./kubernetes/apps/whoami` | `gateway` | `cluster-vars` | `no` |
@@ -106,8 +107,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/crds` | `https://github.com/kubernetes-csi/external-snapshotter//client/config/crd?ref=v8.5.0`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`, `prometheus`, `grafana` |
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
 | `kubernetes/infra/monitoring/alloy` | `repositories.yaml`, `namespace.yaml`, `app.yaml` |
-| `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-kubernetes.yaml`, `alert-rules-certificates.yaml`, `alert-rules-gateway-cilium.yaml`, `alert-rules-observability.yaml`, `alert-rules-apps.yaml`, `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml` |
-| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml` |
+| `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-kubernetes.yaml`, `alert-rules-certificates.yaml`, `alert-rules-gateway-cilium.yaml`, `alert-rules-observability.yaml`, `alert-rules-apps.yaml`, `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml`, `alert-rules-synthetics.yaml` |
+| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml`, `synthetic-smoke-dashboard.yaml` |
 | `kubernetes/infra/monitoring/grafana` | `namespace.yaml`, `repositories.yaml`, `app.yaml`, `secret.yaml`, `grafana-env.yaml`, `gateway.yaml`, `grafana-instance.yaml`, `folders.yaml`, `dashboards`, `alerting` |
 | `kubernetes/infra/monitoring/kube-state-metrics` | `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring` | `namespace.yaml`, `kube-state-metrics`, `snmp-exporter`, `pretty-discord-alerts` |
@@ -127,6 +128,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
 | `kubernetes/apps/renovate` | `app.yaml`, `secret.yaml` |
+| `kubernetes/apps/synthetics` | `namespace.yaml`, `cronjob.yaml` |
 | `kubernetes/apps/valheim` | `./app.yaml`, `./secret.yaml` |
 | `kubernetes/apps/whoami/branch` | `whoami.yaml` |
 | `kubernetes/apps/whoami` | `namespace.yaml`, `whoami.yaml` |

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -21,7 +21,8 @@ Use this runbook to add a Kubernetes app managed by Flux.
 7. Add the new cluster-layer file to `kubernetes/clusters/production/apps/kustomization.yaml`.
 8. If the app should be testable in branch environments, add a branch-aware overlay that uses `branch_slug` in names, namespaces, hostnames, and PVC names.
 9. Add or select a development smoke profile for the app, or document why the app cannot be smoke-tested in development yet.
-10. Verify after Flux reconciles.
+10. For routed HTTP apps, add an unauthenticated probe to `tests/smoke/routes.spec.js` or document why the app should be excluded from in-cluster synthetic smoke checks. Prefer durable page-shell text or redirect assertions and add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires the app to exist first.
+11. Verify after Flux reconciles.
 
 ## Choose Exposure
 

--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -1,0 +1,63 @@
+# Synthetic Smoke Tests
+
+Use this runbook when the in-cluster Playwright smoke checks fail or when adding a routed app to the smoke suite.
+
+## Purpose
+
+`CronJob/synthetic-smoke` runs in the `synthetics` namespace and validates user-visible routes from inside the cluster. These checks exercise DNS, Gateway API routing, TLS termination, HTTP redirects, and the first unauthenticated page shell for selected apps.
+
+The checks are intentionally deeper than pod readiness and lighter than full authenticated end-to-end tests. They do not use credentials in v1.
+
+## Targets
+
+- `whoami.${cluster_domain}` verifies the baseline Gateway TLS path.
+- `authentik.${cluster_domain}` verifies the SSO start or login page.
+- `monitoring.${cluster_domain}` verifies the Grafana login or landing shell.
+- `jellyfin.${cluster_domain}` verifies the Jellyfin web shell.
+- `pihole.${cluster_domain}` verifies the root redirect to `/admin`.
+- `foundry.${cluster_domain}` verifies the Foundry application shell.
+
+## Manual Run
+
+Create a one-off Job from the CronJob:
+
+```bash
+kubectl create job -n synthetics synthetic-smoke-manual-$(date +%Y%m%d%H%M%S) \
+  --from=cronjob/synthetic-smoke
+```
+
+Watch it finish:
+
+```bash
+kubectl get jobs,pods -n synthetics -l app.kubernetes.io/name=synthetic-smoke
+```
+
+Read the Playwright output:
+
+```bash
+kubectl logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
+```
+
+## Common Failures
+
+- DNS failure: confirm the hostname resolves from a pod in `synthetics`.
+- TLS failure: check the Gateway certificate and cert-manager Certificate status.
+- HTTP 404 or 503: inspect the app `HTTPRoute` Accepted and ResolvedRefs conditions.
+- HTTP 5xx: check the backend Service, endpoints, pods, and app logs.
+- Missing text or selector: confirm whether the app upgraded or changed its unauthenticated page shell.
+- Dependency install failure: check outbound network access from the cluster; the Playwright image is pinned, and the npm dependencies are pinned by `tests/smoke/package-lock.json`.
+
+## Add A Probe
+
+1. Add the routed app to `tests/smoke/routes.spec.js`.
+2. Prefer unauthenticated page-shell checks that prove the user-facing route works without storing secrets.
+3. Match durable text, titles, or redirects instead of brittle CSS classes.
+4. Mirror the same smoke files under `kubernetes/apps/synthetics/smoke/`; Flux cannot load ConfigMap files from outside the app kustomization root.
+5. Add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires that app to exist first.
+6. Run the suite locally when the route is reachable, then create a manual Job after Flux applies the change.
+
+## Dashboard And Alert
+
+Grafana owns the `Synthetics` folder, `Synthetic Smoke` dashboard, and `synthetics` alert rule group. The dashboard shows recent pass/fail counts, Job duration, pod termination reasons, and Loki log excerpts for `namespace="synthetics"`.
+
+The alert fires only when smoke Jobs fail more than once in the last hour. A single failed run should be investigated, but it is not enough to alert by itself.

--- a/kubernetes/apps/synthetics/cronjob.yaml
+++ b/kubernetes/apps/synthetics/cronjob.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: synthetic-smoke
+  namespace: synthetics
+  labels:
+    app: synthetic-smoke
+    app.kubernetes.io/name: synthetic-smoke
+    app.kubernetes.io/component: synthetic-test
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 6
+  jobTemplate:
+    metadata:
+      labels:
+        app: synthetic-smoke
+        app.kubernetes.io/name: synthetic-smoke
+        app.kubernetes.io/component: synthetic-test
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: synthetic-smoke
+            app.kubernetes.io/name: synthetic-smoke
+            app.kubernetes.io/component: synthetic-test
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: playwright
+              image: mcr.microsoft.com/playwright:v1.60.0-noble
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CI
+                  value: "true"
+                - name: HOME
+                  value: /tmp
+                - name: npm_config_cache
+                  value: /workdir/.npm
+                - name: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
+                  value: "1"
+                - name: SMOKE_BASE_DOMAIN
+                  value: "${cluster_domain}"
+              command:
+                - /bin/bash
+                - -ceu
+                - |
+                  cp -R /smoke-src/. /workdir
+                  cd /workdir
+                  npm ci --no-audit --no-fund
+                  npm run test -- --reporter=list
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: smoke-source
+                  mountPath: /smoke-src
+                  readOnly: true
+                - name: workdir
+                  mountPath: /workdir
+          volumes:
+            - name: smoke-source
+              configMap:
+                name: synthetic-smoke-source
+            - name: workdir
+              emptyDir: {}

--- a/kubernetes/apps/synthetics/kustomization.yaml
+++ b/kubernetes/apps/synthetics/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: synthetic-smoke-source
+    namespace: synthetics
+    files:
+      - package.json=smoke/package.json
+      - package-lock.json=smoke/package-lock.json
+      - playwright.config.js=smoke/playwright.config.js
+      - routes.spec.js=smoke/routes.spec.js
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/synthetics/namespace.yaml
+++ b/kubernetes/apps/synthetics/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: synthetics
+  labels:
+    name: synthetics
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/synthetics/smoke/package-lock.json
+++ b/kubernetes/apps/synthetics/smoke/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homelab-smoke-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/kubernetes/apps/synthetics/smoke/package.json
+++ b/kubernetes/apps/synthetics/smoke/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0"
+  }
+}

--- a/kubernetes/apps/synthetics/smoke/playwright.config.js
+++ b/kubernetes/apps/synthetics/smoke/playwright.config.js
@@ -1,0 +1,32 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000
+  },
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["list"], ["json", { outputFile: "test-results.json" }]] : "list",
+  use: {
+    baseURL: `https://whoami.${process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+    launchOptions: {
+      chromiumSandbox: false
+    },
+    actionTimeout: 10_000,
+    navigationTimeout: 20_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"]
+      }
+    }
+  ]
+});

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -1,0 +1,47 @@
+const { expect, test } = require("@playwright/test");
+
+const baseDomain = process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com";
+
+function urlFor(host, path = "/") {
+  return `https://${host}.${baseDomain}${path}`;
+}
+
+async function gotoOk(page, url) {
+  const response = await page.goto(url, { waitUntil: "domcontentloaded" });
+  expect(response, `${url} should return an HTTP response`).not.toBeNull();
+  expect(response.status(), `${url} should not return a server error`).toBeLessThan(500);
+  return response;
+}
+
+test.describe("homelab routed services", () => {
+  test("whoami exercises Gateway TLS and routing", async ({ page }) => {
+    await gotoOk(page, urlFor("whoami"));
+    await expect(page.locator("body")).toContainText(/Hostname|IP|RemoteAddr|GET \//i);
+  });
+
+  test("authentik serves the unauthenticated start page", async ({ page }) => {
+    await gotoOk(page, urlFor("authentik"));
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
+  test("grafana reaches the login or landing shell", async ({ page }) => {
+    await gotoOk(page, urlFor("monitoring"));
+    await expect(page.locator("body")).toContainText(/Grafana|Login|Sign in|Welcome/i);
+  });
+
+  test("jellyfin reaches the public web shell", async ({ page }) => {
+    await gotoOk(page, urlFor("jellyfin"));
+    await expect(page.locator("body")).toContainText(/Jellyfin|Please sign in|Wizard|Login/i);
+  });
+
+  test("pihole root redirects to the admin shell", async ({ page }) => {
+    await gotoOk(page, urlFor("pihole"));
+    await expect(page).toHaveURL(/\/admin\/?$/);
+    await expect(page.locator("body")).toContainText(/Pi-hole|Sign in|Login|Password/i);
+  });
+
+  test("foundry reaches the unauthenticated application shell", async ({ page }) => {
+    await gotoOk(page, urlFor("foundry"));
+    await expect(page.locator("body")).toContainText(/Foundry|Game Worlds|Administration|Join Game Session|Setup/i);
+  });
+});

--- a/kubernetes/clusters/production/apps/kustomization.yaml
+++ b/kubernetes/clusters/production/apps/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - jellyfin.yaml
   - foundryvtt.yaml
   - valheim.yaml
+  - synthetics.yaml

--- a/kubernetes/clusters/production/apps/synthetics.yaml
+++ b/kubernetes/clusters/production/apps/synthetics.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-synthetics
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./kubernetes/apps/synthetics
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: gateway
+    - name: grafana
+    - name: authentik
+    - name: app-whoami
+    - name: app-jellyfin
+    - name: app-pihole
+    - name: app-foundryvtt
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-synthetics.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-synthetics.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaAlertRuleGroup
+metadata:
+  name: synthetics
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "synthetics"
+  interval: 1m
+  rules:
+    - uid: synthetic-smoke-repeated-failures
+      title: Synthetic Smoke Repeated Failures
+      condition: C
+      for: 0s
+      noDataState: NoData
+      execErrState: Error
+      annotations:
+        description: "Synthetic smoke tests have failed {{ $values.B.Value }} time(s) in the last hour."
+        summary: In-cluster Playwright smoke checks are failing repeatedly
+        runbook: "docs/runbooks/synthetic-smoke-tests.md"
+      labels:
+        severity: warning
+        component: synthetics
+      data:
+        - refId: A
+          relativeTimeRange:
+            from: 3600
+            to: 0
+          datasourceUid: prometheus
+          model:
+            expr: sum(increase(kube_job_status_failed{namespace="synthetics",job_name=~"synthetic-smoke-.+"}[1h])) OR sum(increase(kube_job_status_failed{exported_namespace="synthetics",job_name=~"synthetic-smoke-.+"}[1h])) OR vector(0)
+            refId: A
+        - refId: B
+          relativeTimeRange:
+            from: 3600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: A
+            reducer: last
+            type: reduce
+            refId: B
+        - refId: C
+          relativeTimeRange:
+            from: 3600
+            to: 0
+          datasourceUid: __expr__
+          model:
+            expression: B
+            conditions:
+              - evaluator:
+                  params:
+                    - 1
+                  type: gt
+                operator:
+                  type: and
+                query:
+                  params:
+                    - C
+                type: query
+            type: threshold
+            refId: C

--- a/kubernetes/infra/monitoring/grafana/alerting/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - alert-rules-proxmox.yaml
   - alert-rules-flux.yaml
   - alert-rules-valheim.yaml
+  - alert-rules-synthetics.yaml

--- a/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
@@ -39,6 +39,12 @@ configMapGenerator:
       - dashboard.json=codex-operations-dashboard.json
     options:
       disableNameSuffixHash: true
+  - name: synthetic-smoke-dashboard
+    namespace: grafana
+    files:
+      - dashboard.json=synthetic-smoke-dashboard.json
+    options:
+      disableNameSuffixHash: true
 resources:
   - proxmox-dashboard.yaml
   - flux-dashboard.yaml
@@ -46,3 +52,4 @@ resources:
   - authentik-dashboard.yaml
   - observability-health-dashboard.yaml
   - codex-operations-dashboard.yaml
+  - synthetic-smoke-dashboard.yaml

--- a/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json
@@ -1,0 +1,333 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "Passing"
+                },
+                "1": {
+                  "color": "red",
+                  "text": "Failing"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(kube_job_status_failed{namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[30m])) OR sum(increase(kube_job_status_failed{exported_namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[30m])) OR vector(0)",
+          "legendFormat": "failed runs",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(kube_job_status_failed{namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[$__rate_interval])) OR sum(increase(kube_job_status_failed{exported_namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[$__rate_interval])) OR vector(0)",
+          "legendFormat": "failed",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(kube_job_status_succeeded{namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[$__rate_interval])) OR sum(increase(kube_job_status_succeeded{exported_namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}[$__rate_interval])) OR vector(0)",
+          "legendFormat": "succeeded",
+          "refId": "B"
+        }
+      ],
+      "title": "Smoke Runs",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (job_name) (kube_job_status_completion_time{namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"} - kube_job_status_start_time{namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"}) OR max by (job_name) (kube_job_status_completion_time{exported_namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"} - kube_job_status_start_time{exported_namespace=\"synthetics\",job_name=~\"synthetic-smoke-.+\"})",
+          "legendFormat": "{{job_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Job Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (pod, container, reason) (kube_pod_container_status_terminated_reason{namespace=\"synthetics\"} > bool 0) OR max by (pod, container, reason) (kube_pod_container_status_terminated_reason{exported_namespace=\"synthetics\"} > bool 0)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Termination Reasons",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{namespace=\"synthetics\", app=\"synthetic-smoke\"} |~ \"failed|Failed|Error|Timeout|PASS|FAIL|chromium|synthetic-smoke\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Smoke Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "synthetics",
+    "smoke"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Synthetic Smoke",
+  "uid": "synthetic-smoke",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: synthetic-smoke
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "synthetics"
+  configMapRef:
+    name: synthetic-smoke-dashboard
+    key: dashboard.json

--- a/kubernetes/infra/monitoring/grafana/folders.yaml
+++ b/kubernetes/infra/monitoring/grafana/folders.yaml
@@ -57,6 +57,17 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
+  name: synthetics
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: "Synthetics"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
   name: monitoring
   namespace: grafana
 spec:

--- a/tests/smoke/package-lock.json
+++ b/tests/smoke/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homelab-smoke-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/smoke/package.json
+++ b/tests/smoke/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0"
+  }
+}

--- a/tests/smoke/playwright.config.js
+++ b/tests/smoke/playwright.config.js
@@ -1,0 +1,32 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000
+  },
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["list"], ["json", { outputFile: "test-results.json" }]] : "list",
+  use: {
+    baseURL: `https://whoami.${process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+    launchOptions: {
+      chromiumSandbox: false
+    },
+    actionTimeout: 10_000,
+    navigationTimeout: 20_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"]
+      }
+    }
+  ]
+});

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -1,0 +1,47 @@
+const { expect, test } = require("@playwright/test");
+
+const baseDomain = process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com";
+
+function urlFor(host, path = "/") {
+  return `https://${host}.${baseDomain}${path}`;
+}
+
+async function gotoOk(page, url) {
+  const response = await page.goto(url, { waitUntil: "domcontentloaded" });
+  expect(response, `${url} should return an HTTP response`).not.toBeNull();
+  expect(response.status(), `${url} should not return a server error`).toBeLessThan(500);
+  return response;
+}
+
+test.describe("homelab routed services", () => {
+  test("whoami exercises Gateway TLS and routing", async ({ page }) => {
+    await gotoOk(page, urlFor("whoami"));
+    await expect(page.locator("body")).toContainText(/Hostname|IP|RemoteAddr|GET \//i);
+  });
+
+  test("authentik serves the unauthenticated start page", async ({ page }) => {
+    await gotoOk(page, urlFor("authentik"));
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
+  test("grafana reaches the login or landing shell", async ({ page }) => {
+    await gotoOk(page, urlFor("monitoring"));
+    await expect(page.locator("body")).toContainText(/Grafana|Login|Sign in|Welcome/i);
+  });
+
+  test("jellyfin reaches the public web shell", async ({ page }) => {
+    await gotoOk(page, urlFor("jellyfin"));
+    await expect(page.locator("body")).toContainText(/Jellyfin|Please sign in|Wizard|Login/i);
+  });
+
+  test("pihole root redirects to the admin shell", async ({ page }) => {
+    await gotoOk(page, urlFor("pihole"));
+    await expect(page).toHaveURL(/\/admin\/?$/);
+    await expect(page.locator("body")).toContainText(/Pi-hole|Sign in|Login|Password/i);
+  });
+
+  test("foundry reaches the unauthenticated application shell", async ({ page }) => {
+    await gotoOk(page, urlFor("foundry"));
+    await expect(page.locator("body")).toContainText(/Foundry|Game Worlds|Administration|Join Game Session|Setup/i);
+  });
+});


### PR DESCRIPTION
## Summary
# Synthetic Smoke

## Summary

Add GitOps-managed in-cluster Playwright smoke tests for key routed services. The runner lives in the new `synthetics` namespace, while Grafana dashboard and alert resources remain managed by the existing Grafana Operator manifests in the `grafana` namespace.

## Important Changes

- Added `CronJob/synthetic-smoke` and `Namespace/synthetics` under `kubernetes/apps/synthetics`.
- Added Playwright smoke specs for whoami, authentik, Grafana, Jellyfin, Pi-hole, and Foundry under `tests/smoke` and the deployable app-local smoke source copy required by Kustomize load restrictions.
- Added production Flux activation with dependencies on Gateway, Grafana/authentik, and probed app Kustomizations.
- Added a Grafana `Synthetics` folder, `Synthetic Smoke` dashboard, and repeated-failure alert rule group.
- Refreshed generated `docs/architecture.md`.

## Documentation Impact

- Added `docs/runbooks/synthetic-smoke-tests.md`.
- Updated `docs/runbooks/add-app.md` so routed HTTP apps consider synthetic smoke coverage.

## Verification

- `kubectl kustomize kubernetes/apps/synthetics`
- `kubectl kustomize kubernetes/clusters/production/apps`
- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- `kubectl kustomize kubernetes/clusters/production`
- `python3 tools/architecture/render.py --check`
- `npm ci && npm run test -- --list` in `tests/smoke`
- `diff -qr tests/smoke kubernetes/apps/synthetics/smoke`
- `pre-commit run --all-files`
- Workflow marker, implementation plan, and owner attestation validation commands passed.
- Verifier agent approved exact HEAD `b56e9960a8c5752460d0b103d8638f4d1ba7ecf8` after re-checking the amended CronJob labels, app render, and full production render.

## Deferred Live Smoke

Local full Playwright execution was attempted after installing Chromium, but this workspace lacks required browser system libraries such as `libglib-2.0.so.0`. The deployed CronJob uses `mcr.microsoft.com/playwright:v1.60.0-noble`, which includes the browser system dependencies and preinstalled browsers. A manual in-cluster Job should be created after Flux applies the branch.

## Workflow Note

Initial implementation was self-owned because higher-priority runtime policy only permits subagent delegation when the user explicitly asks for it. After the user requested agent-backed follow-through, a verifier agent reviewed and approved the exact PR HEAD.


## Changes
- docs/architecture.md
- docs/runbooks/add-app.md
- docs/runbooks/synthetic-smoke-tests.md
- kubernetes/apps/synthetics/cronjob.yaml
- kubernetes/apps/synthetics/kustomization.yaml
- kubernetes/apps/synthetics/namespace.yaml
- kubernetes/apps/synthetics/smoke/package-lock.json
- kubernetes/apps/synthetics/smoke/package.json
- kubernetes/apps/synthetics/smoke/playwright.config.js
- kubernetes/apps/synthetics/smoke/routes.spec.js
- kubernetes/clusters/production/apps/kustomization.yaml
- kubernetes/clusters/production/apps/synthetics.yaml
- kubernetes/infra/monitoring/grafana/alerting/alert-rules-synthetics.yaml
- kubernetes/infra/monitoring/grafana/alerting/kustomization.yaml
- kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
- kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json
- kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.yaml
- kubernetes/infra/monitoring/grafana/folders.yaml
- tests/smoke/package-lock.json
- tests/smoke/package.json
- tests/smoke/playwright.config.js
- tests/smoke/routes.spec.js

## Commits
- b56e996 feat: add synthetic smoke tests

## Verification
- Verified HEAD: `b56e9960a8c5752460d0b103d8638f4d1ba7ecf8`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
