### PR TITLE
docs: require dev-first validation evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Stack: Terraform, Talos OS, Kubernetes, Flux, Cilium, Gateway API, SOPS/Age, Syn
 - Treat Git as the source of truth. Change desired state in this repo, then let Flux reconcile it.
 - Keep live-cluster changes temporary unless a runbook explicitly says otherwise.
 - Codex may run Terraform and Flux against the development cluster for validation and repair when a task calls for it. Production remains GitOps-first; development live changes must still be made durable through repository changes.
+- For Kubernetes, Terraform, Flux, Gateway, storage, secrets references, and app behavior changes, run the implementation through the development cluster before production-oriented PR completion. Use the `whoami` branch deployment verifier when it fits, add `--include-cluster-base` for shared base changes, and record manual development smoke evidence for apps without automated profiles. If development cluster access or required credentials are unavailable, document the exception and substitute checks in the implementation plan, PR summary, and verifier notes.
 - Commit only SOPS-encrypted secret manifests. Kubernetes Secret files use repo path names ending with the standard secret manifest filenames matched by `.sops.yaml`.
 - Use Gateway API with Cilium for ingress. Prefer `HTTPRoute` or `TLSRoute` resources instead of traditional Kubernetes Ingress resources.
 - Use StorageClass `nfs-csi-storage` for persistent app storage unless a decision record supersedes it.
@@ -97,6 +98,7 @@ Primary dependency chain:
 
 ## Before Pushing Kubernetes Changes
 
+- Confirm covered cluster-affecting changes have development-cluster validation evidence, or a documented exception for unavailable development infrastructure or credentials with substitute checks.
 - Confirm HelmRelease `dependsOn` covers required CRDs, storage, and ingress dependencies.
 - Confirm PVCs use `nfs-csi-storage` unless intentionally using another storage class.
 - Confirm Gateway routes reference an existing Gateway and section.

--- a/docs/decisions/tdd-and-development-smoke-evidence.md
+++ b/docs/decisions/tdd-and-development-smoke-evidence.md
@@ -17,9 +17,11 @@ superseded_by:
 
 ## Decision
 
-Implementation plans, PR summaries, and verifier review should use risk-tiered TDD and development smoke evidence for repository changes.
+Implementation plans, PR summaries, and verifier review must use risk-tiered TDD and development validation evidence for repository changes.
 
-This evidence is advisory in v1. Owners and verifiers must document expectations, results, and exceptions, but the harness must not add hard gates for TDD or smoke testing until the practice proves stable across routine work.
+Development-cluster validation is required before production-oriented PR completion for covered cluster-affecting changes: Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, branch overlays, and app behavior. TDD evidence remains risk-tiered and documented. The harness must not add hard gates for TDD or smoke testing until the practice proves stable across routine work; owners and verifiers enforce the requirement through plan, PR, and review evidence.
+
+If the development cluster, kubeconfig, required staged development secrets, or required credentials are unavailable, owners may record a documented exception with substitute checks. Actual development validation failures are not exceptions; the change should be fixed and rerun before production-oriented completion.
 
 The existing single-owner implementation model remains binding. Test-helper and smoke-helper lanes may research, run commands, prepare recommendations, and report evidence, but the implementation owner remains responsible for tracked edits, commits, local workflow files, `.codex/tmp/pr-summary.md`, and final branch state.
 
@@ -28,15 +30,15 @@ The existing single-owner implementation model remains binding. Test-helper and 
 - TDD expectations should scale with operational risk instead of forcing the same process onto docs-only changes and cluster-wide changes.
 - Development smoke tests are valuable only when their evidence identifies the app, branch, exact `HEAD`, profile, result, and cleanup state.
 - The current branch deployment verifier is intentionally narrow, with automated support for `whoami` only while a config-driven app profile model is developed.
-- Hard gates would be brittle before the team has enough examples of useful tests, smoke profiles, and valid exceptions.
+- Hard harness gates would be brittle before the team has enough examples of useful tests, smoke profiles, and valid exceptions.
 - Preserving the single-owner model keeps responsibility clear even when helper lanes contribute evidence.
 
 ## Consequences
 
-- Implementation plans should describe TDD, smoke expectations, and known exceptions in the tests, verification, and risks sections.
-- PR summaries should include commands run, smoke reports or exceptions, documentation impact, and whether generated architecture changed.
-- Verifiers should audit declared tests and smoke evidence against the risk tier, spot-check stale or incomplete evidence, and record residual risk when live validation is unavailable.
-- New app work should add or select a smoke profile when practical, or document why development smoke coverage is deferred.
+- Implementation plans must describe TDD, development validation expectations, and known exceptions in the tests, verification, and risks sections.
+- PR summaries must include commands run, development smoke reports or exceptions, documentation impact, and whether generated architecture changed.
+- Verifiers must audit declared tests and development validation evidence against the risk tier, spot-check stale or incomplete evidence, and confirm documented exceptions when live validation is unavailable.
+- New app work must add or select a smoke profile when practical, or document why development smoke coverage is deferred.
 - Hard harness gates, automated profile enforcement, and non-`whoami` deployment verifier behavior are deferred to future implementations.
 
 ## Operational Notes

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -130,9 +130,17 @@ Branch environments are for app-scoped validation on the development cluster. Us
 
 Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, checks the whoami Service and HTTPRoute, and then removes the temporary branch Flux resources unless `--keep` is set.
 
-The current deployment verifier is intentionally limited to the `whoami` smoke path while the app profile model is expanded. Treat non-`whoami` app smoke as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile as an exception rather than adding ad hoc harness behavior.
+The current deployment verifier is intentionally limited to the `whoami` smoke path while the app profile model is expanded. Treat non-`whoami` app smoke as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile instead of adding ad hoc harness behavior.
 
 The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
+
+### Dev-First Requirement
+
+Run covered cluster-affecting changes through the development cluster before production-oriented PR completion. Covered changes include Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, branch overlays, and app behavior. Docs-only and purely local tooling changes do not require live development validation unless they alter cluster behavior.
+
+Use the `whoami` branch verifier when the supported profile fits the change. Use manual development smoke evidence for apps without automated profiles. Add `--include-cluster-base` for shared cluster base changes before app acceptance. Production remains GitOps-first; development live validation is evidence, not a substitute for durable repository changes.
+
+If the development cluster, kubeconfig, staged development secrets, or required credentials are unavailable, record `smoke_profile: none` with the blocker, substitute checks, and any follow-up needed. Do not treat an actual development validation failure as an exception; fix the change and rerun validation before production-oriented completion.
 
 ### Live App Acceptance
 
@@ -190,7 +198,7 @@ This proves that the pushed branch can be fetched by Flux, the whoami branch ove
 
 For each implementation that changes app behavior, manifests, Gateway routing, storage, secrets references, or branch overlays, list touched apps in the implementation plan or PR summary and choose one smoke path per app:
 
-| Change type | Minimum development smoke evidence |
+| Change type | Minimum development validation evidence |
 | --- | --- |
 | Branch overlay only | Render the branch overlay locally; when supported, run `verify_branch_deploy.py` for the app profile. |
 | Workload, Service, or route | Confirm workload readiness, Service presence, and `HTTPRoute` or `TLSRoute` attachment in a development branch namespace. |
@@ -203,18 +211,18 @@ For each implementation that changes app behavior, manifests, Gateway routing, s
 
 The target model is a config-driven smoke profile per app. A profile should name the app, branch overlay path, activation template, expected namespace, workloads, Services, routes, PVCs, app-specific probes, cleanup expectations, and any required development-only secret/config prerequisites. Profiles should allow the verifier to choose consistent checks without hard-coding each app into the harness.
 
-Until profile expansion lands, use `whoami` as the only automated profile and document either:
+Until profile expansion lands, use `whoami` as the only automated profile and document one of:
 
 - `smoke_profile: whoami` with the exact `verify_branch_deploy.py` command and result.
 - `smoke_profile: manual` with commands and observations for the touched app.
-- `smoke_profile: none` with the reason, such as docs-only, unavailable development cluster, missing app branch overlay, or production-only integration.
+- `smoke_profile: none` with the reason, such as docs-only, local-only, unavailable development cluster or credentials, missing app branch overlay that cannot be safely emulated manually, or production-only integration.
 
 An exact-`HEAD` smoke report should include:
 
 - implementation name, app name, branch, branch slug, and exact commit SHA tested;
 - smoke profile name or documented exception;
 - whether `--push`, `--terraform-apply`, `--include-cluster-base`, or `--keep` was used;
-- readiness, route, storage, secret-reference, and app-specific probe results that apply to the app;
+- readiness, route, storage, secret reference, and app-specific probe results that apply to the app;
 - cleanup status, including any namespaces, Flux resources, or PVCs intentionally left behind;
 - timestamp and kubeconfig or context used, without secret contents.
 

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -19,13 +19,13 @@ Use this runbook for every repository code change. The binding decision is `docs
 3. If ignored local secrets or configs are required, stage them under `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout, preserving repo-relative paths and never logging contents.
 4. Clone the repo into `/workspaces/homelab-ideas/<implementation>` and create `codex/<implementation>` from `origin/main`.
 5. Before tracked edits, create `.codex/tmp/active-implementation` with `implementation`, `branch`, `base`, `role`, `clone_path`, `owner_role`, and `owner_agent`.
-6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development smoke expectations for the implementation, or explain why they do not apply.
+6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development validation expectations for the implementation, or explain why they do not apply.
 7. Before tracked edits, create `.codex/tmp/implementation-owner-attestation.yaml` with implementation identity, role, concrete `agent_id`, clone path, `created_at`, and matching delegation token evidence under `.codex/tmp/delegation-tokens/`.
 8. Validate the marker, plan, and owner attestation.
 9. Make tracked-file changes only in the sibling clone.
 10. Update docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no docs change, record why in `.codex/tmp/pr-summary.md`.
 11. Commit with conventional commits.
-12. Run relevant checks, collect TDD and development smoke evidence expected by the plan, and request verifier review.
+12. Run relevant checks, collect TDD evidence, and collect required development-cluster validation evidence for covered cluster-affecting changes before requesting verifier review.
 13. Record verifier approval for the exact `HEAD` SHA in `.codex/tmp/verifier-approved`.
 14. Record `.codex/tmp/verifier-attestation.yaml` with verifier identity, separate delegation token evidence, and `approved_head` equal to the exact `HEAD` SHA. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
 15. Write `.codex/tmp/pr-summary.md` from the plan and final result.
@@ -154,9 +154,9 @@ Helper subagents may research, test, run smoke checks, or recommend patches thro
 
 If subagent tooling is unavailable or higher-priority runtime policy blocks delegation, blocked delegation is not automatic permission for main-agent self-work. The user must explicitly consent to self-implementation or self-verification for that task, and the approved fallback must be recorded in `.codex/tmp/pr-summary.md`.
 
-## Risk-Tiered TDD And Smoke Evidence
+## Risk-Tiered TDD And Development Validation
 
-TDD and development smoke evidence is advisory in v1. It is still expected for normal work, but it is documented and reviewed rather than enforced by hard harness gates. See `docs/decisions/tdd-and-development-smoke-evidence.md`.
+TDD evidence remains risk-tiered and documented. Development-cluster validation is required for covered cluster-affecting changes before production-oriented PR completion, but it is enforced by implementation and verifier review rather than hard harness gates. See `docs/decisions/tdd-and-development-smoke-evidence.md`.
 
 Declare a risk tier in the plan:
 
@@ -172,30 +172,39 @@ TDD expectations by tier:
 - `medium`: prefer a red-green flow for behavior changes, including local render tests or focused unit tests for Kubernetes/Terraform tooling where applicable.
 - `high`: use a test-helper lane by default to identify or prepare failing tests before implementation, plus broader verification after the change. If no useful failing test can be made, record why.
 
-Development smoke expectations by tier:
+Development validation expectations by tier:
 
 - `docs-only`: no live development smoke required.
-- `low`: smoke only when the changed path affects live app rendering or operator commands.
-- `medium`: use a smoke-helper lane by default for touched apps or explain why local verification is enough.
-- `high`: run development cluster smoke for the affected app or base path when credentials and cluster health allow it; otherwise record the blocker and the safest substitute evidence.
+- `low`: run development validation when the changed path affects live app rendering or operator commands.
+- `medium`: run development validation for Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, and app behavior changes. Use a smoke-helper lane by default for touched apps when delegation is available.
+- `high`: run development validation for the affected app or base path. For shared cluster base changes, include a sequential development base reconcile before app acceptance.
+
+If the development cluster, kubeconfig, required staged development secrets, or required credentials are unavailable, record a documented exception with the blocker and safest substitute checks. A real development validation failure is not an exception; fix the change, rerun validation, or leave the PR incomplete.
+
+Default development validation paths:
+
+- `smoke_profile: whoami`: run `python3 tools/development/verify_branch_deploy.py --app whoami --branch <branch> --slug <slug> --push` when the `whoami` branch profile fits the touched app or acceptance path.
+- `--include-cluster-base`: add this flag when the implementation changes resources under `kubernetes/clusters/development`, shared CRDs, controller installs, Gateway base objects, Cilium, cert-manager, NFS CSI, Flux dependency ordering, or app dependencies that must reconcile before branch app validation.
+- `smoke_profile: manual`: for apps without automated profiles, run manual development smoke checks that prove the relevant workload, Service, route, storage, secret reference, and app-specific behavior. Record exact commands and observations.
+- `smoke_profile: none`: use only for docs-only or local-only changes, unavailable development infrastructure or credentials, missing development branch coverage that cannot be safely emulated manually, or production-only integrations that development cannot represent. Include substitute checks and a follow-up when coverage should be added.
 
 ## Helper Lanes
 
 Use helper lanes without breaking the single-owner model:
 
 - `test-helper`: researches risk, proposes or runs failing tests, and reports command output or patch recommendations. The implementation owner remains the only role that applies tracked-file edits.
-- `smoke-helper`: prepares or runs development cluster smoke checks, captures exact branch and `HEAD` evidence, and recommends cleanup. The implementation owner remains responsible for final branch state and PR notes.
+- `smoke-helper`: prepares or runs development cluster validation, captures exact branch and `HEAD` evidence, and recommends cleanup. The implementation owner remains responsible for final branch state and PR notes.
 
 Helper output belongs in `.codex/tmp/pr-summary.md` or an equivalent local note when it affects verifier review. Include commands, outcomes, skipped checks, and exceptions. Do not create verifier approval files from helper lanes.
 
 ## Evidence Audit
 
-Before requesting verifier review, the implementation owner should audit:
+Before requesting verifier review, the implementation owner must audit:
 
-- The plan declares the intended TDD and smoke expectations for the risk tier.
-- Any skipped failing test, missing smoke profile, unavailable development cluster, or other exception is recorded with a reason.
+- The plan declares the intended TDD and development validation expectations for the risk tier.
+- Any skipped failing test, missing smoke profile, unavailable development cluster, unavailable credentials, or other exception is recorded with a reason and substitute checks.
 - Test evidence includes the exact commands run and pass/fail result.
-- Development smoke evidence includes app name, branch, branch slug, exact `HEAD`, smoke profile or documented exception, report path if one was produced, cleanup status, and whether stale reports were ignored or removed.
+- Development validation evidence includes app name, branch, branch slug, exact `HEAD`, smoke profile or documented exception, report path if one was produced, cleanup status, and whether stale reports were ignored or removed.
 - Parent/process evidence is internally consistent: active marker, plan, owner attestation, delegation token, branch, clone path, and PR summary all point at the same implementation.
 
-Verifier review should audit the same evidence. If declared TDD or smoke evidence is stale, missing, or inconsistent with the risk tier, the verifier should request a rerun, run a spot check, or record the residual risk before sign-off.
+Verifier review must audit the same evidence. If required development validation is stale, missing, or inconsistent with the risk tier, the verifier must request a rerun, run a spot check, or confirm a documented exception before sign-off.


### PR DESCRIPTION
## Summary

Make development-cluster validation mandatory for covered cluster-affecting changes before production-oriented PR completion.

## Important Changes

- Added durable agent guidance that Kubernetes, Terraform, Flux, Gateway, storage, secrets references, and app behavior changes must run through development first.
- Updated the implementation workflow to require development validation evidence for covered changes and documented exceptions only for unavailable development infrastructure, kubeconfig, staged development secrets, or credentials.
- Added a `Dev-First Requirement` section to the development cluster runbook and clarified `whoami`, `--include-cluster-base`, manual smoke, and `smoke_profile: none` usage.
- Updated the TDD and development smoke decision record so the requirement is enforced through implementation and verifier review rather than hard harness gates.

## Documentation Impact

This implementation is documentation and agent guidance only. No generated architecture update was needed because no Kubernetes or Terraform source relationships changed.

## Runtime Policy Fallback

Higher-priority runtime policy only permits subagent delegation when the user explicitly asks for subagents. The user explicitly asked the main agent to implement this plan, so tracked implementation and verifier work used the documented main-agent fallback path for this task. The fallback is recorded here as required by `docs/runbooks/implementation-workflow.md`.

## Commands And Results

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 tools/architecture/render.py --check` - passed.
- `python3 -m unittest tools.development.tests.test_verify_branch_deploy` - passed, 18 tests.
- `git diff --check` - passed.

## TDD And Development Validation Evidence

Risk tier is docs-only because the change updates process documentation and agent guidance. Live development-cluster validation is not required for this policy documentation change. The development verifier unit tests and architecture freshness check were run as substitute static checks.
