### PR TITLE
fix(synthetics): avoid flux envsubst bash expansion

### DIFF
--- a/kubernetes/apps/synthetics/smoke/run-smoke.sh
+++ b/kubernetes/apps/synthetics/smoke/run-smoke.sh
@@ -34,11 +34,16 @@ bounded_logfmt_quote() {
 }
 
 smoke_run_name() {
-  local run_name="${SMOKE_RUN_NAME-}"
+  local run_name
+
+  set +u
+  run_name="$SMOKE_RUN_NAME"
 
   if [ -z "$run_name" ]; then
-    run_name="${HOSTNAME-}"
+    run_name="$HOSTNAME"
   fi
+  set -u
+
   if [ -z "$run_name" ]; then
     run_name="unknown"
   fi


### PR DESCRIPTION
## Summary

Fix the production `app-synthetics` Flux postBuild failure by removing Flux-sensitive Bash braced parameter expansion from `kubernetes/apps/synthetics/smoke/run-smoke.sh`.

## Important Changes

- Updated `smoke_run_name()` to temporarily disable nounset and read optional `$SMOKE_RUN_NAME` and `$HOSTNAME` values with plain variable expansion.
- Preserved the runtime fallback order: `SMOKE_RUN_NAME`, then `HOSTNAME`, then `unknown`.

## Documentation Impact

No documentation changed. The smoke wrapper behavior and operator workflow are unchanged; this only fixes how Flux parses the ConfigMap source during postBuild substitution.

## Verification

- Reproduced the target failure before the edit with `printf '%s\\n' '${SMOKE_RUN_NAME-}' | flux envsubst --strict`, which failed with `missing closing brace`.\n- Passed `flux build kustomization app-synthetics --path ./kubernetes/apps/synthetics --kustomization-file ./kubernetes/clusters/production/apps/synthetics.yaml --dry-run | env cluster_domain=lab.petebeegle.com flux envsubst --strict`.\n- Passed `npm run test:unit` from `kubernetes/apps/synthetics/smoke`, 5 tests.\n- Verifier approved exact HEAD `20fba007e487a04b6dd03f874b3f218c5e5db1be` and validated verifier attestation.\n\n## TDD And Smoke Evidence\n\nRisk tier is medium because the changed script is packaged into a production Flux app. The local red-green render evidence and existing unit tests were run. Development cluster smoke was not run because the failure is deterministic in Flux postBuild rendering, and the focused render plus unit tests cover the changed behavior.