### PR TITLE
fix(foundry): preserve blue deployment selector

### DIFF
--- a/docs/runbooks/foundry-bluegreen.md
+++ b/docs/runbooks/foundry-bluegreen.md
@@ -20,6 +20,7 @@ Use this runbook for Foundry VTT image upgrades. Production changes stay GitOps-
 - Rehearsal evidence is written to `.codex/tmp/foundry-bluegreen-dev-rehearse.json` and is valid only for the current tool/config version.
 - `prepare` pauses the blue Foundry deployment before creating the NFS CSI snapshot desired state.
 - `Service/foundryvtt` remains the stable production backend for the existing public and internal routes.
+- The original blue `Deployment/foundryvtt` selector intentionally stays app-only for Kubernetes selector immutability and compatibility with the existing live Deployment. Color labels live on pod templates and Services so switching can move traffic without mutating the blue Deployment selector.
 - Green preview traffic uses the internal Gateway only at `foundry-green.${cluster_domain}`.
 - The development fixture preview is LAN-only at `foundry-green-preview.development.lab.petebeegle.com`.
 - After `promote`, inactive blue remains scaled to zero until an explicit `retire`.

--- a/kubernetes/apps/foundryvtt/deployment.yaml
+++ b/kubernetes/apps/foundryvtt/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app: foundryvtt
-      foundryvtt.petebeegle.com/color: blue
   template:
     metadata:
       labels:

--- a/tools/tests/test_foundry_bluegreen.py
+++ b/tools/tests/test_foundry_bluegreen.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "foundry_bluegreen.py"
+REPO_ROOT = MODULE_PATH.parents[1]
 SPEC = importlib.util.spec_from_file_location("foundry_bluegreen", MODULE_PATH)
 foundry_bluegreen = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -198,6 +199,19 @@ resources:
                 self.root, Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
             )
         )
+
+    def test_production_blue_deployment_keeps_immutable_selector_app_only(self) -> None:
+        deployment = (
+            REPO_ROOT / "kubernetes/apps/foundryvtt/deployment.yaml"
+        ).read_text(encoding="utf-8")
+
+        selector = deployment.split("  selector:\n", 1)[1].split("  template:\n", 1)[0]
+        template_labels = deployment.split("    metadata:\n", 1)[1].split("    spec:\n", 1)[0]
+
+        self.assertIn("      app: foundryvtt", selector)
+        self.assertNotIn("foundryvtt.petebeegle.com/color", selector)
+        self.assertIn("        app: foundryvtt", template_labels)
+        self.assertIn("        foundryvtt.petebeegle.com/color: blue", template_labels)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Preserve the existing FoundryVTT blue Deployment selector so Flux dry-run does not attempt to mutate an immutable Kubernetes field, while keeping blue/green traffic switching on pod template and Service color labels.

## Important Changes

- Removed `foundryvtt.petebeegle.com/color: blue` from `Deployment/foundryvtt` `spec.selector.matchLabels`.
- Kept the blue color label on the Deployment metadata and pod template labels so `Service/foundryvtt` can continue selecting app+blue.
- Added focused regression coverage asserting the production blue Deployment selector remains app-only while its pod template carries the blue color label.

## Documentation Impact

- Updated `docs/runbooks/foundry-bluegreen.md` to document that the original blue Deployment selector intentionally remains app-only for Kubernetes immutability and live Deployment compatibility.
- `docs/architecture.md` was not regenerated because `python3 tools/architecture/render.py --check` passed.

## Tests And Verification

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 -m unittest tools.tests.test_foundry_bluegreen` ran 7 tests.
- PASS: `kubectl kustomize kubernetes/apps/foundryvtt` rendered Service app+blue selector, app-only Deployment selector, and blue pod template label.
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`

## Workflow Note

The user explicitly assigned this session as implementation owner for `fix-foundry-selector-immutability`; no verifier approval files were created because a separate verifier will handle sign-off.
