### PR TITLE
feat(terraform): manage unifi dns records

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,36 @@ terraform apply
 ```
 This creates an `agent-service-account` Viewer service account in Grafana and outputs a token. The devcontainer's `poststart.sh` exports it automatically as `GRAFANA_SERVICE_ACCOUNT_TOKEN`.
 
+#### UniFi DNS
+UniFi local DNS records are managed from `terraform/external/unifi`. Create the ignored local credentials file at `terraform/external/unifi/terraform.tfvars`:
+
+```tf
+unifi = {
+  api_url        = "https://192.168.1.1"
+  username       = "terraform"
+  password       = "replace-me"
+  site           = "default"
+  allow_insecure = true
+}
+```
+
+The UniFi provider also supports API-key authentication through its standard environment variables. Export `UNIFI_API` and `UNIFI_API_KEY` instead of setting `username` and `password` when using that path.
+
+Before the first apply, import any existing DNS records so Terraform adopts them instead of trying to recreate them:
+
+```sh
+cd terraform/external/unifi
+terraform init
+
+terraform import 'unifi_dns_record.gateway_wildcards["lab"]' 'default:<record-id-for-*.lab.petebeegle.com>'
+terraform import 'unifi_dns_record.gateway_wildcards["development"]' 'default:<record-id-for-*.development.lab.petebeegle.com>'
+
+terraform plan
+terraform apply
+```
+
+If the records live outside the default site, replace the `default:` prefix with the target site name. Do not commit `terraform.tfvars`, state files, credentials, or `.terraform/`.
+
 ### 3. Create the cluster
 Create and bootstrap production via terraform!
 ```sh

--- a/terraform/external/unifi/.terraform.lock.hcl
+++ b/terraform/external/unifi/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/ubiquiti-community/unifi" {
+  version     = "0.41.25"
+  constraints = "0.41.25"
+  hashes = [
+    "h1:qRFnztw0TZG/RQVLHe2Pjz5U/IOY0g+8ESV1AwzIEWU=",
+    "zh:1f45ce17895b191156c1556cb704e022c903afce13d4d0eb9c7a8c2ba1d5c882",
+    "zh:25350e49be814fa80b0831d598773ef5ca6349875fc84ae8c68c5aeecc8546a6",
+    "zh:2782b11d6d05a30a794b627026057f2a5cd1795c658e0fab35d3b779aa238f42",
+    "zh:2997d531fbccec09ceb5cabba6a8af4c9a346e09ce3dbe659385ada8ae9efca5",
+    "zh:32a715e6249b14b62b5b9dbb99c4879b6f5937da2f1c2c8e5ae567c640836fdf",
+    "zh:42d4dda9ac0113318b8032ce78699131fdb0ae535f477ce3b9f686c0c371cfdf",
+    "zh:439d03f851fc29aa517d886c4e81998b5950a7c8c94fba9091819dd26d2b1910",
+    "zh:44cd68b8d00c41d9de7394ed3f75f8f76de0502d412c42fd6f8ba587a8632ddd",
+    "zh:58c7d69284a9942296e5e9751b368836a958fb07faa729951e2775761ce58f6c",
+    "zh:7b2acfa58bee36965874b1f79269e129b7826edd57c2ece138eb3aedaea3cd1f",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8c6b8d2faca5defb41c001c83985a91c9b8f9e81caec0e5653add5f7e80fe95f",
+    "zh:96d147ee8f62d15e20260de8b04cd1aebed3f76ca81223cdafcb522d88bb90ad",
+    "zh:98f39a5d41aed24290150c10bd7582672df6d9be9789245dd49b6935b2a0557e",
+    "zh:9e287652665f9cfde532855b0b4e2a09f7661ba88d594e36a9169a4acafe7852",
+  ]
+}

--- a/terraform/external/unifi/dns-records.tf
+++ b/terraform/external/unifi/dns-records.tf
@@ -1,0 +1,22 @@
+locals {
+  dns_records = {
+    lab = {
+      name  = "*.lab.petebeegle.com"
+      value = "192.168.30.241"
+    }
+    development = {
+      name  = "*.development.lab.petebeegle.com"
+      value = "192.168.30.225"
+    }
+  }
+}
+
+resource "unifi_dns_record" "gateway_wildcards" {
+  for_each = local.dns_records
+
+  name        = each.value.name
+  value       = each.value.value
+  record_type = "A"
+  enabled     = true
+  ttl         = 300
+}

--- a/terraform/external/unifi/provider.tf
+++ b/terraform/external/unifi/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    unifi = {
+      source  = "ubiquiti-community/unifi"
+      version = "0.41.25"
+    }
+  }
+}
+
+provider "unifi" {
+  api_url        = var.unifi.api_url
+  username       = var.unifi.username
+  password       = var.unifi.password
+  site           = var.unifi.site
+  allow_insecure = var.unifi.allow_insecure
+}

--- a/terraform/external/unifi/variables.tf
+++ b/terraform/external/unifi/variables.tf
@@ -1,0 +1,12 @@
+variable "unifi" {
+  description = "UniFi provider connection details supplied from an untracked local tfvars file, or omitted when using provider-supported environment variables such as UNIFI_API and UNIFI_API_KEY."
+  type = object({
+    api_url        = optional(string)
+    username       = optional(string)
+    password       = optional(string)
+    site           = optional(string, "default")
+    allow_insecure = optional(bool, true)
+  })
+  default   = {}
+  sensitive = true
+}


### PR DESCRIPTION
# UniFi DNS Records

## Summary

Add a new Terraform external root for UniFi-managed wildcard DNS records for `lab.petebeegle.com` and `development.lab.petebeegle.com`.

## Important Changes

- Added `terraform/external/unifi` with `ubiquiti-community/unifi` pinned to `0.41.25`.
- Configured the UniFi provider from a sensitive `unifi` object variable with defaults for `site = "default"` and `allow_insecure = true`.
- Added `unifi_dns_record.gateway_wildcards` with `for_each` for:
  - `*.lab.petebeegle.com` -> `192.168.30.241`
  - `*.development.lab.petebeegle.com` -> `192.168.30.225`
- Committed the generated `.terraform.lock.hcl` for the new Terraform root.
- Updated README external dependency guidance with the ignored `terraform/external/unifi/terraform.tfvars` example, API-key environment variable note, and import-before-apply flow.

## Documentation Impact

README external dependency guidance was updated because this adds an operator-facing Terraform root and credential/import workflow.

## Checks

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `terraform -chdir=terraform/external/unifi fmt -check`: passed.
- `terraform -chdir=terraform/external/unifi init -backend=false`: passed and generated `.terraform.lock.hcl`.
- `terraform -chdir=terraform/external/unifi validate`: passed.
- `python3 tools/architecture/render.py --check`: passed; architecture regeneration was not required.

## Deferred Live Work

Live import/apply and DNS verification were not run because UniFi credentials/account access are not available yet. First credentialed use should import the existing records into `unifi_dns_record.gateway_wildcards["lab"]` with `default:<record-id>` and `unifi_dns_record.gateway_wildcards["development"]` with `default:<record-id>`, then run `terraform plan` before apply.
