### PR TITLE
fix(foundry): update public domain

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.development.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |
-| `HTTPRoute` | `foundryvtt/foundryvtt-public` | `foundry2.petebeegle.com` | `gateway/public/http-gateway` | `foundryvtt:80` |
+| `HTTPRoute` | `foundryvtt/foundryvtt-public` | `foundry.petebeegle.com` | `gateway/public/http-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `grafana:80` |

--- a/kubernetes/apps/cloudflare-tunnels/deployment.yaml
+++ b/kubernetes/apps/cloudflare-tunnels/deployment.yaml
@@ -104,7 +104,7 @@ data:
     # E.g. `cloudflared tunnel route dns example-tunnel tunnel.example.com`.
     ingress:
     # Public hostnames enter the cluster through gateway/public, then route by HTTPRoute.
-    - hostname: foundry2.petebeegle.com
+    - hostname: foundry.petebeegle.com
       service: http://cilium-gateway-public.gateway.svc.cluster.local:80
     # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
     - service: http_status:404

--- a/kubernetes/apps/foundryvtt/httproute-public.yaml
+++ b/kubernetes/apps/foundryvtt/httproute-public.yaml
@@ -10,7 +10,7 @@ spec:
       namespace: gateway
       sectionName: http-gateway
   hostnames:
-    - foundry2.petebeegle.com
+    - foundry.petebeegle.com
   rules:
     - matches:
         - path:


### PR DESCRIPTION
## Summary

Update the public Foundry VTT hostname from `foundry2.petebeegle.com` to `foundry.petebeegle.com`.

## Important Changes

- Changed `kubernetes/apps/foundryvtt/httproute-public.yaml` so `HTTPRoute/foundryvtt-public` now matches `foundry.petebeegle.com`.
- Changed `kubernetes/apps/cloudflare-tunnels/deployment.yaml` so the cloudflared ingress rule now routes `foundry.petebeegle.com` to `http://cilium-gateway-public.gateway.svc.cluster.local:80`.
- Refreshed generated `docs/architecture.md` so the Gateway route inventory reflects the new public hostname.

## Documentation Impact

- Updated generated architecture documentation via `python3 tools/architecture/render.py --write`.
- No runbook or decision-record updates were needed because the public Gateway and Cloudflare Tunnel pattern did not change.

## Test And Verification Evidence

- PASS: owner marker validation:
  `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: implementation plan validation:
  `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: owner attestation validation:
  `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `kubectl kustomize kubernetes/apps/foundryvtt`
- PASS: `kubectl kustomize kubernetes/apps/cloudflare-tunnels`
- PASS: `kubectl kustomize kubernetes/clusters/production/apps`
- PASS: `kubectl kustomize kubernetes/clusters/production`
- PASS: `rg -n "foundry\\.petebeegle\\.com" kubernetes docs` found the expected manifest and generated-doc references.
- PASS: `rg -n "foundry2\\.petebeegle\\.com" kubernetes docs` returned no matches.

## Development Validation

- Risk tier: medium.
- Development validation exception: `kubectl config current-context` failed with `error: current-context is not set`, so no safe development cluster context is available in this environment.
- Representativeness note: this change targets a production public Cloudflare hostname; the development cluster paths present in the repo do not include equivalent Cloudflare public tunnel coverage for this hostname.
- Substitute checks: local architecture render check plus focused app kustomize renders, production app activation render, full production cluster kustomize render, and hostname grep checks.

