### PR TITLE
Implementation: fix-synthetics-envsubst

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -53,8 +53,9 @@ kubectl logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
 2. Prefer unauthenticated page-shell checks that prove the user-facing route works without storing secrets.
 3. Match durable text, titles, or redirects instead of brittle CSS classes.
 4. Mirror the same smoke files under `kubernetes/apps/synthetics/smoke/`; Flux cannot load ConfigMap files from outside the app kustomization root.
-5. Add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires that app to exist first.
-6. Run the suite locally when the route is reachable, then create a manual Job after Flux applies the change.
+5. Avoid raw `${...}` syntax in mirrored smoke files unless Flux should substitute it; Flux post-build substitution scans the generated ConfigMap data.
+6. Add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires that app to exist first.
+7. Run the suite locally when the route is reachable, then create a manual Job after Flux applies the change.
 
 ## Dashboard And Alert
 

--- a/kubernetes/apps/synthetics/smoke/playwright.config.js
+++ b/kubernetes/apps/synthetics/smoke/playwright.config.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["list"], ["json", { outputFile: "test-results.json" }]] : "list",
   use: {
-    baseURL: `https://whoami.${process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"}`,
+    baseURL: "https://whoami." + (process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"),
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "off",

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -3,13 +3,13 @@ const { expect, test } = require("@playwright/test");
 const baseDomain = process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com";
 
 function urlFor(host, path = "/") {
-  return `https://${host}.${baseDomain}${path}`;
+  return "https://" + host + "." + baseDomain + path;
 }
 
 async function gotoOk(page, url) {
   const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-  expect(response, `${url} should return an HTTP response`).not.toBeNull();
-  expect(response.status(), `${url} should not return a server error`).toBeLessThan(500);
+  expect(response, url + " should return an HTTP response").not.toBeNull();
+  expect(response.status(), url + " should not return a server error").toBeLessThan(500);
   return response;
 }
 

--- a/tests/smoke/playwright.config.js
+++ b/tests/smoke/playwright.config.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["list"], ["json", { outputFile: "test-results.json" }]] : "list",
   use: {
-    baseURL: `https://whoami.${process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"}`,
+    baseURL: "https://whoami." + (process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"),
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "off",

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -3,13 +3,13 @@ const { expect, test } = require("@playwright/test");
 const baseDomain = process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com";
 
 function urlFor(host, path = "/") {
-  return `https://${host}.${baseDomain}${path}`;
+  return "https://" + host + "." + baseDomain + path;
 }
 
 async function gotoOk(page, url) {
   const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-  expect(response, `${url} should return an HTTP response`).not.toBeNull();
-  expect(response.status(), `${url} should not return a server error`).toBeLessThan(500);
+  expect(response, url + " should return an HTTP response").not.toBeNull();
+  expect(response.status(), url + " should not return a server error").toBeLessThan(500);
   return response;
 }
 


### PR DESCRIPTION
## Summary
Implements `fix-synthetics-envsubst` to unblock `app-synthetics` reconciliation by removing JavaScript `${...}` template-literal syntax from the smoke source files embedded in `ConfigMap/synthetic-smoke-source`.

Important changes:
- Replaced affected smoke-source template literals with string concatenation in both `tests/smoke/` and `kubernetes/apps/synthetics/smoke/`.
- Left the intended Flux `${cluster_domain}` substitution in `kubernetes/apps/synthetics/cronjob.yaml` unchanged.
- Documented the ConfigMap/Flux substitution caveat in `docs/runbooks/synthetic-smoke-tests.md`.

Documentation impact:
- Updated `docs/runbooks/synthetic-smoke-tests.md` with a preventive note for future probe additions.

Verification:
- `rg -n '\$\{' tests/smoke kubernetes/apps/synthetics/smoke` found no smoke-source substitution tokens.
- `export cluster_domain=lab.petebeegle.com; kubectl kustomize kubernetes/apps/synthetics | flux envsubst --strict` passed.
- `kubectl kustomize kubernetes/clusters/production` passed.
- `python3 tools/architecture/render.py --check` passed.
- `npm ci && npm run test -- --list` from `tests/smoke` passed and listed 6 tests.

Workflow note:
- Runtime policy blocks spawning implementation/verifier subagents unless explicitly requested, so implementation and verification were performed locally with fallback self-verification recorded here.


## Changes
- docs/runbooks/synthetic-smoke-tests.md
- kubernetes/apps/synthetics/smoke/playwright.config.js
- kubernetes/apps/synthetics/smoke/routes.spec.js
- tests/smoke/playwright.config.js
- tests/smoke/routes.spec.js

## Commits
- 4d382bf fix: avoid flux substitution in smoke sources

## Verification
- Verified HEAD: `4d382bfb9422382a8e4a3c92340d789d193a3f56`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
