### PR TITLE
Implementation: persist-monitoring-radar-plan

### DIFF
--- a/PLANS.md
+++ b/PLANS.md
@@ -49,3 +49,42 @@ Completed follow-ups:
 Follow-up efforts:
 
 1. No open follow-ups remain from this review set.
+
+## Monitoring Radar Grafana Dashboard
+
+Status: planned. Implementation discovery and live validation are blocked until Grafana MCP is reloaded or otherwise usable from the current Codex session.
+
+Summary:
+
+- Add an overview Grafana dashboard that acts as the homelab monitoring radar: the first port of call for cluster visibility, high-level diagnosis, and drill-down into specialized dashboards.
+- Keep the dashboard broad and shallow. It should answer "what needs attention now?" before sending the operator to Kubernetes, Flux, observability, Proxmox, synthetics, app, or log-focused views.
+
+Key changes:
+
+- Manage the dashboard through GitOps as dashboard JSON plus the existing Grafana Operator wrapper pattern.
+- Provision it in the existing `Monitoring` Grafana folder.
+- Make it Grafana Home by setting `dashboards.default_home_dashboard_path` in the Grafana Helm values.
+- Include links to existing specialized dashboards so this page is a navigation hub, not a replacement for detailed views.
+- Use high-level panels for Kubernetes health, Flux reconciliation, observability stack health, certificates, Gateway/Cilium traffic and errors, storage, synthetics, important apps, capacity, and log triage.
+
+Interfaces/config:
+
+- Follow the existing `GrafanaDashboard` plus ConfigMap pattern under `kubernetes/infra/monitoring/grafana/dashboards/`.
+- Update Grafana Helm values in `kubernetes/infra/monitoring/grafana/app.yaml` for the Home dashboard path.
+- Use existing datasource UIDs `prometheus` and `loki`.
+- Proposed dashboard identity: UID `monitoring-radar`, title `Monitoring Radar`.
+
+Test plan:
+
+- Validate dashboard JSON with `jq`.
+- Render the relevant kustomization with `kustomize`.
+- Run the architecture check and update generated architecture only if source changes require it.
+- Use Grafana MCP/API to confirm dashboard, folder, links, datasources, and Home behavior after the MCP session is usable.
+- After Flux applies the change, verify the live Grafana Home dashboard opens to Monitoring Radar.
+
+Assumptions/defaults:
+
+- Use Viewer-level Grafana MCP access for discovery and validation when possible.
+- GitOps owns durable dashboard and Grafana configuration writes; live changes are temporary diagnostics only.
+- Prefer the Home dashboard path over relying on a folderless Operator dashboard.
+- Do not change alert rules as part of this dashboard-only implementation.


### PR DESCRIPTION
## Summary
## Summary

Append the original Monitoring Radar / overview Grafana dashboard plan to the durable repo planning document.

## Important Changes

- Added `## Monitoring Radar Grafana Dashboard` to `PLANS.md`.
- Preserved the plan intent for a Grafana overview dashboard that serves as the first port of call for cluster visibility, high-level diagnosis, and drill-down into specialized dashboards.
- Captured proposed GitOps management, Grafana Operator wrapper/ConfigMap pattern, Monitoring folder provisioning, Home dashboard configuration, datasource UIDs, dashboard identity, panel coverage, assumptions, and future validation plan.
- Used `PLANS.md` because it is the repo's existing planning file; no `PLAN.md` exists in the repository.

## Documentation Impact

- Updated `PLANS.md`.
- Did not update generated `docs/architecture.md` because this is a docs-only planning note and no Kubernetes or Terraform source changed.

## Tests

- `git diff --check` passed.
- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- Risk tier: docs-only; no code TDD or live development smoke required.

## Workflow Notes

- User explicitly assigned this task to owner identity `implementation-agent-persist-monitoring-radar-plan`.
- Implementation work happened in `/workspaces/homelab-ideas/persist-monitoring-radar-plan` on branch `codex/persist-monitoring-radar-plan`.


## Changes
- PLANS.md

## Commits
- 00c2c6e docs: persist monitoring radar plan

## Verification
- Verified HEAD: `00c2c6ea40d57477e266c6019c7028857bc16c9f`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
