### PR TITLE
Implementation: move-discord-alerts-channel

### DIFF
--- a/kubernetes/infra/monitoring/grafana/grafana-env.yaml
+++ b/kubernetes/infra/monitoring/grafana/grafana-env.yaml
@@ -5,19 +5,19 @@ metadata:
     namespace: grafana
 type: Opaque
 stringData:
-    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:mUWCqnIWC9jopETe2cHx//q8OfSFKDS/KJ5GFbUmyp6qi8oOnpoQelaYf00OawqPcCB6t2J8hd7lzjmDAr2e6e3hZirW72M2F6RSKmnA2Uf16ZQtBrC2aKDHDpsxmJWR6bkq424G4202r1Kms7pmDYO9heJQ8JAdng==,iv:7cAnllHBmYifJwE+D3LKRNs26n/ob9RCbVgMbYgTyrM=,tag:mlHL779h0TVqdx/NfAHf8A==,type:str]
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:Ic3qrQ3tTaiCIXhQyhRWHW4TBxKFXuVc1m+CtMVi3VvKQO+1iERu84WlzuooxbfzRHlSYVtwbhAlj8MVXKg8LZr9yhdv5Z4Jbb7Be1fQPS+UHtdvUPHFxerW53VuriIjBmSRtjYU4Yt/vVz9UVpkzIsq6B1G010IoA==,iv:zwzPQ92o8C6OfzU1prJbdL4hgjn+BLx602Nq8GrUJRs=,tag:NhiKen4eB7Gg5b2Vno6fwA==,type:str]
 sops:
     age:
-        - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQ0xxNjVkMSttd1k5N1BF
-            bU5QYkZ5S2V5WkI0Nm1CLzR4Ry9FWUxMaEFRCjE0MHBiNWdYcWpxYUVTVjF5VC95
-            dmdvRlRnTjZnQVA0M09zYWI0bVQvMU0KLS0tIEExVzhSdFhIaXROZ3BReTZOZXI5
-            d2VKUWNwbUsxQmQvOUN5b3Y3c3BFVlUK7Dfeldhskcv9UyMvPtsb94LD3u5elGZF
-            Z2i5eQ9OChvt0YT764YuYN60BR/xOZCw9jqs93g++69iaPSlZ+hmtA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDY2FBeUZqczA1TDBTZ255
+            YUJ1Y3JtNGJnditoTVhwQjZ2UDdIak5pdHhRClgvdXcwdjgvaEQ4V3QrSTF4dkR0
+            UklXSGRoemdmNzhlSE9yYjd1cVIrcDAKLS0tIFQ3MFhPZEs4TUR0Tm1yY0ZqQmNi
+            ZkIxQmlaWnhCWDB6TVNRVmpDOWE3WncKWbtFlTql4CblLIxPP8fUaTl4ODfdZHtc
+            Ay9Yz/Ubgdwn0v2/E+flbCl/1TawLFXRbZHxsxfXTP3S12JJp1Zh2w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-09-08T04:33:41Z"
-    mac: ENC[AES256_GCM,data:CNMv+JORh48JQcUe1ycNBz+mopRPcvFCR1dX2P33RAxAEm6yilXQggV5SyUVj10jbhS3wQstEBYNlN+aADgpgtNyPTB0j5izkVtgihaU89+1/vDVxCNl6e0GwNiYPXurhOrw8IseNhw5vBB4P0w/RLxsF0lRiwWYGx4SN+M0lQ0=,iv:Y3GHVUcvkw0GncNQPRWxq41wvA81fsi/v0L41UB1GwI=,tag:wqsaR/27G4/ZpYTLm7x1Fw==,type:str]
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.2
+    lastmodified: "2026-05-16T17:30:47Z"
+    mac: ENC[AES256_GCM,data:TKocUTS8/fj5HsF/apzML3nCAXuAid2+p58NeZLSx8z0TuYgRT6FZqbIZ5TaW84iBHbwX/VqqTFDX2OSoqrSbSeemhxr0PqWcb5KqBgNDFljfTu5KksSWX9l3xuGsbh3IkmhdZZ7paGSlaQbnGwuLibStg+W4Gi2AgxVt6mpflc=,iv:74PDFFqZ+Czt6unv8qq+F3sTLpB1nc7+Pgzl4vLcdPg=,tag:jfBlX81MXEmW+kpxkFF+5Q==,type:str]
+    version: 3.13.0

--- a/kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml
+++ b/kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml
@@ -5,19 +5,19 @@ metadata:
     namespace: monitoring
 type: Opaque
 stringData:
-    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:mUWCqnIWC9jopETe2cHx//q8OfSFKDS/KJ5GFbUmyp6qi8oOnpoQelaYf00OawqPcCB6t2J8hd7lzjmDAr2e6e3hZirW72M2F6RSKmnA2Uf16ZQtBrC2aKDHDpsxmJWR6bkq424G4202r1Kms7pmDYO9heJQ8JAdng==,iv:7cAnllHBmYifJwE+D3LKRNs26n/ob9RCbVgMbYgTyrM=,tag:mlHL779h0TVqdx/NfAHf8A==,type:str]
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:ciYuP1QzZyYNIpZTHpAijR8tRC/PFrtMglPwybfewnUpvDhS+lDtQCvW6BFcvFnQPR9KCtU6WKNlSh1gY/xNUQhSXBAQLyZYZ4W2BhJSt+qqiBRD4N9ZgC0q1vbTYmWkx+leD674HyDE6Vi8ZgYSgUbScpxVl2jb/A==,iv:Uhd7mEgGlSkt1bn3Y23bJM+Z0SR7upNQUfhtqsGv+W8=,tag:GT+i6fCrhlI5aWB9w6b5DA==,type:str]
 sops:
     age:
-        - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCQ0xxNjVkMSttd1k5N1BF
-            bU5QYkZ5S2V5WkI0Nm1CLzR4Ry9FWUxMaEFRCjE0MHBiNWdYcWpxYUVTVjF5VC95
-            dmdvRlRnTjZnQVA0M09zYWI0bVQvMU0KLS0tIEExVzhSdFhIaXROZ3BReTZOZXI5
-            d2VKUWNwbUsxQmQvOUN5b3Y3c3BFVlUK7Dfeldhskcv9UyMvPtsb94LD3u5elGZF
-            Z2i5eQ9OChvt0YT764YuYN60BR/xOZCw9jqs93g++69iaPSlZ+hmtA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByUE9YRmgrMHVuL3pjTFZp
+            OTllL08yaDFXVnozUC9uVUNjRWZJVTFYODNJCjdIWEQrbEZ0dEdpTXBFbTBKVEt3
+            U21tNE9iZHdRVVUrZEZ2Zmk3NDlZbUkKLS0tIFBESjdnTndIcGIrLzAwZG1zMVg3
+            d1ZmL2xvaTRHSTJlUEIweWtDK280RFkKicr85T2h59lP2/xFJPpWqIxmZzyyiLGi
+            mGJ1py0zFHdvHjHgtJWnLfjALsu+2S1yLhRfgqefStgmF0+IbjKHRg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-09-08T04:33:41Z"
-    mac: ENC[AES256_GCM,data:CNMv+JORh48JQcUe1ycNBz+mopRPcvFCR1dX2P33RAxAEm6yilXQggV5SyUVj10jbhS3wQstEBYNlN+aADgpgtNyPTB0j5izkVtgihaU89+1/vDVxCNl6e0GwNiYPXurhOrw8IseNhw5vBB4P0w/RLxsF0lRiwWYGx4SN+M0lQ0=,iv:Y3GHVUcvkw0GncNQPRWxq41wvA81fsi/v0L41UB1GwI=,tag:wqsaR/27G4/ZpYTLm7x1Fw==,type:str]
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    version: 3.10.2
+    lastmodified: "2026-05-16T17:30:47Z"
+    mac: ENC[AES256_GCM,data:PTkalU6yfZibN5RGXkRNO7GmRBjg9tcBxgh6w7Kd8ZFo+9e2Hw+SfH+2dAyEG0/3J5h/wvRuEG0BwU7jc/9vGkCoLUWOHQ7E2lWVulsxV14YLt1PDMDnrXRcZAa0/qU0fXL/1DwrAITBcYTW5P+KwpOt3Z6YvglaqEYWW7zgiPk=,iv:T0EF6XIP9dG0TxXaTE2G+gm4czk2h7cXvFcuRpXYXzk=,tag:FTKlKfN8OJ8vF/L7vFsC/Q==,type:str]
+    version: 3.13.0


### PR DESCRIPTION
## Summary
## Summary

Rotate Grafana Discord alert delivery to the public alerts webhook by regenerating the two SOPS-encrypted `grafana-env.yaml` secret manifests from the staged local webhook value.

## Important Changes

- Recreated `kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml`.
- Recreated `kubernetes/infra/monitoring/grafana/grafana-env.yaml`.
- Preserved the existing secret shape and contact point routing; no Grafana contact point or route manifests were changed.
- Repaired the Grafana namespace duplicate's SOPS MAC mismatch through regeneration.

## Documentation Impact

No documentation changes were made because this implementation only rotates encrypted secret data and does not change behavior, topology, or operator guidance.

## Validation

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: pass
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: pass
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`: pass
- Webhook metadata check: pass, HTTP 200 via GET only, no Discord message posted, URL not printed.
- `sops decrypt --extract '["stringData"]["DISCORD_WEBHOOK_URL"]' kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml >/dev/null`: pass
- `sops decrypt --extract '["stringData"]["DISCORD_WEBHOOK_URL"]' kubernetes/infra/monitoring/grafana/grafana-env.yaml >/dev/null`: pass
- Decrypted webhook values in both manifests match the staged local secret without printing the value: pass
- Plaintext webhook scan of both encrypted manifests: pass
- `kubectl kustomize kubernetes/infra/monitoring >/dev/null`: pass
- `kubectl kustomize kubernetes/infra/monitoring/grafana >/dev/null`: pass
- `python3 tools/architecture/render.py --check`: pass

## Workflow Notes

- Implementation owner: `implementation-agent-move-discord-alerts-channel`
- Implementation commit: `ed41d2042d0ab576e41ab93cc844abbd770348f7`
- Separate verifier `verifier-agent-move-discord-alerts-channel` approved exact HEAD `ed41d2042d0ab576e41ab93cc844abbd770348f7`.


## Changes
- kubernetes/infra/monitoring/grafana/grafana-env.yaml
- kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml

## Commits
- ed41d20 chore: rotate discord alert webhooks

## Verification
- Verified HEAD: `ed41d2042d0ab576e41ab93cc844abbd770348f7`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
