### PR TITLE
Implementation: fix-grafana-mcp-auth

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -18,9 +18,8 @@ command = "npx"
 args = ["-y", "terraform-mcp-server@latest"]
 
 [mcp_servers.grafana]
-command = "uvx"
-args = ["mcp-grafana"]
-env = { GRAFANA_URL = "https://monitoring.lab.petebeegle.com" }
+command = ".codex/scripts/run_grafana_mcp.sh"
+args = []
 
 [mcp_servers.context7]
 command = "npx"

--- a/.codex/scripts/run_grafana_mcp.sh
+++ b/.codex/scripts/run_grafana_mcp.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+
+GRAFANA_URL="${GRAFANA_URL:-https://monitoring.lab.petebeegle.com}"
+
+if [[ -z "${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+  state_path="$repo_root/terraform/external/grafana/terraform.tfstate"
+  if ! GRAFANA_SERVICE_ACCOUNT_TOKEN="$(terraform output -state="$state_path" -raw mcp_token 2>/dev/null)"; then
+    printf 'ERROR: failed to load Grafana MCP token from Terraform state at %s.\n' "$state_path" >&2
+    printf 'Run terraform apply in terraform/external/grafana/ or set GRAFANA_SERVICE_ACCOUNT_TOKEN in the process environment.\n' >&2
+    exit 1
+  fi
+
+  if [[ -z "$GRAFANA_SERVICE_ACCOUNT_TOKEN" ]]; then
+    printf 'ERROR: Grafana MCP token loaded from Terraform state is empty.\n' >&2
+    printf 'Run terraform apply in terraform/external/grafana/ or set GRAFANA_SERVICE_ACCOUNT_TOKEN in the process environment.\n' >&2
+    exit 1
+  fi
+fi
+
+export GRAFANA_URL GRAFANA_SERVICE_ACCOUNT_TOKEN
+exec uvx mcp-grafana "$@"

--- a/.devcontainer/poststart.sh
+++ b/.devcontainer/poststart.sh
@@ -44,7 +44,7 @@ for operator_file in "${operator_files[@]}"; do
 done
 
 # Grafana MCP token
-GRAFANA_SERVICE_ACCOUNT_TOKEN=$(tfo -state=terraform/external/grafana/terraform.tfstate -raw mcp_token 2>/dev/null || true)
+GRAFANA_SERVICE_ACCOUNT_TOKEN=$(terraform output -state=terraform/external/grafana/terraform.tfstate -raw mcp_token 2>/dev/null || true)
 if [[ -z "$GRAFANA_SERVICE_ACCOUNT_TOKEN" ]]; then
   echo "WARNING: GRAFANA_SERVICE_ACCOUNT_TOKEN is empty — run 'terraform apply' in terraform/external/grafana/ to provision the token"
 fi

--- a/.mcp.json
+++ b/.mcp.json
@@ -17,11 +17,8 @@
       ]
     },
     "grafana": {
-      "command": "uvx",
-      "args": ["mcp-grafana"],
-      "env": {
-        "GRAFANA_URL": "https://monitoring.lab.petebeegle.com"
-      }
+      "command": ".codex/scripts/run_grafana_mcp.sh",
+      "args": []
     }
   },
   "context7": {


### PR DESCRIPTION
## Summary
## Summary

Fix Grafana MCP authentication by routing startup through `.codex/scripts/run_grafana_mcp.sh`, which defaults `GRAFANA_URL` and loads `GRAFANA_SERVICE_ACCOUNT_TOKEN` from ignored Terraform state when the token is not already present in the process environment.

Commit: `d8c0472316a8d2a456000a82c5f19f70b8da8063`

## Important Changes

- Added `.codex/scripts/run_grafana_mcp.sh` with strict shell settings, script-location repo-root discovery, non-secret error messages, Terraform state token loading, and `uvx mcp-grafana` execution.
- Updated `.codex/config.toml` and `.mcp.json` so the Grafana MCP server calls the wrapper and no longer carries inline Grafana environment config.
- Updated `.devcontainer/poststart.sh` to use `terraform output -state=terraform/external/grafana/terraform.tfstate -raw mcp_token` directly instead of the interactive-only `tfo` alias.
- Confirmed `terraform/external/grafana/main.tf` keeps the Grafana service account role as `Viewer`.

## Documentation Impact

No docs were changed. This is operator tooling/config plumbing and the changed behavior is captured in the wrapper script plus MCP config entries.

## Verification

- Installed staged ignored config from `/workspaces/homelab/.codex/tmp/implementation-secrets/fix-grafana-mcp-auth/terraform/external/grafana/terraform.tfstate` into the sibling clone without logging contents.
- Validated workflow marker, implementation plan, and owner attestation with the codex harness scripts before tracked edits.
- `python3 -m json.tool .mcp.json >/dev/null`
- `python3 - <<'PY' ... tomllib.load(...) ... PY` for `.codex/config.toml`
- `bash -n .codex/scripts/run_grafana_mcp.sh .devcontainer/poststart.sh`
- `shellcheck .codex/scripts/run_grafana_mcp.sh .devcontainer/poststart.sh` skipped because `shellcheck` is not installed.
- `GRAFANA_SERVICE_ACCOUNT_TOKEN="$(terraform output -state=terraform/external/grafana/terraform.tfstate -raw mcp_token 2>/dev/null)" .codex/scripts/run_grafana_mcp.sh -version` returned `v0.14.0` without printing the token.
- `env -u GRAFANA_SERVICE_ACCOUNT_TOKEN .codex/scripts/run_grafana_mcp.sh -version` returned `v0.14.0` by loading from staged Terraform state.
- `pre-commit run --files .codex/config.toml .mcp.json .devcontainer/poststart.sh .codex/scripts/run_grafana_mcp.sh`
- `git diff --check`
- `git diff | rg -n "glsa_|eyJ[A-Za-z0-9_-]*\\.|[A-Za-z0-9+/=_-]{80,}" || true` found no token-like values.
- `rg -n "GRAFANA_SERVICE_ACCOUNT_TOKEN|glsa_|eyJ[A-Za-z0-9_-]*\\." .mcp.json .codex/config.toml || true` found no token entries in tracked MCP config.

## Follow-up

- Operator follow-up: rotate the live Grafana MCP service account token if the previous token may have been exposed outside ignored local state. I did not rotate it from this implementation to avoid logging secret material or making unexpected tracked changes.
- Main-agent live rotation attempt after the code cleanup was blocked: the current Terraform-state MCP token returned HTTP 401 against Grafana `/api/search`, Terraform provider refresh for `grafana_service_account.mcp` returned HTTP 401, SOPS decrypt of `kubernetes/infra/monitoring/grafana/secret.yaml` failed with a MAC mismatch, and no kube context was available in this shell.


## Changes
- .codex/config.toml
- .codex/scripts/run_grafana_mcp.sh
- .devcontainer/poststart.sh
- .mcp.json

## Commits
- d8c0472 fix: load grafana mcp token from terraform state

## Verification
- Verified HEAD: `d8c0472316a8d2a456000a82c5f19f70b8da8063`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
