### PR TITLE
fix(synthetics): label smoke duration by run

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -41,10 +41,10 @@ kubectl logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
 Every completed run should emit exactly one bounded summary line:
 
 ```text
-SMOKE_RUN_SUMMARY status=success failed_count=0 failed_tests="" duration_seconds=37
+SMOKE_RUN_SUMMARY run="synthetic-smoke-28925520" status=success failed_count=0 failed_tests="" duration_seconds=37
 ```
 
-Failed runs use `status=failed` and include the final failed Playwright test names after retries in `failed_tests`. If Playwright fails before the custom reporter can run, the wrapper emits a fallback `SMOKE_RUN_SUMMARY status=failed` line and preserves the non-zero process exit.
+Failed runs use `status=failed` and include the final failed Playwright test names after retries in `failed_tests`. The `run` field is the Kubernetes Job name when available, then the pod hostname, then `unknown`. If Playwright fails before the custom reporter can run, the wrapper emits a fallback `SMOKE_RUN_SUMMARY run="..." status=failed` line and preserves the non-zero process exit.
 
 ## Common Failures
 
@@ -83,7 +83,7 @@ Grafana owns the `Synthetics` folder, `Synthetic Smoke` dashboard, and `syntheti
 
 - `Recent Status` counts recent `status=failed` summary lines.
 - `Smoke Runs` counts `status=success` and `status=failed` summary lines over the panel interval.
-- `Job Duration` unwraps `duration_seconds` from the summary line.
+- `Job Duration` unwraps `duration_seconds` from the summary line and labels each series by `run`.
 - `Smoke Logs` includes `SMOKE_RUN_SUMMARY` lines alongside Playwright failure output.
 
 The alert fires only when summary lines report more than one failed run in the last hour. A single failed run should be investigated, but it is not enough to alert by itself. The alert intentionally remains one aggregate alert instance; it does not group by `failed_tests`, because grouping that label in the alert condition would create separate alert instances per failed test text. Use the failed-test LogQL above from Grafana Explore when the aggregate alert fires.

--- a/kubernetes/apps/synthetics/cronjob.yaml
+++ b/kubernetes/apps/synthetics/cronjob.yaml
@@ -54,6 +54,10 @@ spec:
                   value: "1"
                 - name: SMOKE_BASE_DOMAIN
                   value: "${cluster_domain}"
+                - name: SMOKE_RUN_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['batch.kubernetes.io/job-name']
               command:
                 - /bin/bash
                 - -ceu

--- a/kubernetes/apps/synthetics/smoke/run-smoke.sh
+++ b/kubernetes/apps/synthetics/smoke/run-smoke.sh
@@ -2,6 +2,7 @@
 set -uo pipefail
 
 summary_pattern='^SMOKE_RUN_SUMMARY '
+max_run_name_length=128
 start_seconds="$(date +%s)"
 
 set +u
@@ -28,8 +29,26 @@ logfmt_quote() {
   node -e 'const value = String(process.argv[1] || "").replace(/[\r\n\t]+/g, " "); process.stdout.write(JSON.stringify(value));' "$1"
 }
 
+bounded_logfmt_quote() {
+  node -e 'const max = Number(process.argv[2] || "128"); const clean = String(process.argv[1] || "").replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim(); const value = clean.length <= max ? clean : (max <= 3 ? clean.slice(0, max) : clean.slice(0, max - 3) + "..."); process.stdout.write(JSON.stringify(value));' "$1" "$2"
+}
+
+smoke_run_name() {
+  local run_name="${SMOKE_RUN_NAME-}"
+
+  if [ -z "$run_name" ]; then
+    run_name="${HOSTNAME-}"
+  fi
+  if [ -z "$run_name" ]; then
+    run_name="unknown"
+  fi
+
+  printf '%s' "$run_name"
+}
+
 emit_fallback_summary() {
   local command_status="$1"
+  local run_name
   local status="success"
   local failed_count="0"
   local failed_tests=""
@@ -47,7 +66,10 @@ emit_fallback_summary() {
     failed_tests="playwright execution failed before reporter summary"
   fi
 
-  printf 'SMOKE_RUN_SUMMARY status=%s failed_count=%s failed_tests=%s duration_seconds=%s\n' \
+  run_name="$(smoke_run_name)"
+
+  printf 'SMOKE_RUN_SUMMARY run=%s status=%s failed_count=%s failed_tests=%s duration_seconds=%s\n' \
+    "$(bounded_logfmt_quote "$run_name" "$max_run_name_length")" \
     "$status" \
     "$failed_count" \
     "$(logfmt_quote "$failed_tests")" \

--- a/kubernetes/apps/synthetics/smoke/run-smoke.test.js
+++ b/kubernetes/apps/synthetics/smoke/run-smoke.test.js
@@ -5,31 +5,46 @@ const test = require("node:test");
 
 const scriptPath = path.join(__dirname, "run-smoke.sh");
 
-function runWrapper(command) {
+function runWrapper(command, env = {}) {
   return spawnSync("bash", [scriptPath], {
     cwd: __dirname,
     encoding: "utf8",
     env: {
       ...process.env,
+      SMOKE_RUN_NAME: "",
+      HOSTNAME: "synthetic-smoke-hostname",
+      ...env,
       SMOKE_PLAYWRIGHT_COMMAND: command
     }
   });
 }
 
 test("wrapper preserves a successful reporter summary without adding another line", () => {
-  const result = runWrapper("printf '%s\\n' 'SMOKE_RUN_SUMMARY status=success failed_count=0 failed_tests=\"\" duration_seconds=37'");
+  const result = runWrapper("printf '%s\\n' 'SMOKE_RUN_SUMMARY run=\"synthetic-smoke-28925520\" status=success failed_count=0 failed_tests=\"\" duration_seconds=37'");
   const summaryLines = result.stdout.split("\n").filter((line) => line.startsWith("SMOKE_RUN_SUMMARY "));
 
   assert.equal(result.status, 0);
-  assert.deepEqual(summaryLines, ['SMOKE_RUN_SUMMARY status=success failed_count=0 failed_tests="" duration_seconds=37']);
+  assert.deepEqual(summaryLines, ['SMOKE_RUN_SUMMARY run="synthetic-smoke-28925520" status=success failed_count=0 failed_tests="" duration_seconds=37']);
 });
 
 test("wrapper emits one fallback summary and preserves non-zero exit when Playwright fails before reporter output", () => {
-  const result = runWrapper("printf '%s\\n' 'setup exploded'; exit 42");
+  const result = runWrapper("printf '%s\\n' 'setup exploded'; exit 42", {
+    SMOKE_RUN_NAME: 'synthetic "manual" run \\ 123'
+  });
   const output = result.stdout + result.stderr;
   const summaryLines = output.split("\n").filter((line) => line.startsWith("SMOKE_RUN_SUMMARY "));
 
   assert.equal(result.status, 42);
   assert.equal(summaryLines.length, 1);
-  assert.match(summaryLines[0], /^SMOKE_RUN_SUMMARY status=failed failed_count=0 failed_tests="playwright execution failed before reporter summary" duration_seconds=\d+$/);
+  assert.match(summaryLines[0], /^SMOKE_RUN_SUMMARY run="synthetic \\"manual\\" run \\\\ 123" status=failed failed_count=0 failed_tests="playwright execution failed before reporter summary" duration_seconds=\d+$/);
+});
+
+test("wrapper fallback uses hostname when smoke run name is unavailable", () => {
+  const result = runWrapper("exit 42");
+  const output = result.stdout + result.stderr;
+  const summaryLines = output.split("\n").filter((line) => line.startsWith("SMOKE_RUN_SUMMARY "));
+
+  assert.equal(result.status, 42);
+  assert.equal(summaryLines.length, 1);
+  assert.match(summaryLines[0], /^SMOKE_RUN_SUMMARY run="synthetic-smoke-hostname" status=failed /);
 });

--- a/kubernetes/apps/synthetics/smoke/smoke-summary-reporter.js
+++ b/kubernetes/apps/synthetics/smoke/smoke-summary-reporter.js
@@ -1,4 +1,5 @@
 const MAX_FAILED_TESTS_LENGTH = 512;
+const MAX_RUN_NAME_LENGTH = 128;
 
 function sanitizeLogfmtValue(value) {
   return String(value)
@@ -21,6 +22,10 @@ function quoteLogfmt(value) {
   return '"' + sanitizeLogfmtValue(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
 }
 
+function smokeRunName(env = process.env) {
+  return env.SMOKE_RUN_NAME || env.HOSTNAME || "unknown";
+}
+
 function testTitle(test) {
   if (typeof test.titlePath === "function") {
     const parts = test.titlePath().filter(Boolean);
@@ -39,10 +44,12 @@ function finalFailedTests(suite) {
     .map(testTitle);
 }
 
-function formatSummary({ status, failedTests, durationSeconds }) {
+function formatSummary({ status, failedTests, durationSeconds, runName = smokeRunName() }) {
   const failedTestText = truncate(failedTests.map(sanitizeLogfmtValue).join("; "));
+  const runNameText = truncate(sanitizeLogfmtValue(runName), MAX_RUN_NAME_LENGTH);
   return [
     "SMOKE_RUN_SUMMARY",
+    "run=" + quoteLogfmt(runNameText),
     "status=" + status,
     "failed_count=" + failedTests.length,
     "failed_tests=" + quoteLogfmt(failedTestText),
@@ -73,6 +80,8 @@ class SmokeSummaryReporter {
 
 module.exports = SmokeSummaryReporter;
 module.exports.MAX_FAILED_TESTS_LENGTH = MAX_FAILED_TESTS_LENGTH;
+module.exports.MAX_RUN_NAME_LENGTH = MAX_RUN_NAME_LENGTH;
 module.exports.finalFailedTests = finalFailedTests;
 module.exports.formatSummary = formatSummary;
 module.exports.quoteLogfmt = quoteLogfmt;
+module.exports.smokeRunName = smokeRunName;

--- a/kubernetes/apps/synthetics/smoke/smoke-summary-reporter.test.js
+++ b/kubernetes/apps/synthetics/smoke/smoke-summary-reporter.test.js
@@ -2,7 +2,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const SmokeSummaryReporter = require("./smoke-summary-reporter");
-const { MAX_FAILED_TESTS_LENGTH, finalFailedTests } = SmokeSummaryReporter;
+const { MAX_FAILED_TESTS_LENGTH, MAX_RUN_NAME_LENGTH, finalFailedTests } = SmokeSummaryReporter;
 
 function makeSuite(tests) {
   return {
@@ -38,16 +38,43 @@ async function captureReporterLine(reporter, result, suite) {
   return lines[0];
 }
 
+async function withEnv(updates, fn) {
+  const original = new Map(Object.keys(updates).map((key) => [key, process.env[key]]));
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of original.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 test("reporter emits a successful bounded summary", async () => {
   const timestamps = [1_000, 38_000];
   const reporter = new SmokeSummaryReporter({ now: () => timestamps.shift() });
-  const line = await captureReporterLine(reporter, { status: "passed" }, makeSuite([]));
+  const line = await withEnv({ SMOKE_RUN_NAME: "synthetic-smoke-28925520", HOSTNAME: "pod-hostname" }, () =>
+    captureReporterLine(reporter, { status: "passed" }, makeSuite([]))
+  );
 
-  assert.equal(line, 'SMOKE_RUN_SUMMARY status=success failed_count=0 failed_tests="" duration_seconds=37');
+  assert.equal(line, 'SMOKE_RUN_SUMMARY run="synthetic-smoke-28925520" status=success failed_count=0 failed_tests="" duration_seconds=37');
 });
 
 test("reporter records only final failed tests after retries with escaping and truncation", async () => {
   const longTitle = 'pihole root redirects to the "admin" shell with slash \\ ' + "x".repeat(600);
+  const longRunName = 'synthetic "manual" run \\ ' + "x".repeat(200);
   const suite = makeSuite([
     makeTest("whoami exercises Gateway TLS and routing", "flaky"),
     makeTest(longTitle, "unexpected")
@@ -55,11 +82,17 @@ test("reporter records only final failed tests after retries with escaping and t
   const failedTests = finalFailedTests(suite);
   const timestamps = [2_000, 44_000];
   const reporter = new SmokeSummaryReporter({ now: () => timestamps.shift() });
-  const line = await captureReporterLine(reporter, { status: "failed" }, suite);
+  const line = await withEnv({ SMOKE_RUN_NAME: undefined, HOSTNAME: longRunName }, () =>
+    captureReporterLine(reporter, { status: "failed" }, suite)
+  );
+  const runField = line.match(/run="((?:\\"|\\\\|[^"])*)"/)[1];
   const failedTestsField = line.match(/failed_tests="((?:\\"|\\\\|[^"])*)"/)[1];
 
   assert.deepEqual(failedTests, [longTitle]);
-  assert.match(line, /^SMOKE_RUN_SUMMARY status=failed failed_count=1 failed_tests="/);
+  assert.match(line, /^SMOKE_RUN_SUMMARY run="synthetic \\"manual\\" run \\\\ /);
+  assert.match(line, / status=failed failed_count=1 failed_tests="/);
+  assert.ok(runField.length <= MAX_RUN_NAME_LENGTH + 4);
+  assert.equal(runField.endsWith("..."), true);
   assert.match(line, /\\"admin\\"/);
   assert.match(line, /slash \\\\/);
   assert.doesNotMatch(line, /\n|\r/);

--- a/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json
@@ -204,8 +204,8 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "max_over_time({namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\" | logfmt | unwrap duration_seconds [$__interval])",
-          "legendFormat": "duration_seconds",
+          "expr": "max by (run) (max_over_time({namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\" | logfmt | unwrap duration_seconds [$__interval]))",
+          "legendFormat": "{{run}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary

Restore per-run naming for the Synthetic Smoke dashboard Job Duration panel while keeping the Loki `SMOKE_RUN_SUMMARY` summary-line model introduced by PR #236.

## Important Changes

- Added `SMOKE_RUN_NAME` to `CronJob/synthetic-smoke` from the downward API field path `metadata.labels['batch.kubernetes.io/job-name']`.
- Added bounded quoted `run="..."` logfmt output to reporter-emitted and wrapper fallback `SMOKE_RUN_SUMMARY` lines.
- Kept existing `status`, `failed_count`, `failed_tests`, and `duration_seconds` fields for alert/query compatibility.
- Updated unit tests for reporter and wrapper output, including run-name escaping, truncation, and hostname fallback.
- Updated the Grafana Job Duration Loki query to aggregate by parsed `run` and display `{{run}}` in the legend.

## Documentation Impact

- Updated `docs/runbooks/synthetic-smoke-tests.md` summary-line example and dashboard description so the documented model includes the new `run` field.
- `docs/architecture.md` did not need regeneration; `python3 tools/architecture/render.py --check` passed.

## Tests And Verification

- PASS: `npm run test:unit` in `kubernetes/apps/synthetics/smoke`.
- PASS: `bash -n kubernetes/apps/synthetics/smoke/run-smoke.sh`.
- PASS: `jq empty kubernetes/infra/monitoring/grafana/dashboards/synthetic-smoke-dashboard.json`.
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `kubectl kustomize kubernetes/apps/synthetics`.
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana`.
- PASS: `git diff --check`.
- PASS: active implementation marker, implementation plan, and owner attestation validators.
- Standalone `kustomize` is not installed in this environment; `kubectl kustomize` was used as the substitute.

## Live Verification

- No live-cluster changes or smoke runs were performed. Local unit, syntax, JSON, architecture, and kustomize render checks covered the behavior and manifest changes without requiring development-cluster credentials.

## Workflow Note

- The user explicitly assigned this task to `implementation-agent-synthetic-smoke-duration-run-label`. No verifier approval files were created and no push was performed.
