### PR TITLE
fix(foundry): preflight development preview dns

### DIFF
--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -27,6 +27,24 @@ Use this runbook to create, bootstrap, test, and clean up the dedicated developm
 
 The development base intentionally includes CRDs, Cilium, cert-manager/certs, Gateway API, NFS CSI, and whoami. Authentik, games/media apps, Cloudflare tunnels, Renovate, VPN, and the full monitoring stack are omitted to keep the single-node cluster resource-conscious and to avoid production-only secrets or traffic paths unless a test explicitly needs them.
 
+## LAN DNS
+
+Development HTTPS previews are hostname-based, matching production Gateway behavior. The operator's LAN resolver must provide:
+
+```text
+*.development.lab.petebeegle.com A 192.168.30.225
+```
+
+This repository does not currently manage the user's LAN resolver, router, or Pi-hole configuration. Keep that DNS record outside GitOps unless a future decision record explicitly adds resolver management.
+
+Verify the local resolver before running development preview checks:
+
+```sh
+getent hosts foundry-green-preview.development.lab.petebeegle.com
+```
+
+The expected A record is `192.168.30.225`. If the hostname resolves to production `192.168.30.241`, another IP, or no A records, fix local DNS before applying live development preview resources. Browser checks should use `https://foundry-green-preview.development.lab.petebeegle.com/`; that route is expected to land on the development internal Gateway `192.168.30.225`.
+
 ## Local Tfvars
 
 Do not commit `terraform/development/terraform.tfvars`; it is ignored by Git.

--- a/docs/runbooks/foundry-bluegreen.md
+++ b/docs/runbooks/foundry-bluegreen.md
@@ -18,6 +18,7 @@ Use this runbook for Foundry VTT image upgrades. Production changes stay GitOps-
 - `dev-rehearse` uses the small development-only fixture in `kubernetes/apps/foundry-bluegreen-fixture`, not real Foundry and not Foundry secrets.
 - `dev-rehearse` only accepts the development kubeconfig at `~/.kube/homelab-development.config` after path expansion and resolution.
 - Rehearsal evidence is written to `.codex/tmp/foundry-bluegreen-dev-rehearse.json` and is valid only for the current tool/config version.
+- `dev-rehearse` requires local DNS for `foundry-green-preview.development.lab.petebeegle.com` to resolve to the development internal Gateway IP `192.168.30.225` before it writes successful evidence or applies live development resources.
 - `prepare` pauses the blue Foundry deployment before creating the NFS CSI snapshot desired state.
 - `Service/foundryvtt` remains the stable production backend for the existing public and internal routes.
 - Green preview traffic uses the internal Gateway only at `foundry-green.${cluster_domain}`.
@@ -30,10 +31,15 @@ From a clean implementation branch:
 
 ```bash
 python3 tools/foundry_bluegreen.py status
+getent hosts foundry-green-preview.development.lab.petebeegle.com
 python3 tools/foundry_bluegreen.py dev-rehearse
 ```
 
+Required LAN DNS is `*.development.lab.petebeegle.com A 192.168.30.225`. This repository does not currently manage the operator's LAN resolver, so configure that wildcard record outside GitOps before rehearsing. If the hostname resolves to production `192.168.30.241`, any other IP, or no A records, `dev-rehearse` fails before live kubectl work and before writing successful evidence.
+
 The rehearsal applies the safe fixture to development, waits for blue and green HTTP workloads, scales blue to zero, creates `VolumeSnapshot/foundry-fixture-blue-rehearsal` with `VolumeSnapshotClass/nfs-csi-snapshot`, waits for readiness, and scales blue back to one replica.
+
+After rehearsal succeeds, open `https://foundry-green-preview.development.lab.petebeegle.com/` from the LAN. The HTTPS hostname route should land on the development internal Gateway at `192.168.30.225`, matching the production Gateway hostname behavior without using the production Gateway IP.
 
 If development access is unavailable, do not run production commands. Record the blocker in the PR summary and rerun rehearsal when access returns.
 

--- a/tools/foundry_bluegreen.py
+++ b/tools/foundry_bluegreen.py
@@ -7,12 +7,13 @@ import argparse
 import hashlib
 import json
 import re
+import socket
 import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Callable, Iterable, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,6 +21,9 @@ APP_DIR = Path("kubernetes/apps/foundryvtt")
 FIXTURE_DIR = Path("kubernetes/apps/foundry-bluegreen-fixture")
 EVIDENCE_PATH = Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
 DEV_KUBECONFIG = Path.home() / ".kube/homelab-development.config"
+DEVELOPMENT_PREVIEW_HOSTNAME = "foundry-green-preview.development.lab.petebeegle.com"
+DEVELOPMENT_GATEWAY_INTERNAL_IP = "192.168.30.225"
+PRODUCTION_GATEWAY_INTERNAL_IP = "192.168.30.241"
 PRODUCTION_COMMANDS = {"prepare", "promote", "rollback", "retire"}
 CONFIG_VERSION_GLOBS = [
     "tools/foundry_bluegreen.py",
@@ -117,6 +121,40 @@ def require_development_kubeconfig(kubeconfig: str | Path) -> Path:
             f"dev-rehearse requires development kubeconfig {expected}; got {actual}"
         )
     return actual
+
+
+def local_a_records(hostname: str) -> list[str]:
+    try:
+        answers = socket.getaddrinfo(hostname, None, socket.AF_INET, socket.SOCK_STREAM)
+    except socket.gaierror:
+        return []
+    return sorted({answer[4][0] for answer in answers})
+
+
+def require_development_preview_dns(
+    resolver: Callable[[str], Sequence[str]] = local_a_records,
+) -> list[str]:
+    records = sorted(set(resolver(DEVELOPMENT_PREVIEW_HOSTNAME)))
+    expected = DEVELOPMENT_GATEWAY_INTERNAL_IP
+    rendered = ", ".join(records) if records else "none"
+    if not records:
+        raise FoundryBlueGreenError(
+            "development DNS preflight failed: "
+            f"{DEVELOPMENT_PREVIEW_HOSTNAME} has no A records; expected {expected}"
+        )
+    if PRODUCTION_GATEWAY_INTERNAL_IP in records:
+        raise FoundryBlueGreenError(
+            "development DNS preflight failed: "
+            f"{DEVELOPMENT_PREVIEW_HOSTNAME} resolves to production Gateway "
+            f"{PRODUCTION_GATEWAY_INTERNAL_IP}; expected development Gateway {expected}"
+        )
+    if records != [expected]:
+        raise FoundryBlueGreenError(
+            "development DNS preflight failed: "
+            f"{DEVELOPMENT_PREVIEW_HOSTNAME} has unexpected A record(s) {rendered}; "
+            f"expected only {expected}"
+        )
+    return records
 
 
 def read(path: Path) -> str:
@@ -378,9 +416,14 @@ def command_status(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_dev_rehearse(args: argparse.Namespace, runner: CommandRunner) -> int:
+def command_dev_rehearse(
+    args: argparse.Namespace,
+    runner: CommandRunner,
+    resolver: Callable[[str], Sequence[str]] = local_a_records,
+) -> int:
     root = args.root
     kubeconfig = require_development_kubeconfig(args.kubeconfig)
+    require_development_preview_dns(resolver)
     fixture = root / FIXTURE_DIR
     namespace = "foundry-bluegreen-fixture"
     runner.run(["kubectl", "kustomize", str(fixture)])

--- a/tools/tests/test_foundry_bluegreen.py
+++ b/tools/tests/test_foundry_bluegreen.py
@@ -27,6 +27,16 @@ class FakeRunner:
         return foundry_bluegreen.CommandResult(args=args)
 
 
+class FakeResolver:
+    def __init__(self, addresses: list[str]) -> None:
+        self.addresses = addresses
+        self.hostnames: list[str] = []
+
+    def __call__(self, hostname: str) -> list[str]:
+        self.hostnames.append(hostname)
+        return self.addresses
+
+
 class FoundryBlueGreenTests(unittest.TestCase):
     def setUp(self) -> None:
         self.tmp = tempfile.TemporaryDirectory()
@@ -164,13 +174,16 @@ resources:
 
     def test_dev_rehearse_uses_fixture_and_writes_current_evidence(self) -> None:
         runner = FakeRunner()
+        resolver = FakeResolver([foundry_bluegreen.DEVELOPMENT_GATEWAY_INTERNAL_IP])
 
         self.quiet(
             foundry_bluegreen.command_dev_rehearse,
             self.args("dev-rehearse", kubeconfig=str(foundry_bluegreen.DEV_KUBECONFIG)),
             runner,
+            resolver,
         )
 
+        self.assertEqual([foundry_bluegreen.DEVELOPMENT_PREVIEW_HOSTNAME], resolver.hostnames)
         commands = [" ".join(call[0]) for call in runner.calls]
         self.assertIn("kubectl kustomize " + str(self.root / foundry_bluegreen.FIXTURE_DIR), commands)
         self.assertTrue(any("apply -k" in command for command in commands))
@@ -185,11 +198,54 @@ resources:
 
     def test_dev_rehearse_rejects_non_development_kubeconfig_before_kubectl(self) -> None:
         runner = FakeRunner()
+        resolver = FakeResolver([foundry_bluegreen.DEVELOPMENT_GATEWAY_INTERNAL_IP])
 
         with self.assertRaisesRegex(foundry_bluegreen.FoundryBlueGreenError, "development kubeconfig"):
             foundry_bluegreen.command_dev_rehearse(
                 self.args("dev-rehearse", kubeconfig="~/.kube/homelab-production.config"),
                 runner,
+                resolver,
+            )
+
+        self.assertEqual([], resolver.hostnames)
+        self.assertEqual([], runner.calls)
+        self.assertIsNone(
+            foundry_bluegreen.read_evidence(
+                self.root, Path(".codex/tmp/foundry-bluegreen-dev-rehearse.json")
+            )
+        )
+
+    def test_development_preview_dns_preflight_accepts_development_gateway(self) -> None:
+        resolver = FakeResolver([foundry_bluegreen.DEVELOPMENT_GATEWAY_INTERNAL_IP])
+
+        foundry_bluegreen.require_development_preview_dns(resolver)
+
+        self.assertEqual([foundry_bluegreen.DEVELOPMENT_PREVIEW_HOSTNAME], resolver.hostnames)
+
+    def test_development_preview_dns_preflight_rejects_production_gateway(self) -> None:
+        resolver = FakeResolver([foundry_bluegreen.PRODUCTION_GATEWAY_INTERNAL_IP])
+
+        with self.assertRaisesRegex(
+            foundry_bluegreen.FoundryBlueGreenError,
+            "production Gateway 192\\.168\\.30\\.241",
+        ):
+            foundry_bluegreen.require_development_preview_dns(resolver)
+
+    def test_development_preview_dns_preflight_rejects_no_a_records(self) -> None:
+        resolver = FakeResolver([])
+
+        with self.assertRaisesRegex(foundry_bluegreen.FoundryBlueGreenError, "has no A records"):
+            foundry_bluegreen.require_development_preview_dns(resolver)
+
+    def test_dev_rehearse_rejects_dns_mismatch_before_kubectl_or_evidence(self) -> None:
+        runner = FakeRunner()
+        resolver = FakeResolver(["192.168.30.250"])
+
+        with self.assertRaisesRegex(foundry_bluegreen.FoundryBlueGreenError, "unexpected A record"):
+            foundry_bluegreen.command_dev_rehearse(
+                self.args("dev-rehearse", kubeconfig=str(foundry_bluegreen.DEV_KUBECONFIG)),
+                runner,
+                resolver,
             )
 
         self.assertEqual([], runner.calls)


### PR DESCRIPTION
# Development Gateway DNS Preflight

## Summary

Add a development Gateway DNS preflight to `tools/foundry_bluegreen.py dev-rehearse` so successful rehearsal evidence and live development kubectl work are blocked unless `foundry-green-preview.development.lab.petebeegle.com` resolves locally to the development internal Gateway `192.168.30.225`.

Branch base changed from the stacked PR branch `origin/codex/foundry-bluegreen-dev-gated` to current `origin/main` after PR #228 merged. The branch now contains only the DNS-preflight commit on top of `origin/main`.

Current exact `HEAD`: `d2d767c895dbeb4d78b81da9f6a0880c315e248b`.

## Important Changes

- Added local resolver-based A record validation for the Foundry development preview hostname.
- Preserved the existing development kubeconfig guard before DNS or kubectl work.
- Failed clearly when the preview hostname has no A records, resolves to production `192.168.30.241`, or resolves to any unexpected IP.
- Added fake-resolver unit tests for passing development DNS, production DNS mismatch, no A records, and mismatch ordering before kubectl/evidence.

## Documentation Impact

Updated:

- `docs/runbooks/foundry-bluegreen.md`
- `docs/runbooks/development-cluster.md`

Both runbooks now document required LAN DNS, the fact that this repo does not manage the user's resolver, the `getent hosts foundry-green-preview.development.lab.petebeegle.com` check, the HTTPS browser URL, and the expected development Gateway IP `192.168.30.225`.

## Validation

- `python3 -m unittest tools.tests.test_foundry_bluegreen`: passed, 10 tests.
- `python3 tools/architecture/render.py --check`: passed.
- `git diff --check`: passed.
- `getent hosts foundry-green-preview.development.lab.petebeegle.com`: returned `192.168.30.241 foundry-green-preview.development.lab.petebeegle.com`.
- `python3 tools/foundry_bluegreen.py dev-rehearse`: failed with DNS preflight mismatch before kubectl work, reporting production Gateway `192.168.30.241` instead of expected development Gateway `192.168.30.225`.
- `.codex/tmp/foundry-bluegreen-dev-rehearse.json`: absent after the failed DNS mismatch probe.
- `git log --oneline origin/main..HEAD`: shows only `fix(foundry): preflight development preview dns`.

## Risks And Notes

- Local DNS remains operator-managed outside this repository.
- No Pi-hole, router, or LAN resolver management was added.
- Separate verifier approved exact `HEAD` `d2d767c895dbeb4d78b81da9f6a0880c315e248b`; verifier evidence exists under `.codex/tmp/`.
