### PR TITLE
Implementation: synthetic-smoke-pihole-login

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -14,7 +14,7 @@ The checks are intentionally deeper than pod readiness and lighter than full aut
 - `authentik.${cluster_domain}` verifies the SSO start or login page.
 - `monitoring.${cluster_domain}` verifies the Grafana login or landing shell.
 - `jellyfin.${cluster_domain}` verifies the Jellyfin web shell.
-- `pihole.${cluster_domain}` verifies the root redirect to `/admin`.
+- `pihole.${cluster_domain}` verifies the root redirect reaches the Pi-hole admin/login shell.
 - `foundry.${cluster_domain}` verifies the Foundry application shell.
 
 ## Manual Run

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -36,7 +36,7 @@ test.describe("homelab routed services", () => {
 
   test("pihole root redirects to the admin shell", async ({ page }) => {
     await gotoOk(page, urlFor("pihole"));
-    await expect(page).toHaveURL(/\/admin\/?$/);
+    await expect(page).toHaveURL(/\/admin(?:\/|\/login)?$/);
     await expect(page.locator("body")).toContainText(/Pi-hole|Sign in|Login|Password/i);
   });
 

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -36,7 +36,7 @@ test.describe("homelab routed services", () => {
 
   test("pihole root redirects to the admin shell", async ({ page }) => {
     await gotoOk(page, urlFor("pihole"));
-    await expect(page).toHaveURL(/\/admin\/?$/);
+    await expect(page).toHaveURL(/\/admin(?:\/|\/login)?$/);
     await expect(page.locator("body")).toContainText(/Pi-hole|Sign in|Login|Password/i);
   });
 


### PR DESCRIPTION
## Summary
## Summary

- Accept Pi-hole root redirects that land on `/admin`, `/admin/`, or `/admin/login` in both synthetic smoke spec copies.
- Keep the repository smoke tests and in-cluster synthetics ConfigMap source mirror in sync.

## Documentation Impact

- Updated `docs/runbooks/synthetic-smoke-tests.md` so the Pi-hole target describes reaching the admin/login shell instead of only `/admin`.

## Verification Evidence

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `diff -qr tests/smoke kubernetes/apps/synthetics/smoke`: passed with no differences.
- `npm ci && npm run test -- --list` from `tests/smoke`: passed; listed 6 Playwright tests.
- `kubectl kustomize kubernetes/apps/synthetics`: passed.
- `kubectl kustomize kubernetes/clusters/production`: passed.
- `pre-commit run --all-files`: passed.

## TDD And Smoke Notes

- Risk tier: low.
- No separate failing unit test was added because the changed behavior is the Playwright URL assertion itself; the smoke test listing and render checks are the useful local verification seam.
- No live development smoke was run; this is a matcher/docs update and requested local verification commands all passed.


## Changes
- docs/runbooks/synthetic-smoke-tests.md
- kubernetes/apps/synthetics/smoke/routes.spec.js
- tests/smoke/routes.spec.js

## Commits
- b6f4f39 fix: accept pihole login redirect in smoke test

## Verification
- Verified HEAD: `b6f4f39fc9da1e40f1d2c2b5bf52f66d0db310bf`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
