### PR TITLE
feat(foundry): add dev-gated blue green workflow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Root Kustomization: `kubernetes/clusters/development/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`.
-- App activation list: `whoami.yaml`.
+- App activation list: `whoami.yaml`, `foundry-bluegreen-fixture.yaml`.
 
 - Branch environment templates: `whoami-template.yaml`.
 
@@ -91,6 +91,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-renovate` | `./kubernetes/apps/renovate` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-valheim` | `./kubernetes/apps/valheim` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-whoami` | `./kubernetes/apps/whoami` | `gateway` | `cluster-vars` | `no` |
+| `development` | `app-foundry-bluegreen-fixture` | `./kubernetes/apps/foundry-bluegreen-fixture` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
 | `development` | `app-whoami` | `./kubernetes/apps/whoami` | `gateway` | `cluster-vars` | `no` |
 
 ## Kustomize Resource Relationships
@@ -101,7 +102,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/controllers/cert-manager` | `app.yaml`, `secret.yaml` |
 | `kubernetes/infra/controllers/grafana-operator` | `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/controllers` | `./nfs-csi`, `./cert-manager`, `./grafana-operator` |
-| `kubernetes/infra/controllers/nfs-csi` | `app.yaml`, `storageclass.yaml` |
+| `kubernetes/infra/controllers/nfs-csi` | `app.yaml`, `storageclass.yaml`, `volumesnapshotclass.yaml` |
 | `kubernetes/infra/crds/grafana` | `app.yaml` |
 | `kubernetes/infra/crds` | `https://github.com/kubernetes-csi/external-snapshotter//client/config/crd?ref=v8.5.0`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`, `prometheus`, `grafana` |
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
@@ -123,6 +124,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./vpn-dns.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
+| `kubernetes/apps/foundry-bluegreen-fixture` | `namespace.yaml`, `pvc-blue.yaml`, `pvc-green.yaml`, `deployment-blue.yaml`, `deployment-green.yaml`, `service-blue.yaml`, `service-green.yaml`, `httproute-green-preview.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml`, `httproute-public.yaml` |
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
@@ -137,6 +139,7 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
+| `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.development.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt-public` | `foundry2.petebeegle.com` | `gateway/public/http-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
@@ -158,6 +161,8 @@ This document is generated for agentic repo navigation. It records relationships
 | Source | Owner | StorageClass | Path |
 | --- | --- | --- | --- |
 | HelmRelease values | `valheim/valheim-server` | `nfs-csi-storage` | `kubernetes/apps/valheim/app.yaml` |
+| PVC | `foundry-bluegreen-fixture/foundry-fixture-blue` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-blue.yaml` |
+| PVC | `foundry-bluegreen-fixture/foundry-fixture-green` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-green.yaml` |
 | PVC | `foundryvtt/foundryvtt-data-pvc` | `nfs-csi-storage` | `kubernetes/apps/foundryvtt/pvc.yaml` |
 | PVC | `wireguard/wireguard-pvc` | `nfs-csi-storage` | `kubernetes/infra/network/vpn/pvc.yaml` |
 | Values file | `authentik` | `nfs-csi-storage` | `kubernetes/infra/authentik/values.yaml` |

--- a/docs/runbooks/foundry-bluegreen.md
+++ b/docs/runbooks/foundry-bluegreen.md
@@ -1,0 +1,73 @@
+---
+status: current
+scope:
+  - foundryvtt
+  - blue-green-upgrades
+  - nfs-csi-snapshots
+created: 2026-05-16
+last_verified: 2026-05-16
+---
+
+# Foundry Safe Blue/Green Upgrade
+
+Use this runbook for Foundry VTT image upgrades. Production changes stay GitOps-first: the tool edits repository desired state and the operator commits, opens a PR, merges it, and waits for Flux. Do not patch production routes live.
+
+## Safety Model
+
+- Development rehearsal is mandatory before production `prepare`, `promote`, `rollback`, or `retire`.
+- `dev-rehearse` uses the small development-only fixture in `kubernetes/apps/foundry-bluegreen-fixture`, not real Foundry and not Foundry secrets.
+- Rehearsal evidence is written to `.codex/tmp/foundry-bluegreen-dev-rehearse.json` and is valid only for the current tool/config version.
+- `prepare` pauses the blue Foundry deployment before creating the NFS CSI snapshot desired state.
+- `Service/foundryvtt` remains the stable production backend for the existing public and internal routes.
+- Green preview traffic uses the internal Gateway only at `foundry-green.${cluster_domain}`.
+- The development fixture preview is LAN-only at `foundry-green-preview.development.lab.petebeegle.com`.
+- After `promote`, inactive blue remains scaled to zero until an explicit `retire`.
+
+## Development Rehearsal
+
+From a clean implementation branch:
+
+```bash
+python3 tools/foundry_bluegreen.py status
+python3 tools/foundry_bluegreen.py dev-rehearse
+```
+
+The rehearsal applies the safe fixture to development, waits for blue and green HTTP workloads, scales blue to zero, creates `VolumeSnapshot/foundry-fixture-blue-rehearsal` with `VolumeSnapshotClass/nfs-csi-snapshot`, waits for readiness, and scales blue back to one replica.
+
+If development access is unavailable, do not run production commands. Record the blocker in the PR summary and rerun rehearsal when access returns.
+
+## Prepare Green
+
+```bash
+python3 tools/foundry_bluegreen.py prepare --image felddy/foundryvtt:<tag>
+```
+
+`prepare` fails unless current rehearsal evidence exists. On success it edits `kubernetes/apps/foundryvtt` to:
+
+- scale blue `Deployment/foundryvtt` to zero for snapshot consistency,
+- add `VolumeSnapshot/foundryvtt-blue-pre-upgrade`,
+- add green PVC, Deployment, preview Service, and internal preview `HTTPRoute`.
+
+Commit the desired-state changes, open a PR, merge it after review, and wait for Flux to reconcile production.
+
+## Promote, Roll Back, Retire
+
+Promote after the green preview is validated:
+
+```bash
+python3 tools/foundry_bluegreen.py promote
+```
+
+Rollback if green is not acceptable:
+
+```bash
+python3 tools/foundry_bluegreen.py rollback
+```
+
+Retire only after the promoted state has soaked and rollback is no longer needed:
+
+```bash
+python3 tools/foundry_bluegreen.py retire
+```
+
+Each command edits repository desired state only. Commit, PR, merge, and wait for Flux after each production step.

--- a/docs/runbooks/foundry-bluegreen.md
+++ b/docs/runbooks/foundry-bluegreen.md
@@ -16,6 +16,7 @@ Use this runbook for Foundry VTT image upgrades. Production changes stay GitOps-
 
 - Development rehearsal is mandatory before production `prepare`, `promote`, `rollback`, or `retire`.
 - `dev-rehearse` uses the small development-only fixture in `kubernetes/apps/foundry-bluegreen-fixture`, not real Foundry and not Foundry secrets.
+- `dev-rehearse` only accepts the development kubeconfig at `~/.kube/homelab-development.config` after path expansion and resolution.
 - Rehearsal evidence is written to `.codex/tmp/foundry-bluegreen-dev-rehearse.json` and is valid only for the current tool/config version.
 - `prepare` pauses the blue Foundry deployment before creating the NFS CSI snapshot desired state.
 - `Service/foundryvtt` remains the stable production backend for the existing public and internal routes.

--- a/kubernetes/apps/foundry-bluegreen-fixture/deployment-blue.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/deployment-blue.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foundry-fixture-blue
+  namespace: foundry-bluegreen-fixture
+  labels:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foundry-bluegreen-fixture
+      foundryvtt.petebeegle.com/color: blue
+  template:
+    metadata:
+      labels:
+        app: foundry-bluegreen-fixture
+        foundryvtt.petebeegle.com/color: blue
+    spec:
+      initContainers:
+        - name: write-page
+          image: busybox:1.37.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cat >/work/index.html <<'EOF'
+              foundry blue fixture
+              EOF
+          volumeMounts:
+            - name: webroot
+              mountPath: /work
+      containers:
+        - name: http
+          image: nginx:1.29.4-alpine
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: webroot
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: webroot
+          persistentVolumeClaim:
+            claimName: foundry-fixture-blue

--- a/kubernetes/apps/foundry-bluegreen-fixture/deployment-green.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/deployment-green.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foundry-fixture-green
+  namespace: foundry-bluegreen-fixture
+  labels:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foundry-bluegreen-fixture
+      foundryvtt.petebeegle.com/color: green
+  template:
+    metadata:
+      labels:
+        app: foundry-bluegreen-fixture
+        foundryvtt.petebeegle.com/color: green
+    spec:
+      initContainers:
+        - name: write-page
+          image: busybox:1.37.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cat >/work/index.html <<'EOF'
+              foundry green fixture
+              EOF
+          volumeMounts:
+            - name: webroot
+              mountPath: /work
+      containers:
+        - name: http
+          image: nginx:1.29.4-alpine
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: webroot
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: webroot
+          persistentVolumeClaim:
+            claimName: foundry-fixture-green

--- a/kubernetes/apps/foundry-bluegreen-fixture/httproute-green-preview.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/httproute-green-preview.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foundry-fixture-green-preview
+  namespace: foundry-bluegreen-fixture
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+      sectionName: https-gateway
+  hostnames:
+    - foundry-green-preview.development.lab.petebeegle.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: foundry-fixture-green
+          port: 80
+          weight: 1

--- a/kubernetes/apps/foundry-bluegreen-fixture/kustomization.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc-blue.yaml
+  - pvc-green.yaml
+  - deployment-blue.yaml
+  - deployment-green.yaml
+  - service-blue.yaml
+  - service-green.yaml
+  - httproute-green-preview.yaml

--- a/kubernetes/apps/foundry-bluegreen-fixture/namespace.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foundry-bluegreen-fixture
+  labels:
+    name: foundry-bluegreen-fixture
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/foundry-bluegreen-fixture/pvc-blue.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/pvc-blue.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: foundryvtt-data-pvc
-  namespace: foundryvtt
+  name: foundry-fixture-blue
+  namespace: foundry-bluegreen-fixture
   labels:
-    app: foundryvtt
+    app: foundry-bluegreen-fixture
     foundryvtt.petebeegle.com/color: blue
 spec:
   storageClassName: nfs-csi-storage
@@ -13,4 +13,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 40G
+      storage: 1Gi

--- a/kubernetes/apps/foundry-bluegreen-fixture/pvc-green.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/pvc-green.yaml
@@ -2,15 +2,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: foundryvtt-data-pvc
-  namespace: foundryvtt
+  name: foundry-fixture-green
+  namespace: foundry-bluegreen-fixture
   labels:
-    app: foundryvtt
-    foundryvtt.petebeegle.com/color: blue
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: green
 spec:
   storageClassName: nfs-csi-storage
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 40G
+      storage: 1Gi

--- a/kubernetes/apps/foundry-bluegreen-fixture/service-blue.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/service-blue.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foundry-fixture-blue
+  namespace: foundry-bluegreen-fixture
+  labels:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: blue
+spec:
+  selector:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: blue
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/kubernetes/apps/foundry-bluegreen-fixture/service-green.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/service-green.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foundry-fixture-green
+  namespace: foundry-bluegreen-fixture
+  labels:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: green
+spec:
+  selector:
+    app: foundry-bluegreen-fixture
+    foundryvtt.petebeegle.com/color: green
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/kubernetes/apps/foundryvtt/deployment.yaml
+++ b/kubernetes/apps/foundryvtt/deployment.yaml
@@ -6,16 +6,19 @@ metadata:
   name: foundryvtt
   labels:
     app: foundryvtt
+    foundryvtt.petebeegle.com/color: blue
 
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: foundryvtt
+      foundryvtt.petebeegle.com/color: blue
   template:
     metadata:
       labels:
         app: foundryvtt
+        foundryvtt.petebeegle.com/color: blue
     spec:
       securityContext:
         runAsUser: 421

--- a/kubernetes/apps/foundryvtt/service.yaml
+++ b/kubernetes/apps/foundryvtt/service.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   selector:
     app: foundryvtt
+    foundryvtt.petebeegle.com/color: blue
   ports:
     - name: web
       port: 80

--- a/kubernetes/clusters/development/apps/foundry-bluegreen-fixture.yaml
+++ b/kubernetes/clusters/development/apps/foundry-bluegreen-fixture.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-foundry-bluegreen-fixture
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./kubernetes/apps/foundry-bluegreen-fixture
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: gateway
+    - name: nfs-csi
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/kubernetes/clusters/development/apps/kustomization.yaml
+++ b/kubernetes/clusters/development/apps/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - whoami.yaml
+  - foundry-bluegreen-fixture.yaml

--- a/kubernetes/infra/controllers/nfs-csi/app.yaml
+++ b/kubernetes/infra/controllers/nfs-csi/app.yaml
@@ -51,3 +51,10 @@ spec:
     externalProvisioner:
       volumeBindingMode: Immediate
       reclaimPolicy: Retain
+    externalSnapshotter:
+      enabled: true
+      customResourceDefinitions:
+        enabled: false
+      deletionPolicy: Retain
+    volumeSnapshotClass:
+      create: false

--- a/kubernetes/infra/controllers/nfs-csi/kustomization.yaml
+++ b/kubernetes/infra/controllers/nfs-csi/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - app.yaml
   - storageclass.yaml
+  - volumesnapshotclass.yaml

--- a/kubernetes/infra/controllers/nfs-csi/volumesnapshotclass.yaml
+++ b/kubernetes/infra/controllers/nfs-csi/volumesnapshotclass.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: nfs-csi-snapshot
+driver: nfs.csi.k8s.io
+deletionPolicy: Retain

--- a/tools/foundry_bluegreen.py
+++ b/tools/foundry_bluegreen.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Safe, dev-gated blue/green workflow for Foundry VTT upgrades."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = Path("kubernetes/apps/foundryvtt")
+FIXTURE_DIR = Path("kubernetes/apps/foundry-bluegreen-fixture")
+EVIDENCE_PATH = Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
+DEV_KUBECONFIG = Path.home() / ".kube/homelab-development.config"
+PRODUCTION_COMMANDS = {"prepare", "promote", "rollback", "retire"}
+CONFIG_VERSION_GLOBS = [
+    "tools/foundry_bluegreen.py",
+    "kubernetes/infra/controllers/nfs-csi/*.yaml",
+    "kubernetes/apps/foundry-bluegreen-fixture/*.yaml",
+    "kubernetes/clusters/development/apps/foundry-bluegreen-fixture.yaml",
+]
+
+
+class FoundryBlueGreenError(RuntimeError):
+    """Raised when a workflow precondition fails."""
+
+
+@dataclass
+class CommandResult:
+    args: Sequence[str]
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = 0
+
+
+class CommandRunner:
+    def run(self, args: Sequence[str], *, input_text: str | None = None) -> CommandResult:
+        completed = subprocess.run(
+            list(args),
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            rendered = " ".join(args)
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise FoundryBlueGreenError(f"command failed: {rendered}\n{detail}")
+        return CommandResult(args=args, stdout=completed.stdout, stderr=completed.stderr, returncode=0)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def rel(root: Path, path: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def config_version(root: Path) -> str:
+    digest = hashlib.sha256()
+    for pattern in CONFIG_VERSION_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if path.is_file():
+                digest.update(rel(root, path).encode())
+                digest.update(b"\0")
+                digest.update(path.read_bytes())
+                digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def read_evidence(root: Path, evidence_path: Path) -> dict[str, object] | None:
+    path = root / evidence_path
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def require_current_dev_rehearsal(root: Path, evidence_path: Path) -> dict[str, object]:
+    expected = config_version(root)
+    evidence = read_evidence(root, evidence_path)
+    if not evidence:
+        raise FoundryBlueGreenError(
+            "production command blocked: run `tools/foundry_bluegreen.py dev-rehearse` first"
+        )
+    if evidence.get("status") != "succeeded":
+        raise FoundryBlueGreenError("production command blocked: last dev-rehearse did not succeed")
+    if evidence.get("config_version") != expected:
+        raise FoundryBlueGreenError(
+            "production command blocked: dev-rehearse evidence is stale for this tool/config version"
+        )
+    return evidence
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def replace_first_replicas(path: Path, replicas: int) -> None:
+    text = read(path)
+    next_text, count = re.subn(r"(?m)^  replicas: \d+\s*$", f"  replicas: {replicas}", text, count=1)
+    if count != 1:
+        raise FoundryBlueGreenError(f"could not update replicas in {path}")
+    write(path, next_text)
+
+
+def set_service_color(path: Path, color: str) -> None:
+    text = read(path)
+    next_text, count = re.subn(
+        r"(?m)^    foundryvtt\.petebeegle\.com/color: (blue|green)\s*$",
+        f"    foundryvtt.petebeegle.com/color: {color}",
+        text,
+        count=1,
+    )
+    if count != 1:
+        raise FoundryBlueGreenError(f"could not update active service color in {path}")
+    write(path, next_text)
+
+
+def service_color(path: Path) -> str:
+    match = re.search(r"(?m)^    foundryvtt\.petebeegle\.com/color: (blue|green)\s*$", read(path))
+    if not match:
+        raise FoundryBlueGreenError(f"could not determine active service color in {path}")
+    return match.group(1)
+
+
+def ensure_kustomization_resource(path: Path, resource: str) -> None:
+    text = read(path)
+    line = f"  - {resource}"
+    if line in text.splitlines():
+        return
+    if "resources:\n" not in text:
+        raise FoundryBlueGreenError(f"{path} has no resources block")
+    text = text.rstrip() + f"\n{line}\n"
+    write(path, text)
+
+
+def remove_kustomization_resource(path: Path, resource: str) -> None:
+    lines = [line for line in read(path).splitlines() if line.strip() != f"- {resource}"]
+    write(path, "\n".join(lines).rstrip() + "\n")
+
+
+def remove_file_if_exists(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+
+
+def validate_image(image: str) -> str:
+    if not re.fullmatch(r"felddy/foundryvtt:[A-Za-z0-9._-]+", image):
+        raise FoundryBlueGreenError("prepare requires --image in the form felddy/foundryvtt:<tag>")
+    return image
+
+
+def green_deployment(image: str) -> str:
+    return f"""---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: foundryvtt
+  name: foundryvtt-green
+  labels:
+    app: foundryvtt
+    foundryvtt.petebeegle.com/color: green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: foundryvtt
+      foundryvtt.petebeegle.com/color: green
+  template:
+    metadata:
+      labels:
+        app: foundryvtt
+        foundryvtt.petebeegle.com/color: green
+    spec:
+      securityContext:
+        runAsUser: 421
+        runAsGroup: 421
+        fsGroup: 421
+      containers:
+        - name: foundryvtt
+          image: {image}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: FOUNDRY_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: foundryvtt-secret
+                  key: FOUNDRY_ADMIN_KEY
+            - name: FOUNDRY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: foundryvtt-secret
+                  key: FOUNDRY_USERNAME
+            - name: FOUNDRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: foundryvtt-secret
+                  key: FOUNDRY_PASSWORD
+            - name: FOUNDRY_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: foundryvtt-secret
+                  key: FOUNDRY_LICENSE_KEY
+          ports:
+            - name: web
+              containerPort: 30000
+          volumeMounts:
+            - name: foundryvtt-data-persistent-storage
+              mountPath: /data
+          resources:
+            requests:
+              memory: "1Gi"
+              cpu: "500m"
+            limits:
+              memory: "4Gi"
+              cpu: "1"
+      volumes:
+        - name: foundryvtt-data-persistent-storage
+          persistentVolumeClaim:
+            claimName: foundryvtt-data-green-pvc
+"""
+
+
+def green_pvc() -> str:
+    return """---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: foundryvtt-data-green-pvc
+  namespace: foundryvtt
+  labels:
+    app: foundryvtt
+    foundryvtt.petebeegle.com/color: green
+spec:
+  storageClassName: nfs-csi-storage
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    apiGroup: snapshot.storage.k8s.io
+    kind: VolumeSnapshot
+    name: foundryvtt-blue-pre-upgrade
+  resources:
+    requests:
+      storage: 40G
+"""
+
+
+def blue_snapshot() -> str:
+    return """---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: foundryvtt-blue-pre-upgrade
+  namespace: foundryvtt
+  labels:
+    app: foundryvtt
+    foundryvtt.petebeegle.com/color: blue
+spec:
+  volumeSnapshotClassName: nfs-csi-snapshot
+  source:
+    persistentVolumeClaimName: foundryvtt-data-pvc
+"""
+
+
+def green_preview_service() -> str:
+    return """---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foundryvtt-green
+  labels:
+    name: foundryvtt-green
+    foundryvtt.petebeegle.com/color: green
+  namespace: foundryvtt
+spec:
+  selector:
+    app: foundryvtt
+    foundryvtt.petebeegle.com/color: green
+  ports:
+    - name: web
+      port: 80
+      targetPort: 30000
+"""
+
+
+def green_preview_route() -> str:
+    return """---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foundryvtt-green-preview
+  namespace: foundryvtt
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+      sectionName: https-gateway
+  hostnames:
+    - foundry-green.${cluster_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: foundryvtt-green
+          port: 80
+          weight: 1
+"""
+
+
+def write_green_resources(root: Path, image: str) -> None:
+    app = root / APP_DIR
+    resources = {
+        "snapshot-blue.yaml": blue_snapshot(),
+        "pvc-green.yaml": green_pvc(),
+        "deployment-green.yaml": green_deployment(image),
+        "service-green-preview.yaml": green_preview_service(),
+        "httproute-green-preview.yaml": green_preview_route(),
+    }
+    for name, text in resources.items():
+        write(app / name, text)
+        ensure_kustomization_resource(app / "kustomization.yaml", name)
+
+
+def ensure_green_prepared(root: Path) -> None:
+    required = ["deployment-green.yaml", "pvc-green.yaml", "service-green-preview.yaml", "httproute-green-preview.yaml"]
+    missing = [name for name in required if not (root / APP_DIR / name).exists()]
+    if missing:
+        raise FoundryBlueGreenError(f"green is not prepared; missing {', '.join(missing)}")
+
+
+def command_status(args: argparse.Namespace) -> int:
+    root = args.root
+    evidence = read_evidence(root, args.evidence)
+    active = service_color(root / APP_DIR / "service.yaml")
+    current_version = config_version(root)
+    print(f"Foundry active production service color: {active}")
+    print(f"Current tool/config version: {current_version}")
+    if evidence:
+        state = "current" if evidence.get("config_version") == current_version else "stale"
+        print(f"Last dev-rehearse: {evidence.get('status')} ({state}) at {evidence.get('completed_at')}")
+    else:
+        print("Last dev-rehearse: none")
+    return 0
+
+
+def command_dev_rehearse(args: argparse.Namespace, runner: CommandRunner) -> int:
+    root = args.root
+    kubeconfig = Path(args.kubeconfig)
+    fixture = root / FIXTURE_DIR
+    namespace = "foundry-bluegreen-fixture"
+    runner.run(["kubectl", "kustomize", str(fixture)])
+    kubectl = ["kubectl", "--kubeconfig", str(kubeconfig)]
+    runner.run([*kubectl, "apply", "-f", str(root / "kubernetes/infra/controllers/nfs-csi/app.yaml")])
+    runner.run([*kubectl, "apply", "-f", str(root / "kubernetes/infra/controllers/nfs-csi/volumesnapshotclass.yaml")])
+    runner.run([*kubectl, "-n", "kube-system", "wait", "helmrelease/csi-driver-nfs", "--for=condition=Ready", "--timeout=300s"])
+    runner.run([*kubectl, "apply", "-k", str(fixture)])
+    for deployment in ["foundry-fixture-blue", "foundry-fixture-green"]:
+        runner.run([*kubectl, "-n", namespace, "rollout", "status", f"deployment/{deployment}", "--timeout=120s"])
+    runner.run([*kubectl, "-n", namespace, "scale", "deployment/foundry-fixture-blue", "--replicas=0"])
+    snapshot = """---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: foundry-fixture-blue-rehearsal
+  namespace: foundry-bluegreen-fixture
+spec:
+  volumeSnapshotClassName: nfs-csi-snapshot
+  source:
+    persistentVolumeClaimName: foundry-fixture-blue
+"""
+    runner.run([*kubectl, "apply", "-f", "-"], input_text=snapshot)
+    runner.run(
+        [
+            *kubectl,
+            "-n",
+            namespace,
+            "wait",
+            "volumesnapshot/foundry-fixture-blue-rehearsal",
+            "--for=jsonpath={.status.readyToUse}=true",
+            "--timeout=120s",
+        ]
+    )
+    runner.run([*kubectl, "-n", namespace, "scale", "deployment/foundry-fixture-blue", "--replicas=1"])
+    runner.run([*kubectl, "-n", namespace, "rollout", "status", "deployment/foundry-fixture-blue", "--timeout=120s"])
+    write_json(
+        root / args.evidence,
+        {
+            "command": "dev-rehearse",
+            "status": "succeeded",
+            "cluster": "development",
+            "fixture": FIXTURE_DIR.as_posix(),
+            "kubeconfig": str(kubeconfig),
+            "config_version": config_version(root),
+            "completed_at": utc_now(),
+        },
+    )
+    print("dev-rehearse succeeded; production commands are now unblocked for this tool/config version")
+    return 0
+
+
+def command_prepare(args: argparse.Namespace) -> int:
+    root = args.root
+    require_current_dev_rehearsal(root, args.evidence)
+    image = validate_image(args.image)
+    replace_first_replicas(root / APP_DIR / "deployment.yaml", 0)
+    write_green_resources(root, image)
+    print("prepared green desired state and paused blue for snapshot consistency")
+    print("commit these changes, open a PR, merge it, and wait for Flux before promoting")
+    return 0
+
+
+def command_promote(args: argparse.Namespace) -> int:
+    root = args.root
+    require_current_dev_rehearsal(root, args.evidence)
+    ensure_green_prepared(root)
+    replace_first_replicas(root / APP_DIR / "deployment.yaml", 0)
+    replace_first_replicas(root / APP_DIR / "deployment-green.yaml", 1)
+    set_service_color(root / APP_DIR / "service.yaml", "green")
+    print("promoted stable Service/foundryvtt to green desired state; blue remains scaled to zero")
+    print("commit these changes, open a PR, merge it, and wait for Flux")
+    return 0
+
+
+def command_rollback(args: argparse.Namespace) -> int:
+    root = args.root
+    require_current_dev_rehearsal(root, args.evidence)
+    ensure_green_prepared(root)
+    set_service_color(root / APP_DIR / "service.yaml", "blue")
+    replace_first_replicas(root / APP_DIR / "deployment.yaml", 1)
+    replace_first_replicas(root / APP_DIR / "deployment-green.yaml", 0)
+    print("rolled stable Service/foundryvtt back to blue desired state")
+    print("commit these changes, open a PR, merge it, and wait for Flux")
+    return 0
+
+
+def command_retire(args: argparse.Namespace) -> int:
+    root = args.root
+    require_current_dev_rehearsal(root, args.evidence)
+    app = root / APP_DIR
+    active = service_color(app / "service.yaml")
+    if active == "green":
+        retired = ["deployment.yaml", "pvc.yaml", "snapshot-blue.yaml"]
+    else:
+        retired = [
+            "deployment-green.yaml",
+            "pvc-green.yaml",
+            "service-green-preview.yaml",
+            "httproute-green-preview.yaml",
+            "snapshot-blue.yaml",
+        ]
+    for name in retired:
+        remove_kustomization_resource(app / "kustomization.yaml", name)
+        remove_file_if_exists(app / name)
+    print(f"retired inactive {'blue' if active == 'green' else 'green'} desired state")
+    print("commit these changes, open a PR, merge it, and wait for Flux")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=ROOT, help="repository root")
+    parser.add_argument("--evidence", type=Path, default=EVIDENCE_PATH, help="dev rehearsal evidence path")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("status", help="show active color and dev gate status")
+
+    dev = subparsers.add_parser("dev-rehearse", help="exercise the safe development fixture")
+    dev.add_argument("--kubeconfig", default=str(DEV_KUBECONFIG), help="development kubeconfig")
+
+    prepare = subparsers.add_parser("prepare", help="prepare green Foundry desired state")
+    prepare.add_argument("--image", required=True, help="Foundry image, for example felddy/foundryvtt:14.361")
+
+    subparsers.add_parser("promote", help="move stable production service to green desired state")
+    subparsers.add_parser("rollback", help="move stable production service back to blue desired state")
+    subparsers.add_parser("retire", help="remove inactive desired state after the outcome is accepted")
+    return parser
+
+
+def dispatch(args: argparse.Namespace, runner: CommandRunner | None = None) -> int:
+    runner = runner or CommandRunner()
+    if args.command == "status":
+        return command_status(args)
+    if args.command == "dev-rehearse":
+        return command_dev_rehearse(args, runner)
+    if args.command == "prepare":
+        return command_prepare(args)
+    if args.command == "promote":
+        return command_promote(args)
+    if args.command == "rollback":
+        return command_rollback(args)
+    if args.command == "retire":
+        return command_retire(args)
+    raise FoundryBlueGreenError(f"unknown command: {args.command}")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    args.root = args.root.resolve()
+    try:
+        return dispatch(args)
+    except FoundryBlueGreenError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/foundry_bluegreen.py
+++ b/tools/foundry_bluegreen.py
@@ -105,6 +105,20 @@ def require_current_dev_rehearsal(root: Path, evidence_path: Path) -> dict[str, 
     return evidence
 
 
+def resolved_path(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def require_development_kubeconfig(kubeconfig: str | Path) -> Path:
+    actual = resolved_path(kubeconfig)
+    expected = resolved_path(DEV_KUBECONFIG)
+    if actual != expected:
+        raise FoundryBlueGreenError(
+            f"dev-rehearse requires development kubeconfig {expected}; got {actual}"
+        )
+    return actual
+
+
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
@@ -366,7 +380,7 @@ def command_status(args: argparse.Namespace) -> int:
 
 def command_dev_rehearse(args: argparse.Namespace, runner: CommandRunner) -> int:
     root = args.root
-    kubeconfig = Path(args.kubeconfig)
+    kubeconfig = require_development_kubeconfig(args.kubeconfig)
     fixture = root / FIXTURE_DIR
     namespace = "foundry-bluegreen-fixture"
     runner.run(["kubectl", "kustomize", str(fixture)])

--- a/tools/tests/test_foundry_bluegreen.py
+++ b/tools/tests/test_foundry_bluegreen.py
@@ -167,7 +167,7 @@ resources:
 
         self.quiet(
             foundry_bluegreen.command_dev_rehearse,
-            self.args("dev-rehearse", kubeconfig="/tmp/dev.config"),
+            self.args("dev-rehearse", kubeconfig=str(foundry_bluegreen.DEV_KUBECONFIG)),
             runner,
         )
 
@@ -182,6 +182,22 @@ resources:
         self.assertIsNotNone(evidence)
         self.assertEqual(evidence["status"], "succeeded")
         self.assertEqual(evidence["config_version"], foundry_bluegreen.config_version(self.root))
+
+    def test_dev_rehearse_rejects_non_development_kubeconfig_before_kubectl(self) -> None:
+        runner = FakeRunner()
+
+        with self.assertRaisesRegex(foundry_bluegreen.FoundryBlueGreenError, "development kubeconfig"):
+            foundry_bluegreen.command_dev_rehearse(
+                self.args("dev-rehearse", kubeconfig="~/.kube/homelab-production.config"),
+                runner,
+            )
+
+        self.assertEqual([], runner.calls)
+        self.assertIsNone(
+            foundry_bluegreen.read_evidence(
+                self.root, Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_foundry_bluegreen.py
+++ b/tools/tests/test_foundry_bluegreen.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "foundry_bluegreen.py"
+SPEC = importlib.util.spec_from_file_location("foundry_bluegreen", MODULE_PATH)
+foundry_bluegreen = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules["foundry_bluegreen"] = foundry_bluegreen
+SPEC.loader.exec_module(foundry_bluegreen)
+
+
+class FakeRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], str | None]] = []
+
+    def run(self, args, *, input_text=None):
+        self.calls.append((list(args), input_text))
+        return foundry_bluegreen.CommandResult(args=args)
+
+
+class FoundryBlueGreenTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.write_minimal_repo()
+
+    def write(self, path: str, text: str) -> None:
+        target = self.root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+
+    def write_minimal_repo(self) -> None:
+        self.write("tools/foundry_bluegreen.py", "tool version\n")
+        self.write("kubernetes/infra/controllers/nfs-csi/app.yaml", "nfs\n")
+        self.write("kubernetes/apps/foundry-bluegreen-fixture/kustomization.yaml", "fixture\n")
+        self.write("kubernetes/clusters/development/apps/foundry-bluegreen-fixture.yaml", "fixture flux\n")
+        self.write(
+            "kubernetes/apps/foundryvtt/deployment.yaml",
+            """---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foundryvtt
+spec:
+  replicas: 1
+""",
+        )
+        self.write(
+            "kubernetes/apps/foundryvtt/service.yaml",
+            """---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foundryvtt
+spec:
+  selector:
+    app: foundryvtt
+    foundryvtt.petebeegle.com/color: blue
+""",
+        )
+        self.write(
+            "kubernetes/apps/foundryvtt/kustomization.yaml",
+            """---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml
+""",
+        )
+        self.write("kubernetes/apps/foundryvtt/pvc.yaml", "blue pvc\n")
+
+    def args(self, command: str, **kwargs) -> Namespace:
+        values = {
+            "root": self.root,
+            "evidence": Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json"),
+            "command": command,
+        }
+        values.update(kwargs)
+        return Namespace(**values)
+
+    def write_current_evidence(self) -> None:
+        foundry_bluegreen.write_json(
+            self.root / ".codex/tmp/foundry-bluegreen-dev-rehearse.json",
+            {
+                "status": "succeeded",
+                "config_version": foundry_bluegreen.config_version(self.root),
+                "completed_at": "2026-05-16T00:00:00Z",
+            },
+        )
+
+    def quiet(self, func, *args):
+        with redirect_stdout(io.StringIO()):
+            return func(*args)
+
+    def test_prepare_requires_current_dev_rehearsal(self) -> None:
+        with self.assertRaisesRegex(foundry_bluegreen.FoundryBlueGreenError, "dev-rehearse"):
+            foundry_bluegreen.command_prepare(
+                self.args("prepare", image="felddy/foundryvtt:14.361")
+            )
+
+    def test_prepare_pauses_blue_and_adds_green_desired_state(self) -> None:
+        self.write_current_evidence()
+
+        self.quiet(
+            foundry_bluegreen.command_prepare,
+            self.args("prepare", image="felddy/foundryvtt:14.362")
+        )
+
+        deployment = (self.root / "kubernetes/apps/foundryvtt/deployment.yaml").read_text()
+        service = (self.root / "kubernetes/apps/foundryvtt/service.yaml").read_text()
+        kustomization = (self.root / "kubernetes/apps/foundryvtt/kustomization.yaml").read_text()
+        green = (self.root / "kubernetes/apps/foundryvtt/deployment-green.yaml").read_text()
+        route = (self.root / "kubernetes/apps/foundryvtt/httproute-green-preview.yaml").read_text()
+        self.assertIn("replicas: 0", deployment)
+        self.assertIn("foundryvtt.petebeegle.com/color: blue", service)
+        self.assertIn("felddy/foundryvtt:14.362", green)
+        self.assertIn("name: internal", route)
+        self.assertIn("foundry-green.${cluster_domain}", route)
+        self.assertIn("- snapshot-blue.yaml", kustomization)
+        self.assertIn("- deployment-green.yaml", kustomization)
+
+    def test_promote_moves_stable_service_to_green_and_keeps_blue_zero(self) -> None:
+        self.write_current_evidence()
+        self.quiet(
+            foundry_bluegreen.command_prepare,
+            self.args("prepare", image="felddy/foundryvtt:14.362")
+        )
+
+        self.quiet(foundry_bluegreen.command_promote, self.args("promote"))
+
+        deployment = (self.root / "kubernetes/apps/foundryvtt/deployment.yaml").read_text()
+        service = (self.root / "kubernetes/apps/foundryvtt/service.yaml").read_text()
+        self.assertIn("replicas: 0", deployment)
+        self.assertIn("foundryvtt.petebeegle.com/color: green", service)
+
+    def test_rollback_restores_blue_and_scales_green_down(self) -> None:
+        self.write_current_evidence()
+        self.quiet(
+            foundry_bluegreen.command_prepare,
+            self.args("prepare", image="felddy/foundryvtt:14.362")
+        )
+        self.quiet(foundry_bluegreen.command_promote, self.args("promote"))
+
+        self.quiet(foundry_bluegreen.command_rollback, self.args("rollback"))
+
+        deployment = (self.root / "kubernetes/apps/foundryvtt/deployment.yaml").read_text()
+        green = (self.root / "kubernetes/apps/foundryvtt/deployment-green.yaml").read_text()
+        service = (self.root / "kubernetes/apps/foundryvtt/service.yaml").read_text()
+        self.assertIn("replicas: 1", deployment)
+        self.assertIn("replicas: 0", green)
+        self.assertIn("foundryvtt.petebeegle.com/color: blue", service)
+
+    def test_dev_rehearse_uses_fixture_and_writes_current_evidence(self) -> None:
+        runner = FakeRunner()
+
+        self.quiet(
+            foundry_bluegreen.command_dev_rehearse,
+            self.args("dev-rehearse", kubeconfig="/tmp/dev.config"),
+            runner,
+        )
+
+        commands = [" ".join(call[0]) for call in runner.calls]
+        self.assertIn("kubectl kustomize " + str(self.root / foundry_bluegreen.FIXTURE_DIR), commands)
+        self.assertTrue(any("apply -k" in command for command in commands))
+        self.assertTrue(any("deployment/foundry-fixture-blue --replicas=0" in command for command in commands))
+        self.assertTrue(any("volumesnapshot/foundry-fixture-blue-rehearsal" in command for command in commands))
+        evidence = foundry_bluegreen.read_evidence(
+            self.root, Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
+        )
+        self.assertIsNotNone(evidence)
+        self.assertEqual(evidence["status"], "succeeded")
+        self.assertEqual(evidence["config_version"], foundry_bluegreen.config_version(self.root))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Foundry Safe Blue/Green Upgrade, Dev-Gated

## Summary

Adds shared NFS CSI snapshot support, a development-only blue/green rehearsal fixture, and `tools/foundry_bluegreen.py` for dev-gated Foundry upgrade operations.

## Important Changes

- Enabled the NFS CSI chart snapshot controller for development and production while keeping snapshot CRD creation disabled in the chart.
- Added `VolumeSnapshotClass/nfs-csi-snapshot`.
- Added `kubernetes/apps/foundry-bluegreen-fixture`, activated only by the development cluster, with small PVC-backed blue and green HTTP workloads and an internal preview route at `foundry-green-preview.development.lab.petebeegle.com`.
- Added explicit blue labels to the existing production Foundry Deployment/PVC/Service while keeping `Service/foundryvtt` and the existing public/internal route hostnames stable.
- Added `tools/foundry_bluegreen.py` with `status`, `dev-rehearse`, `prepare --image felddy/foundryvtt:<tag>`, `promote`, `rollback`, and `retire`.
- `dev-rehearse` now rejects any kubeconfig path other than the resolved development kubeconfig path before issuing any `kubectl` call.
- Production `prepare`, `promote`, `rollback`, and `retire` hard-fail unless current dev rehearsal evidence exists for the current tool/config version.
- Production operations edit repository desired state and print PR/Flux instructions; they do not patch production routes live.

## Documentation Impact

- Added `docs/runbooks/foundry-bluegreen.md`.
- Regenerated `docs/architecture.md` with `python3 tools/architecture/render.py --write`.

## Test And Verification Evidence

- `python3 -m unittest tools.tests.test_foundry_bluegreen` passed, including a fake-runner test proving `~/.kube/homelab-production.config` is rejected with zero runner calls and no evidence file.
- `PATH=/tmp/kustomize-bin:$PATH kustomize build kubernetes/infra/controllers/nfs-csi` passed.
- `PATH=/tmp/kustomize-bin:$PATH kustomize build kubernetes/apps/foundry-bluegreen-fixture` passed.
- `PATH=/tmp/kustomize-bin:$PATH kustomize build kubernetes/apps/foundryvtt` passed.
- `python3 tools/architecture/render.py --check` passed.
- `git diff --check` passed.
- `python3 tools/foundry_bluegreen.py dev-rehearse --kubeconfig ~/.kube/homelab-production.config` failed with exit code 2 as expected before live kubectl calls.

## Development Smoke Evidence

- `python3 tools/foundry_bluegreen.py dev-rehearse` against development succeeded.
- Evidence file: `.codex/tmp/foundry-bluegreen-dev-rehearse.json`.
- Rehearsed config version: `d08453d46918111a3e09ef79827c940f4b85c6063a89b037c9e1d6c82b547761`.
- Completed at: `2026-05-16T17:30:26Z`.
- `kubectl --kubeconfig ~/.kube/homelab-development.config -n foundry-bluegreen-fixture get deploy,pvc,volumesnapshot,httproute` showed both fixture deployments available, both PVCs bound, `VolumeSnapshot/foundry-fixture-blue-rehearsal` `READYTOUSE=true`, and the green preview HTTPRoute present.
- `kubectl --kubeconfig ~/.kube/homelab-development.config get volumesnapshotclass nfs-csi-snapshot -o name` returned `volumesnapshotclass.snapshot.storage.k8s.io/nfs-csi-snapshot`.
- `kubectl --kubeconfig ~/.kube/homelab-development.config -n kube-system get helmrelease csi-driver-nfs` showed Ready with Helm upgrade succeeded.
- Cleanup status: no cleanup performed; the development-only fixture remains managed by the branch desired state and is safe to keep for verifier inspection.

## TDD Evidence

- Focused unit tests were added for the new tool behavior using a fake runner.
- Red-first was not separately captured because separate test-helper/subagent tooling was unavailable in this runtime; the final tests cover the production gate, prepare pause and green desired state, promote, rollback, and development fixture rehearsal commands.

## Workflow Evidence

- Implementation owner and separate verifier lanes were used.
- Verifier approved exact HEAD `38a770d20d39210d70383d4ca3bdf8b09399fca5`.
- Verifier evidence exists under `.codex/tmp/`.

## Risks And Notes

- Development live smoke applied the NFS CSI HelmRelease source and `VolumeSnapshotClass` directly to development so the rehearsal could validate snapshot behavior before branch merge. The same durable desired state is present in this branch.
- Production traffic movement remains GitOps-only and requires separate commits/PRs when the operator runs `prepare`, `promote`, `rollback`, or `retire`.
