### PR TITLE
fix: ignore synthetic smoke failed pods in generic alert

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -62,3 +62,5 @@ kubectl logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
 Grafana owns the `Synthetics` folder, `Synthetic Smoke` dashboard, and `synthetics` alert rule group. The dashboard shows recent pass/fail counts, Job duration, pod termination reasons, and Loki log excerpts for `namespace="synthetics"`.
 
 The alert fires only when smoke Jobs fail more than once in the last hour. A single failed run should be investigated, but it is not enough to alert by itself.
+
+Failed `synthetic-smoke-*` pods in the `synthetics` namespace are excluded from the generic `Kubernetes Failed Pods` alert because repeated synthetic failures are covered by `Synthetic Smoke Repeated Failures`.

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml
@@ -137,7 +137,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: sum(kube_pod_status_phase{phase="Failed"} > bool 0) OR vector(0)
+            expr: sum((kube_pod_status_phase{phase="Failed"} unless kube_pod_status_phase{phase="Failed",namespace="synthetics",pod=~"synthetic-smoke-.+"} unless kube_pod_status_phase{phase="Failed",exported_namespace="synthetics",pod=~"synthetic-smoke-.+"}) > bool 0) OR vector(0)
             refId: A
         - refId: B
           relativeTimeRange:


### PR DESCRIPTION
# ignore-synthetic-failed-pods

## Summary

Exclude synthetic smoke CronJob failed pods from the generic `Kubernetes Failed Pods` Grafana alert while leaving `Synthetic Smoke Repeated Failures` unchanged.

## Important Changes

- Updated `kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml` so the generic failed-pods PromQL counts failed pods except `synthetic-smoke-*` pods in the `synthetics` namespace, supporting both `namespace` and `exported_namespace` label styles.
- Updated `docs/runbooks/synthetic-smoke-tests.md` to document that synthetic smoke failed pods are covered by the dedicated repeated-failures alert instead of the generic Kubernetes failed-pods alert.

## Documentation Impact

`docs/runbooks/synthetic-smoke-tests.md` was updated because the alert-routing behavior is operator-facing.

## Validation

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `kubectl kustomize kubernetes/infra/monitoring/grafana/alerting >/tmp/ignore-synthetic-alerting.yaml` passed.
- `kubectl kustomize kubernetes/infra/monitoring/grafana >/tmp/ignore-synthetic-grafana.yaml` passed.
- `python3 tools/architecture/render.py --check` passed.
- `pre-commit run yamllint --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml docs/runbooks/synthetic-smoke-tests.md` passed.
- `pre-commit run end-of-file-fixer --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml docs/runbooks/synthetic-smoke-tests.md` passed.
- `pre-commit run trailing-whitespace --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml docs/runbooks/synthetic-smoke-tests.md` passed.
- `pre-commit run k8svalidate --files kubernetes/infra/monitoring/grafana/alerting/alert-rules-kubernetes.yaml` passed.
- `git diff --check` passed.

## Skipped Checks

- Live-cluster smoke was not run because this is an alert-only manifest expression change and does not alter a deployed app path or require cluster state to validate the repository change.
- `promtool` validation was not run because `promtool` is not installed in the environment; local substitute validation was YAML/schema/kustomize rendering plus inspection of the rendered expression.

## Delegation

Delegation fallback is not used; this is delegated implementation owner work by `implementation-agent-ignore-synthetic-failed-pods`.
