### PR TITLE
Add synthetics development smoke profile

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`.
 - App activation list: `whoami.yaml`, `foundry-bluegreen-fixture.yaml`.
 
-- Branch environment templates: `whoami-template.yaml`.
+- Branch environment templates: `whoami-template.yaml`, `synthetics-template.yaml`.
 
 ### Flux Substitution Variables
 
@@ -130,6 +130,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
 | `kubernetes/apps/renovate` | `app.yaml`, `secret.yaml` |
+| `kubernetes/apps/synthetics/branch` | `namespace.yaml`, `cronjob.yaml` |
 | `kubernetes/apps/synthetics` | `namespace.yaml`, `cronjob.yaml` |
 | `kubernetes/apps/valheim` | `./app.yaml`, `./secret.yaml` |
 | `kubernetes/apps/whoami/branch` | `whoami.yaml` |

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -128,11 +128,11 @@ Branch environments are for app-scoped validation on the development cluster. Us
 <app>-${branch_slug}.development.lab.petebeegle.com
 ```
 
-Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, checks the whoami Service and HTTPRoute, and then removes the temporary branch Flux resources unless `--keep` is set.
+Use `tools/development/verify_branch_deploy.py` as the canonical path for branch validation. The tool loads JSON smoke profiles from `tools/development/smoke-profiles/`, renders the selected activation template, applies it directly to the development cluster, forces Flux reconciliation, runs profile-specific checks, and then removes the temporary branch Flux resources unless `--keep` is set.
 
-The current deployment verifier is intentionally limited to the `whoami` smoke path while the app profile model is expanded. Treat non-`whoami` app smoke as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile instead of adding ad hoc harness behavior.
+The current automated profiles are `whoami` and `synthetics`. Treat apps without a profile as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile instead of adding ad hoc harness behavior.
 
-The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
+Activation templates live in `kubernetes/clusters/development/branches/`, and branch-aware app payload overlays live under app directories such as `kubernetes/apps/whoami/branch/` and `kubernetes/apps/synthetics/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. Templates are not referenced from the live development entrypoint and are suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
 
 ### Dev-First Requirement
 
@@ -156,6 +156,12 @@ Normal live verification:
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+Synthetic smoke deployment verification:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app synthetics --branch codex/example-change --slug example-change --push
 ```
 
 Run Terraform apply first when the development cluster base may need to be created or repaired:
@@ -192,7 +198,7 @@ kubectl --kubeconfig ~/.kube/homelab-development.config wait namespace/whoami-ex
 kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gitrepository.source.toolkit.fluxcd.io/branch-example-change
 ```
 
-This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
+The `whoami` profile proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. The `synthetics` profile proves the synthetic smoke CronJob deploys suspended, the smoke source ConfigMap contains the expected files, `SMOKE_BASE_DOMAIN` is substituted to the development domain, and a temporary Job can run Playwright test discovery with `npm run test -- --list` without executing route probes. Without `--include-cluster-base`, these profiles do not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps outside the selected profile.
 
 ### Touched-App Smoke Matrix
 
@@ -211,9 +217,10 @@ For each implementation that changes app behavior, manifests, Gateway routing, s
 
 The target model is a config-driven smoke profile per app. A profile should name the app, branch overlay path, activation template, expected namespace, workloads, Services, routes, PVCs, app-specific probes, cleanup expectations, and any required development-only secret/config prerequisites. Profiles should allow the verifier to choose consistent checks without hard-coding each app into the harness.
 
-Until profile expansion lands, use `whoami` as the only automated profile and document one of:
+Current automated profiles:
 
 - `smoke_profile: whoami` with the exact `verify_branch_deploy.py` command and result.
+- `smoke_profile: synthetics` with the exact `verify_branch_deploy.py` command and result. This profile deploys the branch CronJob suspended and validates JavaScript discovery; it does not run route probes.
 - `smoke_profile: manual` with commands and observations for the touched app.
 - `smoke_profile: none` with the reason, such as docs-only, local-only, unavailable development cluster or credentials, missing app branch overlay that cannot be safely emulated manually, or production-only integration.
 

--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -8,6 +8,8 @@ Use this runbook when the in-cluster Playwright smoke checks fail or when adding
 
 The checks are intentionally deeper than pod readiness and lighter than full authenticated end-to-end tests. They do not use credentials in v1.
 
+Development branch validation uses `tools/development/verify_branch_deploy.py --app synthetics`. That profile deploys a branch-scoped synthetic smoke CronJob in a suspended state, verifies the generated ConfigMap and development-domain substitution, and runs a temporary Job with `SMOKE_PLAYWRIGHT_COMMAND='npm run test -- --list'` to prove the JavaScript and Playwright configuration load. It intentionally does not run route probes in development.
+
 ## Targets
 
 - `whoami.${cluster_domain}` verifies the baseline Gateway TLS path.
@@ -72,10 +74,12 @@ sum by (failed_tests) (count_over_time({namespace="synthetics", app="synthetic-s
 1. Add the routed app to `tests/smoke/routes.spec.js`.
 2. Prefer unauthenticated page-shell checks that prove the user-facing route works without storing secrets.
 3. Match durable text, titles, or redirects instead of brittle CSS classes.
-4. Mirror the same smoke files under `kubernetes/apps/synthetics/smoke/`; Flux cannot load ConfigMap files from outside the app kustomization root.
+4. Mirror the same smoke files under `kubernetes/apps/synthetics/smoke/` and `kubernetes/apps/synthetics/branch/smoke/`; Flux cannot load ConfigMap files from outside the app kustomization root.
 5. Avoid raw `${...}` syntax in mirrored smoke files unless Flux should substitute it; Flux post-build substitution scans the generated ConfigMap data.
 6. Add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires that app to exist first.
 7. Run the suite locally when the route is reachable, then create a manual Job after Flux applies the change.
+
+For smoke source or CronJob changes, also run the `synthetics` development smoke profile before production-oriented completion so deploy-time ConfigMap, Flux substitution, and JavaScript discovery errors are caught before production.
 
 ## Dashboard And Alert
 

--- a/kubernetes/apps/synthetics/branch/cronjob.yaml
+++ b/kubernetes/apps/synthetics/branch/cronjob.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: synthetic-smoke-${branch_slug}
+  namespace: synthetics-${branch_slug}
+  labels:
+    app: synthetic-smoke
+    app.kubernetes.io/name: synthetic-smoke
+    app.kubernetes.io/component: synthetic-test
+    app.kubernetes.io/part-of: branch-environment
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  schedule: "*/15 * * * *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        app: synthetic-smoke
+        app.kubernetes.io/name: synthetic-smoke
+        app.kubernetes.io/component: synthetic-test
+        app.kubernetes.io/part-of: branch-environment
+        homelab.petebeegle.com/branch-slug: ${branch_slug}
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app: synthetic-smoke
+            app.kubernetes.io/name: synthetic-smoke
+            app.kubernetes.io/component: synthetic-test
+            app.kubernetes.io/part-of: branch-environment
+            homelab.petebeegle.com/branch-slug: ${branch_slug}
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: playwright
+              image: mcr.microsoft.com/playwright:v1.60.0-noble
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: CI
+                  value: "true"
+                - name: HOME
+                  value: /tmp
+                - name: npm_config_cache
+                  value: /workdir/.npm
+                - name: PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
+                  value: "1"
+                - name: SMOKE_BASE_DOMAIN
+                  value: "${cluster_domain}"
+                - name: SMOKE_RUN_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.labels['batch.kubernetes.io/job-name']
+              command:
+                - /bin/bash
+                - -ceu
+                - |
+                  cp -R /smoke-src/. /workdir
+                  cd /workdir
+                  npm ci --no-audit --no-fund
+                  bash ./run-smoke.sh
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 512Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: smoke-source
+                  mountPath: /smoke-src
+                  readOnly: true
+                - name: workdir
+                  mountPath: /workdir
+          volumes:
+            - name: smoke-source
+              configMap:
+                name: synthetic-smoke-source
+            - name: workdir
+              emptyDir: {}

--- a/kubernetes/apps/synthetics/branch/kustomization.yaml
+++ b/kubernetes/apps/synthetics/branch/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cronjob.yaml
+configMapGenerator:
+  - name: synthetic-smoke-source
+    namespace: synthetics-${branch_slug}
+    files:
+      - package.json=smoke/package.json
+      - package-lock.json=smoke/package-lock.json
+      - playwright.config.js=smoke/playwright.config.js
+      - run-smoke.sh=smoke/run-smoke.sh
+      - routes.spec.js=smoke/routes.spec.js
+      - smoke-summary-reporter.js=smoke/smoke-summary-reporter.js
+    options:
+      disableNameSuffixHash: true

--- a/kubernetes/apps/synthetics/branch/namespace.yaml
+++ b/kubernetes/apps/synthetics/branch/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: synthetics-${branch_slug}
+  labels:
+    name: synthetics-${branch_slug}
+    app.kubernetes.io/name: synthetic-smoke
+    app.kubernetes.io/part-of: branch-environment
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/synthetics/branch/smoke/package-lock.json
+++ b/kubernetes/apps/synthetics/branch/smoke/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homelab-smoke-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/kubernetes/apps/synthetics/branch/smoke/package.json
+++ b/kubernetes/apps/synthetics/branch/smoke/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "homelab-smoke-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:unit": "node --test smoke-summary-reporter.test.js run-smoke.test.js"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0"
+  }
+}

--- a/kubernetes/apps/synthetics/branch/smoke/playwright.config.js
+++ b/kubernetes/apps/synthetics/branch/smoke/playwright.config.js
@@ -1,0 +1,32 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000
+  },
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["list"], ["./smoke-summary-reporter.js"]] : "list",
+  use: {
+    baseURL: "https://whoami." + (process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com"),
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+    launchOptions: {
+      chromiumSandbox: false
+    },
+    actionTimeout: 10_000,
+    navigationTimeout: 20_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"]
+      }
+    }
+  ]
+});

--- a/kubernetes/apps/synthetics/branch/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/branch/smoke/routes.spec.js
@@ -1,0 +1,47 @@
+const { expect, test } = require("@playwright/test");
+
+const baseDomain = process.env.SMOKE_BASE_DOMAIN || "lab.petebeegle.com";
+
+function urlFor(host, path = "/") {
+  return "https://" + host + "." + baseDomain + path;
+}
+
+async function gotoOk(page, url) {
+  const response = await page.goto(url, { waitUntil: "domcontentloaded" });
+  expect(response, url + " should return an HTTP response").not.toBeNull();
+  expect(response.status(), url + " should not return a server error").toBeLessThan(500);
+  return response;
+}
+
+test.describe("homelab routed services", () => {
+  test("whoami exercises Gateway TLS and routing", async ({ page }) => {
+    await gotoOk(page, urlFor("whoami"));
+    await expect(page.locator("body")).toContainText(/Hostname|IP|RemoteAddr|GET \//i);
+  });
+
+  test("authentik serves the unauthenticated start page", async ({ page }) => {
+    await gotoOk(page, urlFor("authentik"));
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
+  test("grafana reaches the login or landing shell", async ({ page }) => {
+    await gotoOk(page, urlFor("monitoring"));
+    await expect(page.locator("body")).toContainText(/Grafana|Login|Sign in|Welcome/i);
+  });
+
+  test("jellyfin reaches the public web shell", async ({ page }) => {
+    await gotoOk(page, urlFor("jellyfin"));
+    await expect(page.locator("body")).toContainText(/Jellyfin|Please sign in|Wizard|Login/i);
+  });
+
+  test("pihole root redirects to the admin shell", async ({ page }) => {
+    await gotoOk(page, urlFor("pihole"));
+    await expect(page).toHaveURL(/\/admin(?:\/|\/login)?$/);
+    await expect(page.locator("body")).toContainText(/Pi-hole|Sign in|Login|Password/i);
+  });
+
+  test("foundry reaches the unauthenticated application shell", async ({ page }) => {
+    await gotoOk(page, urlFor("foundry"));
+    await expect(page.locator("body")).toContainText(/Foundry|Game Worlds|Administration|Join Game Session|Setup/i);
+  });
+});

--- a/kubernetes/apps/synthetics/branch/smoke/run-smoke.sh
+++ b/kubernetes/apps/synthetics/branch/smoke/run-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+summary_pattern='^SMOKE_RUN_SUMMARY '
+max_run_name_length=128
+start_seconds="$(date +%s)"
+
+set +u
+tmpdir=$TMPDIR
+playwright_command=$SMOKE_PLAYWRIGHT_COMMAND
+set -u
+
+if [ -z "$tmpdir" ]; then
+  tmpdir=/tmp
+fi
+
+if [ -z "$playwright_command" ]; then
+  playwright_command='npm run test'
+fi
+
+log_file="$(mktemp "$tmpdir/synthetic-smoke.XXXXXX.log")"
+
+cleanup() {
+  rm -f "$log_file"
+}
+trap cleanup EXIT
+
+logfmt_quote() {
+  node -e 'const value = String(process.argv[1] || "").replace(/[\r\n\t]+/g, " "); process.stdout.write(JSON.stringify(value));' "$1"
+}
+
+bounded_logfmt_quote() {
+  node -e 'const max = Number(process.argv[2] || "128"); const clean = String(process.argv[1] || "").replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim(); const value = clean.length <= max ? clean : (max <= 3 ? clean.slice(0, max) : clean.slice(0, max - 3) + "..."); process.stdout.write(JSON.stringify(value));' "$1" "$2"
+}
+
+smoke_run_name() {
+  local run_name
+
+  set +u
+  run_name="$SMOKE_RUN_NAME"
+
+  if [ -z "$run_name" ]; then
+    run_name="$HOSTNAME"
+  fi
+  set -u
+
+  if [ -z "$run_name" ]; then
+    run_name="unknown"
+  fi
+
+  printf '%s' "$run_name"
+}
+
+emit_fallback_summary() {
+  local command_status="$1"
+  local run_name
+  local status="success"
+  local failed_count="0"
+  local failed_tests=""
+  local end_seconds
+  local duration_seconds
+
+  end_seconds="$(date +%s)"
+  duration_seconds=$((end_seconds - start_seconds))
+  if (( duration_seconds < 0 )); then
+    duration_seconds=0
+  fi
+
+  if (( command_status != 0 )); then
+    status="failed"
+    failed_tests="playwright execution failed before reporter summary"
+  fi
+
+  run_name="$(smoke_run_name)"
+
+  printf 'SMOKE_RUN_SUMMARY run=%s status=%s failed_count=%s failed_tests=%s duration_seconds=%s\n' \
+    "$(bounded_logfmt_quote "$run_name" "$max_run_name_length")" \
+    "$status" \
+    "$failed_count" \
+    "$(logfmt_quote "$failed_tests")" \
+    "$duration_seconds"
+}
+
+set +e
+bash -c "$playwright_command" 2>&1 | tee "$log_file"
+playwright_status=$?
+set -e
+
+if ! grep -q "$summary_pattern" "$log_file"; then
+  emit_fallback_summary "$playwright_status"
+fi
+
+exit "$playwright_status"

--- a/kubernetes/apps/synthetics/branch/smoke/smoke-summary-reporter.js
+++ b/kubernetes/apps/synthetics/branch/smoke/smoke-summary-reporter.js
@@ -1,0 +1,87 @@
+const MAX_FAILED_TESTS_LENGTH = 512;
+const MAX_RUN_NAME_LENGTH = 128;
+
+function sanitizeLogfmtValue(value) {
+  return String(value)
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncate(value, maxLength = MAX_FAILED_TESTS_LENGTH) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  if (maxLength <= 3) {
+    return value.slice(0, maxLength);
+  }
+  return value.slice(0, maxLength - 3) + "...";
+}
+
+function quoteLogfmt(value) {
+  return '"' + sanitizeLogfmtValue(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}
+
+function smokeRunName(env = process.env) {
+  return env.SMOKE_RUN_NAME || env.HOSTNAME || "unknown";
+}
+
+function testTitle(test) {
+  if (typeof test.titlePath === "function") {
+    const parts = test.titlePath().filter(Boolean);
+    return parts[parts.length - 1] || test.title || "unknown test";
+  }
+  return test.title || "unknown test";
+}
+
+function finalFailedTests(suite) {
+  if (!suite || typeof suite.allTests !== "function") {
+    return [];
+  }
+  return suite
+    .allTests()
+    .filter((test) => typeof test.outcome === "function" && test.outcome() === "unexpected")
+    .map(testTitle);
+}
+
+function formatSummary({ status, failedTests, durationSeconds, runName = smokeRunName() }) {
+  const failedTestText = truncate(failedTests.map(sanitizeLogfmtValue).join("; "));
+  const runNameText = truncate(sanitizeLogfmtValue(runName), MAX_RUN_NAME_LENGTH);
+  return [
+    "SMOKE_RUN_SUMMARY",
+    "run=" + quoteLogfmt(runNameText),
+    "status=" + status,
+    "failed_count=" + failedTests.length,
+    "failed_tests=" + quoteLogfmt(failedTestText),
+    "duration_seconds=" + Math.max(0, Math.round(durationSeconds))
+  ].join(" ");
+}
+
+class SmokeSummaryReporter {
+  constructor(options = {}) {
+    this._now = options.now || (() => Date.now());
+    this._startMs = undefined;
+    this._suite = undefined;
+  }
+
+  onBegin(_config, suite) {
+    this._startMs = this._now();
+    this._suite = suite;
+  }
+
+  onEnd(result) {
+    const failedTests = finalFailedTests(this._suite);
+    const startMs = this._startMs ?? this._now();
+    const durationSeconds = (this._now() - startMs) / 1000;
+    const status = result.status === "passed" ? "success" : "failed";
+    console.log(formatSummary({ status, failedTests, durationSeconds }));
+  }
+}
+
+module.exports = SmokeSummaryReporter;
+module.exports.MAX_FAILED_TESTS_LENGTH = MAX_FAILED_TESTS_LENGTH;
+module.exports.MAX_RUN_NAME_LENGTH = MAX_RUN_NAME_LENGTH;
+module.exports.finalFailedTests = finalFailedTests;
+module.exports.formatSummary = formatSummary;
+module.exports.quoteLogfmt = quoteLogfmt;
+module.exports.smokeRunName = smokeRunName;

--- a/kubernetes/clusters/development/branches/README.md
+++ b/kubernetes/clusters/development/branches/README.md
@@ -2,7 +2,7 @@
 
 This directory is a template library, not part of the live development cluster entrypoint.
 
-The manifests here are cluster-layer activation templates: they create a branch-specific Flux `GitRepository` and `Kustomization` that point the development cluster at a Git branch. The app payload they activate lives under app directories such as `kubernetes/apps/whoami/branch/`, where resource names, namespaces, and hostnames are parameterized with `${branch_slug}`.
+The manifests here are cluster-layer activation templates: they create a branch-specific Flux `GitRepository` and `Kustomization` that point the development cluster at a Git branch. The app payload they activate lives under app directories such as `kubernetes/apps/whoami/branch/` and `kubernetes/apps/synthetics/branch/`, where resource names, namespaces, and hostnames are parameterized with `${branch_slug}`.
 
 To test an app branch, copy the relevant template into `kubernetes/clusters/development/apps/branches/` or another reviewed cluster-layer path, replace `branch_name` and `branch_slug`, set `spec.suspend: false`, and commit the activation. Branch app hostnames should follow `<app>-${branch_slug}.development.lab.petebeegle.com`.
 
@@ -14,6 +14,7 @@ Local verification without pushing is supported for manifest shape checks:
 export branch_slug=example
 export cluster_domain=development.lab.petebeegle.com
 kubectl kustomize kubernetes/apps/whoami/branch | flux envsubst --strict
+kubectl kustomize kubernetes/apps/synthetics/branch | flux envsubst --strict
 kubectl kustomize kubernetes/clusters/development
 
 cp kubernetes/clusters/development/branches/whoami-template.yaml /tmp/whoami-branch.yaml

--- a/kubernetes/clusters/development/branches/kustomization.yaml
+++ b/kubernetes/clusters/development/branches/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - whoami-template.yaml
+  - synthetics-template.yaml

--- a/kubernetes/clusters/development/branches/synthetics-template.yaml
+++ b/kubernetes/clusters/development/branches/synthetics-template.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: branch-synthetics-${branch_slug}
+  namespace: flux-system
+spec:
+  interval: 1m
+  suspend: true
+  ref:
+    branch: ${branch_name}
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/petebeegle/homelab
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: branch-synthetics-${branch_slug}
+  namespace: flux-system
+spec:
+  interval: 2m
+  retryInterval: 1m
+  path: ./kubernetes/apps/synthetics/branch
+  prune: true
+  wait: true
+  suspend: true
+  sourceRef:
+    kind: GitRepository
+    name: branch-synthetics-${branch_slug}
+  dependsOn:
+    - name: gateway
+  postBuild:
+    substitute:
+      branch_slug: ${branch_slug}
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -1,11 +1,22 @@
 # Development Tools
 
-`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. V1 supports `whoami` only. It verifies the branch namespace, active pod readiness, the whoami Service, and the HTTPRoute.
+`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. It loads JSON smoke profiles from `tools/development/smoke-profiles/`.
+
+Supported profiles:
+
+- `whoami`: verifies the branch namespace, active pod readiness, Service, and HTTPRoute.
+- `synthetics`: verifies the suspended branch CronJob, smoke source ConfigMap, development domain substitution, and a temporary Playwright JavaScript discovery Job.
 
 Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+Verify the synthetic smoke deployment path without running route probes:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app synthetics --branch codex/example-change --slug example-change --push
 ```
 
 Use `--include-cluster-base` to first reconcile the development base from `--branch` in the known order and restore the `flux-system` GitRepository to `main` before the tool exits:

--- a/tools/development/smoke-profiles/synthetics.json
+++ b/tools/development/smoke-profiles/synthetics.json
@@ -1,0 +1,39 @@
+{
+  "app": "synthetics",
+  "activation_template": "kubernetes/clusters/development/branches/synthetics-template.yaml",
+  "git_repository": "branch-synthetics-${branch_slug}",
+  "namespace": "synthetics-${branch_slug}",
+  "max_slug_length": 44,
+  "configmaps": [
+    {
+      "name": "synthetic-smoke-source",
+      "required_keys": [
+        "package.json",
+        "package-lock.json",
+        "playwright.config.js",
+        "run-smoke.sh",
+        "routes.spec.js",
+        "smoke-summary-reporter.js"
+      ]
+    }
+  ],
+  "cronjobs": [
+    {
+      "name": "synthetic-smoke-${branch_slug}",
+      "suspend": true,
+      "configmap_volumes": {
+        "smoke-source": "synthetic-smoke-source"
+      },
+      "env": {
+        "SMOKE_BASE_DOMAIN": "development.lab.petebeegle.com"
+      }
+    }
+  ],
+  "javascript_validity_jobs": [
+    {
+      "name": "synthetic-smoke-js-${branch_slug}",
+      "cronjob": "synthetic-smoke-${branch_slug}",
+      "command": "npm run test -- --list"
+    }
+  ]
+}

--- a/tools/development/smoke-profiles/whoami.json
+++ b/tools/development/smoke-profiles/whoami.json
@@ -1,0 +1,13 @@
+{
+  "app": "whoami",
+  "activation_template": "kubernetes/clusters/development/branches/whoami-template.yaml",
+  "namespace": "whoami-${branch_slug}",
+  "max_slug_length": 56,
+  "require_active_pods": true,
+  "services": [
+    "whoami-${branch_slug}"
+  ],
+  "httproutes": [
+    "whoami-${branch_slug}"
+  ]
+}

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -79,6 +79,73 @@ NO_ACTIVE_PODS = json.dumps(
     }
 )
 
+READY_CONFIGMAP = json.dumps(
+    {
+        "metadata": {"name": "synthetic-smoke-source", "namespace": "synthetics-example-change"},
+        "data": {
+            "package.json": "{}",
+            "package-lock.json": "{}",
+            "playwright.config.js": "module.exports = {};",
+            "run-smoke.sh": "echo ok",
+            "routes.spec.js": "test('ok', () => {});",
+            "smoke-summary-reporter.js": "module.exports = {};",
+        },
+    }
+)
+
+MISSING_CONFIGMAP_KEY = json.dumps(
+    {
+        "metadata": {"name": "synthetic-smoke-source", "namespace": "synthetics-example-change"},
+        "data": {
+            "package.json": "{}",
+        },
+    }
+)
+
+READY_CRONJOB = json.dumps(
+    {
+        "metadata": {"name": "synthetic-smoke-example-change", "namespace": "synthetics-example-change"},
+        "spec": {
+            "suspend": True,
+            "jobTemplate": {
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "restartPolicy": "Never",
+                            "containers": [
+                                {
+                                    "name": "playwright",
+                                    "env": [
+                                        {"name": "CI", "value": "true"},
+                                        {"name": "SMOKE_BASE_DOMAIN", "value": "development.lab.petebeegle.com"},
+                                    ],
+                                    "volumeMounts": [
+                                        {"name": "smoke-source", "mountPath": "/smoke-src", "readOnly": True}
+                                    ],
+                                }
+                            ],
+                            "volumes": [
+                                {"name": "smoke-source", "configMap": {"name": "synthetic-smoke-source"}},
+                                {"name": "workdir", "emptyDir": {}},
+                            ],
+                        }
+                    }
+                }
+            },
+        },
+    }
+)
+
+UNSUSPENDED_CRONJOB = json.dumps(
+    {
+        **json.loads(READY_CRONJOB),
+        "spec": {
+            **json.loads(READY_CRONJOB)["spec"],
+            "suspend": False,
+        },
+    }
+)
+
 
 TEMPLATE = """---
 apiVersion: source.toolkit.fluxcd.io/v1
@@ -102,6 +169,28 @@ spec:
     name: branch-${branch_slug}
 """
 
+SYNTHETICS_TEMPLATE = """---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: branch-synthetics-${branch_slug}
+  namespace: flux-system
+spec:
+  suspend: true
+  ref:
+    branch: ${branch_name}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: branch-synthetics-${branch_slug}
+  namespace: flux-system
+spec:
+  suspend: true
+  sourceRef:
+    name: branch-synthetics-${branch_slug}
+"""
+
 
 class FakeRunner:
     quiet = True
@@ -114,12 +203,16 @@ class FakeRunner:
         timeout_on: str | None = None,
         pods_json: str = READY_PODS,
         cluster_pods_json: str = READY_PODS,
+        configmap_json: str = READY_CONFIGMAP,
+        cronjob_json: str = READY_CRONJOB,
     ) -> None:
         self.plan_returncode = plan_returncode
         self.fail_on = fail_on
         self.timeout_on = timeout_on
         self.pods_json = pods_json
         self.cluster_pods_json = cluster_pods_json
+        self.configmap_json = configmap_json
+        self.cronjob_json = cronjob_json
         self.calls: list[tuple[list[str], dict[str, object]]] = []
 
     def __call__(self, args: list[str], **kwargs: object) -> SimpleNamespace:
@@ -135,6 +228,12 @@ class FakeRunner:
             return SimpleNamespace(returncode=0, stdout=self.cluster_pods_json)
         if args[-4:] == ["get", "pods", "-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=self.pods_json)
+        if "get" in args and "configmap" in args:
+            return SimpleNamespace(returncode=0, stdout=self.configmap_json)
+        if "get" in args and "cronjob" in args:
+            return SimpleNamespace(returncode=0, stdout=self.cronjob_json)
+        if "logs" in args:
+            return SimpleNamespace(returncode=0, stdout="javascript blew up")
         if args[-4:] == ["get", "httproute", "whoami-example-change", "-o"] or args[-2:] == ["-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=READY_HTTPROUTE)
         return SimpleNamespace(returncode=0, stdout="")
@@ -190,6 +289,45 @@ class VerifyBranchDeployTest(unittest.TestCase):
         with self.assertRaises(argparse.ArgumentTypeError):
             verify.parse_duration("soon")
 
+    def test_synthetics_profile_loads_and_is_supported(self) -> None:
+        profile = verify.load_profile("synthetics")
+
+        self.assertIn("synthetics", verify.supported_apps())
+        self.assertEqual(profile.namespace, "synthetics-${branch_slug}")
+        self.assertEqual(profile.max_slug_length, 44)
+        self.assertEqual(profile.javascript_validity_jobs[0]["command"], "npm run test -- --list")
+
+    def test_synthetics_profile_rejects_slug_too_long_for_job_names(self) -> None:
+        config = verify.AppConfig(
+            app="synthetics",
+            branch="codex/example-change",
+            slug="a" * 45,
+            kubeconfig=Path("/tmp/kubeconfig"),
+            timeout=verify.parse_duration("2m"),
+            push=False,
+            terraform_apply=False,
+            include_cluster_base=False,
+            keep=False,
+        )
+
+        with self.assertRaisesRegex(verify.VerificationError, "too long"):
+            verify.assert_profile(config, verify.load_profile("synthetics"), runner=FakeRunner())
+
+    def test_synthetics_branch_smoke_sources_mirror_production_sources(self) -> None:
+        for name in (
+            "package.json",
+            "package-lock.json",
+            "playwright.config.js",
+            "run-smoke.sh",
+            "routes.spec.js",
+            "smoke-summary-reporter.js",
+        ):
+            with self.subTest(name=name):
+                production = REPO_ROOT / "kubernetes/apps/synthetics/smoke" / name
+                branch = REPO_ROOT / "kubernetes/apps/synthetics/branch/smoke" / name
+
+                self.assertEqual(branch.read_text(encoding="utf-8"), production.read_text(encoding="utf-8"))
+
     def test_run_command_wraps_subprocess_timeout(self) -> None:
         config = self._config()
         runner = FakeRunner(timeout_on="rollout")
@@ -225,6 +363,18 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertTrue(any("delete kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change" in command for command in commands))
         self.assertTrue(any("wait namespace/whoami-example-change --for=delete" in command for command in commands))
         self.assertTrue(any("delete gitrepository.source.toolkit.fluxcd.io/branch-example-change" in command for command in commands))
+
+    def test_synthetics_acceptance_uses_profile_git_repository_and_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "terraform" / "development").mkdir(parents=True)
+            runner = FakeRunner()
+
+            verify.run_acceptance(self._config(app="synthetics"), runner=runner, repo_root=root, template_text=SYNTHETICS_TEMPLATE)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("reconcile source git branch-synthetics-example-change" in command for command in commands))
+        self.assertTrue(any("delete gitrepository.source.toolkit.fluxcd.io/branch-synthetics-example-change" in command for command in commands))
 
     def test_apply_uses_rendered_activation_stdin(self) -> None:
         runner = FakeRunner()
@@ -298,6 +448,50 @@ class VerifyBranchDeployTest(unittest.TestCase):
         commands = [" ".join(command) for command in runner.commands]
         self.assertTrue(any("get service whoami-example-change" in command for command in commands))
         self.assertTrue(any("get httproute whoami-example-change -o json" in command for command in commands))
+
+    def test_synthetics_assert_checks_configmap_cronjob_and_javascript_job(self) -> None:
+        runner = FakeRunner()
+        config = self._config(app="synthetics")
+
+        verify.assert_profile(config, verify.load_profile("synthetics"), runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("get namespace synthetics-example-change" in command for command in commands))
+        self.assertTrue(any("get configmap synthetic-smoke-source -o json" in command for command in commands))
+        self.assertTrue(any("get cronjob synthetic-smoke-example-change -o json" in command for command in commands))
+        self.assertTrue(any("wait job/synthetic-smoke-js-example-change --for=condition=Complete" in command for command in commands))
+        self.assertTrue(any("delete job/synthetic-smoke-js-example-change" in command for command in commands))
+
+        applied_jobs = [
+            json.loads(str(kwargs["input"]))
+            for command, kwargs in runner.calls
+            if command[-3:] == ["apply", "-f", "-"] and "input" in kwargs
+        ]
+        self.assertEqual(applied_jobs[0]["kind"], "Job")
+        env = applied_jobs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
+        self.assertIn({"name": "SMOKE_PLAYWRIGHT_COMMAND", "value": "npm run test -- --list"}, env)
+
+    def test_synthetics_configmap_assert_requires_all_source_keys(self) -> None:
+        runner = FakeRunner(configmap_json=MISSING_CONFIGMAP_KEY)
+
+        with self.assertRaisesRegex(verify.VerificationError, "missing required key"):
+            verify.assert_profile(self._config(app="synthetics"), verify.load_profile("synthetics"), runner=runner)
+
+    def test_synthetics_cronjob_must_be_suspended(self) -> None:
+        runner = FakeRunner(cronjob_json=UNSUSPENDED_CRONJOB)
+
+        with self.assertRaisesRegex(verify.VerificationError, "suspend"):
+            verify.assert_profile(self._config(app="synthetics"), verify.load_profile("synthetics"), runner=runner)
+
+    def test_javascript_validity_job_cleanup_runs_after_failure(self) -> None:
+        runner = FakeRunner(fail_on="wait job/synthetic-smoke-js-example-change")
+
+        with self.assertRaisesRegex(verify.VerificationError, "javascript blew up"):
+            verify.assert_profile(self._config(app="synthetics"), verify.load_profile("synthetics"), runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("logs job/synthetic-smoke-js-example-change" in command for command in commands))
+        self.assertTrue(any("delete job/synthetic-smoke-js-example-change" in command for command in commands))
 
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
         runner = FakeRunner(cluster_pods_json=READY_PODS)
@@ -392,13 +586,14 @@ class VerifyBranchDeployTest(unittest.TestCase):
     def _config(
         self,
         *,
+        app: str = "whoami",
         push: bool = False,
         terraform_apply: bool = False,
         include_cluster_base: bool = False,
         keep: bool = False,
     ) -> verify.AppConfig:
         return verify.AppConfig(
-            app="whoami",
+            app=app,
             branch="codex/example-change",
             slug="example-change",
             kubeconfig=Path("/tmp/kubeconfig"),

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -12,14 +12,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILE_DIR = REPO_ROOT / "tools" / "development" / "smoke-profiles"
 DEFAULT_KUBECONFIG = Path("~/.kube/homelab-development.config").expanduser()
 DEFAULT_TIMEOUT = "10m"
 FLUX_NAMESPACE = "flux-system"
-SUPPORTED_APPS = {"whoami"}
 DEVELOPMENT_BASE_KUSTOMIZATIONS = (
     "crds",
     "cert-manager",
@@ -66,6 +66,21 @@ class AppConfig:
         return f"{self.app}-{self.slug}"
 
 
+@dataclass(frozen=True)
+class SmokeProfile:
+    app: str
+    activation_template: str
+    git_repository: str
+    namespace: str
+    require_active_pods: bool
+    services: tuple[str, ...]
+    httproutes: tuple[str, ...]
+    configmaps: tuple[dict[str, Any], ...]
+    cronjobs: tuple[dict[str, Any], ...]
+    javascript_validity_jobs: tuple[dict[str, Any], ...]
+    max_slug_length: int | None
+
+
 class VerificationError(RuntimeError):
     """Raised when validation or a live verification step fails."""
 
@@ -96,9 +111,14 @@ def parse_duration(value: str) -> Duration:
     return Duration(raw=value, seconds=seconds)
 
 
+def supported_apps(profile_dir: Path = PROFILE_DIR) -> set[str]:
+    return {path.stem for path in profile_dir.glob("*.json")}
+
+
 def validate_app(app: str) -> str:
-    if app not in SUPPORTED_APPS:
-        raise argparse.ArgumentTypeError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(SUPPORTED_APPS))}")
+    apps = supported_apps()
+    if app not in apps:
+        raise argparse.ArgumentTypeError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(apps))}")
     return app
 
 
@@ -125,6 +145,72 @@ def validate_slug(slug: str) -> str:
     return slug
 
 
+def load_profile(app: str, *, repo_root: Path = REPO_ROOT) -> SmokeProfile:
+    path = repo_root / "tools" / "development" / "smoke-profiles" / f"{app}.json"
+    if not path.exists() and repo_root != REPO_ROOT:
+        path = REPO_ROOT / "tools" / "development" / "smoke-profiles" / f"{app}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise VerificationError(f"smoke profile {app!r} not found at {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"smoke profile {app!r} is not valid JSON: {exc}") from exc
+
+    if data.get("app") != app:
+        raise VerificationError(f"smoke profile {path} app does not match {app!r}")
+    return SmokeProfile(
+        app=app,
+        activation_template=require_string(data, "activation_template", path),
+        git_repository=str(data.get("git_repository", "branch-${branch_slug}")),
+        namespace=require_string(data, "namespace", path),
+        require_active_pods=bool(data.get("require_active_pods", False)),
+        services=tuple(require_string_list(data.get("services", []), f"{path}: services")),
+        httproutes=tuple(require_string_list(data.get("httproutes", []), f"{path}: httproutes")),
+        configmaps=tuple(require_dict_list(data.get("configmaps", []), f"{path}: configmaps")),
+        cronjobs=tuple(require_dict_list(data.get("cronjobs", []), f"{path}: cronjobs")),
+        javascript_validity_jobs=tuple(
+            require_dict_list(data.get("javascript_validity_jobs", []), f"{path}: javascript_validity_jobs")
+        ),
+        max_slug_length=optional_positive_int(data.get("max_slug_length"), f"{path}: max_slug_length"),
+    )
+
+
+def require_string(data: dict[str, Any], key: str, path: Path) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise VerificationError(f"smoke profile {path} requires non-empty string key {key!r}")
+    return value
+
+
+def require_string_list(value: Any, context: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise VerificationError(f"{context} must be a list of non-empty strings")
+    return value
+
+
+def require_dict_list(value: Any, context: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise VerificationError(f"{context} must be a list of objects")
+    return value
+
+
+def optional_positive_int(value: Any, context: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, int) or value <= 0:
+        raise VerificationError(f"{context} must be a positive integer")
+    return value
+
+
+def render_value(value: str, config: AppConfig) -> str:
+    return (
+        value.replace("${branch_name}", config.branch)
+        .replace("${branch_slug}", config.slug)
+        .replace("${app}", config.app)
+        .replace("${namespace}", config.namespace)
+    )
+
+
 def render_activation_template(template_text: str, *, branch: str, slug: str) -> str:
     validate_branch(branch)
     validate_slug(slug)
@@ -140,9 +226,9 @@ def render_activation_template(template_text: str, *, branch: str, slug: str) ->
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Verify a whoami branch environment on the homelab development cluster."
+        description="Verify an app branch environment on the homelab development cluster."
     )
-    parser.add_argument("--app", required=True, type=validate_app, choices=sorted(SUPPORTED_APPS))
+    parser.add_argument("--app", required=True, type=validate_app, choices=sorted(supported_apps()))
     parser.add_argument("--branch", required=True, type=validate_branch)
     parser.add_argument("--slug", required=True, type=validate_slug)
     parser.add_argument("--push", action="store_true", help="Push current HEAD to origin as --branch before activation.")
@@ -167,8 +253,11 @@ def run_acceptance(
 ) -> None:
     activated = False
     failure: BaseException | None = None
+    profile: SmokeProfile | None = None
 
     try:
+        profile = load_profile(config.app, repo_root=repo_root)
+        validate_profile_slug(profile, config)
         if config.push:
             push_branch(config, runner=runner, repo_root=repo_root)
 
@@ -180,21 +269,21 @@ def run_acceptance(
         rendered = render_activation_template(
             template_text
             if template_text is not None
-            else (repo_root / "kubernetes/clusters/development/branches/whoami-template.yaml").read_text(encoding="utf-8"),
+            else (repo_root / profile.activation_template).read_text(encoding="utf-8"),
             branch=config.branch,
             slug=config.slug,
         )
         apply_activation(config, rendered, runner=runner)
         activated = True
 
-        reconcile_flux(config, runner=runner)
-        assert_whoami(config, runner=runner)
+        reconcile_flux(config, profile=profile, runner=runner)
+        assert_profile(config, profile, runner=runner)
     except BaseException as exc:
         failure = exc
     finally:
         if activated and not config.keep:
             try:
-                cleanup_branch_environment(config, runner=runner)
+                cleanup_branch_environment(config, profile=profile, runner=runner)
             except BaseException as cleanup_exc:
                 if failure is None:
                     failure = cleanup_exc
@@ -254,9 +343,10 @@ def apply_activation(config: AppConfig, rendered: str, *, runner: Runner) -> Non
     )
 
 
-def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
+def reconcile_flux(config: AppConfig, *, profile: SmokeProfile | None = None, runner: Runner) -> None:
+    git_repository = profile_git_repository(config, profile)
     run_command(
-        flux(config, "reconcile", "source", "git", config.git_repository, "--namespace", FLUX_NAMESPACE, "--timeout", config.timeout.raw),
+        flux(config, "reconcile", "source", "git", git_repository, "--namespace", FLUX_NAMESPACE, "--timeout", config.timeout.raw),
         runner=runner,
         timeout=config.timeout,
     )
@@ -266,7 +356,7 @@ def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
             "-n",
             FLUX_NAMESPACE,
             "wait",
-            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            f"gitrepository.source.toolkit.fluxcd.io/{git_repository}",
             "--for=condition=Ready",
             f"--timeout={config.timeout.raw}",
         ),
@@ -423,24 +513,225 @@ def reconcile_flux_kustomization(config: AppConfig, name: str, *, runner: Runner
     )
 
 
+def assert_profile(config: AppConfig, profile: SmokeProfile, *, runner: Runner) -> None:
+    validate_profile_slug(profile, config)
+    namespace = render_value(profile.namespace, config)
+    run_command(kubectl(config, "get", "namespace", namespace), runner=runner, timeout=config.timeout)
+    if profile.require_active_pods:
+        wait_for_active_pods_ready(
+            config,
+            runner=runner,
+            namespace=namespace,
+            require_non_terminated=True,
+            context=f"namespace {namespace}",
+        )
+    for service in profile.services:
+        run_command(kubectl(config, "-n", namespace, "get", "service", render_value(service, config)), runner=runner, timeout=config.timeout)
+    for route in profile.httproutes:
+        route_name = render_value(route, config)
+        route_result = run_command(
+            kubectl(config, "-n", namespace, "get", "httproute", route_name, "-o", "json"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+        )
+        assert_httproute_ready(str(getattr(route_result, "stdout", "")), route_name=route_name)
+    for configmap in profile.configmaps:
+        assert_configmap(config, namespace, configmap, runner=runner)
+    for cronjob in profile.cronjobs:
+        assert_cronjob(config, namespace, cronjob, runner=runner)
+    for job in profile.javascript_validity_jobs:
+        run_javascript_validity_job(config, namespace, job, runner=runner)
+
+
 def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
-    name = config.namespace
-    run_command(kubectl(config, "get", "namespace", name), runner=runner, timeout=config.timeout)
-    wait_for_active_pods_ready(
-        config,
-        runner=runner,
-        namespace=name,
-        require_non_terminated=True,
-        context=f"namespace {name}",
+    assert_profile(config, whoami_profile(), runner=runner)
+
+
+def whoami_profile() -> SmokeProfile:
+    return SmokeProfile(
+        app="whoami",
+        activation_template="kubernetes/clusters/development/branches/whoami-template.yaml",
+        git_repository="branch-${branch_slug}",
+        namespace="whoami-${branch_slug}",
+        require_active_pods=True,
+        services=("whoami-${branch_slug}",),
+        httproutes=("whoami-${branch_slug}",),
+        configmaps=(),
+        cronjobs=(),
+        javascript_validity_jobs=(),
+        max_slug_length=56,
     )
-    run_command(kubectl(config, "-n", name, "get", "service", name), runner=runner, timeout=config.timeout)
-    route = run_command(
-        kubectl(config, "-n", name, "get", "httproute", name, "-o", "json"),
+
+
+def validate_profile_slug(profile: SmokeProfile, config: AppConfig) -> None:
+    if profile.max_slug_length is not None and len(config.slug) > profile.max_slug_length:
+        raise VerificationError(
+            f"slug {config.slug!r} is too long for {profile.app}; maximum length is {profile.max_slug_length}"
+        )
+
+
+def assert_configmap(config: AppConfig, namespace: str, check: dict[str, Any], *, runner: Runner) -> None:
+    name = render_value(require_check_string(check, "name", "ConfigMap check"), config)
+    result = get_json_resource(config, namespace, "configmap", name, runner=runner)
+    data = result.get("data")
+    if not isinstance(data, dict):
+        raise VerificationError(f"ConfigMap {namespace}/{name} has no data")
+    for key in require_string_list(check.get("required_keys", []), f"ConfigMap {namespace}/{name} required_keys"):
+        if key not in data:
+            raise VerificationError(f"ConfigMap {namespace}/{name} missing required key {key!r}")
+
+
+def assert_cronjob(config: AppConfig, namespace: str, check: dict[str, Any], *, runner: Runner) -> None:
+    name = render_value(require_check_string(check, "name", "CronJob check"), config)
+    cronjob = get_json_resource(config, namespace, "cronjob", name, runner=runner)
+    if check.get("suspend") is not None and cronjob.get("spec", {}).get("suspend") is not bool(check["suspend"]):
+        raise VerificationError(f"CronJob {namespace}/{name} suspend did not equal {bool(check['suspend'])}")
+
+    pod_spec = cronjob.get("spec", {}).get("jobTemplate", {}).get("spec", {}).get("template", {}).get("spec", {})
+    if not isinstance(pod_spec, dict):
+        raise VerificationError(f"CronJob {namespace}/{name} has no pod template spec")
+    containers = pod_spec.get("containers")
+    if not isinstance(containers, list) or not containers:
+        raise VerificationError(f"CronJob {namespace}/{name} has no containers")
+    container = containers[0]
+    if not isinstance(container, dict):
+        raise VerificationError(f"CronJob {namespace}/{name} first container is not an object")
+
+    for volume_name, configmap_name in check.get("configmap_volumes", {}).items():
+        assert_configmap_volume(pod_spec, volume_name, render_value(str(configmap_name), config), cronjob_name=f"{namespace}/{name}")
+    for env_name, env_value in check.get("env", {}).items():
+        assert_container_env(container, str(env_name), render_value(str(env_value), config), cronjob_name=f"{namespace}/{name}")
+
+
+def assert_configmap_volume(pod_spec: dict[str, Any], volume_name: str, configmap_name: str, *, cronjob_name: str) -> None:
+    volumes = pod_spec.get("volumes")
+    if not isinstance(volumes, list):
+        raise VerificationError(f"CronJob {cronjob_name} has no volumes")
+    for volume in volumes:
+        if isinstance(volume, dict) and volume.get("name") == volume_name:
+            actual = volume.get("configMap", {}).get("name")
+            if actual == configmap_name:
+                return
+            raise VerificationError(f"CronJob {cronjob_name} volume {volume_name!r} references {actual!r}, not {configmap_name!r}")
+    raise VerificationError(f"CronJob {cronjob_name} missing volume {volume_name!r}")
+
+
+def assert_container_env(container: dict[str, Any], name: str, value: str, *, cronjob_name: str) -> None:
+    env = container.get("env")
+    if not isinstance(env, list):
+        raise VerificationError(f"CronJob {cronjob_name} container has no env list")
+    for item in env:
+        if isinstance(item, dict) and item.get("name") == name:
+            if item.get("value") == value:
+                return
+            raise VerificationError(f"CronJob {cronjob_name} env {name!r} is {item.get('value')!r}, not {value!r}")
+    raise VerificationError(f"CronJob {cronjob_name} missing env {name!r}")
+
+
+def run_javascript_validity_job(config: AppConfig, namespace: str, check: dict[str, Any], *, runner: Runner) -> None:
+    cronjob_name = render_value(require_check_string(check, "cronjob", "JavaScript validity job"), config)
+    job_name = render_value(require_check_string(check, "name", "JavaScript validity job"), config)
+    command = require_check_string(check, "command", "JavaScript validity job")
+    cronjob = get_json_resource(config, namespace, "cronjob", cronjob_name, runner=runner)
+    job = job_from_cronjob(cronjob, namespace=namespace, job_name=job_name, command=command)
+    failure: BaseException | None = None
+
+    try:
+        run_command(
+            kubectl(config, "apply", "-f", "-"),
+            runner=runner,
+            timeout=config.timeout,
+            input_text=json.dumps(job),
+        )
+        run_command(
+            kubectl(config, "-n", namespace, "wait", f"job/{job_name}", "--for=condition=Complete", f"--timeout={config.timeout.raw}"),
+            runner=runner,
+            timeout=config.timeout,
+        )
+    except BaseException as exc:
+        failure = exc
+        logs = run_command(
+            kubectl(config, "-n", namespace, "logs", f"job/{job_name}", "--all-containers=true", "--tail=200"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+            success_codes=(0, 1),
+        )
+        output = str(getattr(logs, "stdout", "")).strip()
+        raise VerificationError(f"JavaScript validity Job {namespace}/{job_name} failed: {output or failure}") from exc
+    finally:
+        try:
+            run_command(
+                kubectl(
+                    config,
+                    "-n",
+                    namespace,
+                    "delete",
+                    f"job/{job_name}",
+                    "--ignore-not-found=true",
+                    "--wait=true",
+                    f"--timeout={config.timeout.raw}",
+                ),
+                runner=runner,
+                timeout=config.timeout,
+            )
+        except BaseException as cleanup_exc:
+            if failure is None:
+                raise cleanup_exc
+            print(f"JavaScript validity Job cleanup failed after primary error: {cleanup_exc}", file=sys.stderr)
+
+
+def job_from_cronjob(cronjob: dict[str, Any], *, namespace: str, job_name: str, command: str) -> dict[str, Any]:
+    job_spec = cronjob.get("spec", {}).get("jobTemplate", {}).get("spec")
+    if not isinstance(job_spec, dict):
+        raise VerificationError("CronJob has no job template spec")
+    spec = json.loads(json.dumps(job_spec))
+    pod_spec = spec.get("template", {}).get("spec", {})
+    containers = pod_spec.get("containers")
+    if not isinstance(containers, list) or not containers or not isinstance(containers[0], dict):
+        raise VerificationError("CronJob job template has no first container")
+    env = containers[0].setdefault("env", [])
+    if not isinstance(env, list):
+        raise VerificationError("CronJob first container env is not a list")
+    env[:] = [item for item in env if not (isinstance(item, dict) and item.get("name") == "SMOKE_PLAYWRIGHT_COMMAND")]
+    env.append({"name": "SMOKE_PLAYWRIGHT_COMMAND", "value": command})
+    return {
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": {
+            "name": job_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "synthetic-smoke",
+                "app.kubernetes.io/component": "javascript-validity",
+            },
+        },
+        "spec": spec,
+    }
+
+
+def require_check_string(check: dict[str, Any], key: str, context: str) -> str:
+    value = check.get(key)
+    if not isinstance(value, str) or not value:
+        raise VerificationError(f"{context} requires non-empty string key {key!r}")
+    return value
+
+
+def get_json_resource(config: AppConfig, namespace: str, kind: str, name: str, *, runner: Runner) -> dict[str, Any]:
+    result = run_command(
+        kubectl(config, "-n", namespace, "get", kind, name, "-o", "json"),
         runner=runner,
         timeout=config.timeout,
         capture_output=True,
     )
-    assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=name)
+    try:
+        resource = json.loads(str(getattr(result, "stdout", "")))
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"{kind} {namespace}/{name} did not return valid JSON: {exc}") from exc
+    if not isinstance(resource, dict):
+        raise VerificationError(f"{kind} {namespace}/{name} did not return a JSON object")
+    return resource
 
 
 def wait_for_active_pods_ready(
@@ -485,7 +776,7 @@ def wait_for_active_pods_ready(
         )
 
 
-def parse_pods(pods_json: str, *, context: str) -> list[dict[str, object]]:
+def parse_pods(pods_json: str, *, context: str) -> list[dict[str, Any]]:
     try:
         pod_list = json.loads(pods_json)
     except json.JSONDecodeError as exc:
@@ -497,12 +788,12 @@ def parse_pods(pods_json: str, *, context: str) -> list[dict[str, object]]:
     return [pod for pod in items if isinstance(pod, dict)]
 
 
-def is_pod_deleting(pod: dict[str, object]) -> bool:
+def is_pod_deleting(pod: dict[str, Any]) -> bool:
     metadata = pod.get("metadata", {})
     return isinstance(metadata, dict) and bool(metadata.get("deletionTimestamp"))
 
 
-def pod_phase(pod: dict[str, object]) -> str:
+def pod_phase(pod: dict[str, Any]) -> str:
     status = pod.get("status", {})
     if not isinstance(status, dict):
         return ""
@@ -510,7 +801,7 @@ def pod_phase(pod: dict[str, object]) -> str:
     return str(phase) if phase is not None else ""
 
 
-def pod_name(pod: dict[str, object]) -> str:
+def pod_name(pod: dict[str, Any]) -> str:
     metadata = pod.get("metadata", {})
     if not isinstance(metadata, dict):
         raise VerificationError("pod did not include metadata")
@@ -520,7 +811,7 @@ def pod_name(pod: dict[str, object]) -> str:
     return str(name)
 
 
-def pod_namespace_name(pod: dict[str, object], *, default: str | None) -> str | None:
+def pod_namespace_name(pod: dict[str, Any], *, default: str | None) -> str | None:
     metadata = pod.get("metadata", {})
     if not isinstance(metadata, dict):
         return default
@@ -545,7 +836,13 @@ def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
     raise VerificationError(f"HTTPRoute {route_name} has no parent with Accepted and ResolvedRefs conditions")
 
 
-def cleanup_branch_environment(config: AppConfig, *, runner: Runner) -> None:
+def profile_git_repository(config: AppConfig, profile: SmokeProfile | None) -> str:
+    if profile is None:
+        return config.git_repository
+    return render_value(profile.git_repository, config)
+
+
+def cleanup_branch_environment(config: AppConfig, *, profile: SmokeProfile | None = None, runner: Runner) -> None:
     run_command(
         kubectl(
             config,
@@ -571,7 +868,7 @@ def cleanup_branch_environment(config: AppConfig, *, runner: Runner) -> None:
             "-n",
             FLUX_NAMESPACE,
             "delete",
-            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            f"gitrepository.source.toolkit.fluxcd.io/{profile_git_repository(config, profile)}",
             "--ignore-not-found=true",
             "--wait=true",
             f"--timeout={config.timeout.raw}",


### PR DESCRIPTION
# synthetics-development-smoke-profile

Branch: `codex/synthetics-development-smoke-profile`
Implementation HEAD: `493511671afa51a01006f07647d837997249cd50`

## Summary

- Added JSON-backed development smoke profiles for `whoami` and `synthetics`.
- Added a branch-scoped `synthetics` overlay that deploys the synthetic smoke CronJob suspended.
- Added a synthetics verifier path that checks namespace, ConfigMap source keys, CronJob suspension, development `SMOKE_BASE_DOMAIN`, and a temporary Playwright discovery Job using `npm run test -- --list`.

## Documentation impact

- Updated `tools/development/README.md`, `docs/runbooks/development-cluster.md`, `docs/runbooks/synthetic-smoke-tests.md`, and `kubernetes/clusters/development/branches/README.md`.
- Regenerated `docs/architecture.md`.

## Workflow fallback

- Runtime policy allows subagents only when the user explicitly requests delegation/parallel agent work. The user explicitly requested implementation of this plan, so main-agent self-implementation fallback was used instead of implementation/verifier subagents.
- The user then explicitly requested verification before PR creation, so main-agent self-verification fallback was used for exact HEAD `493511671afa51a01006f07647d837997249cd50`.

## Test and validation evidence

- `python3 -m unittest tools.development.tests.test_verify_branch_deploy`: passed, 26 tests.
- `npm run test:unit` in `kubernetes/apps/synthetics/smoke`: passed, 5 tests.
- `npm ci --no-audit --no-fund && npm run test:unit && npm run test -- --list` in `kubernetes/apps/synthetics/smoke`: passed; Playwright discovered 6 route tests.
- `kubectl kustomize kubernetes/apps/synthetics/branch | flux envsubst --strict`: passed with `branch_slug=synthetics-development-smoke-profile` and `cluster_domain=development.lab.petebeegle.com`.
- `kubectl kustomize kubernetes/clusters/development`: passed.
- `kubectl kustomize kubernetes/clusters/development/branches | flux envsubst --strict`: passed with `branch_name=codex/synthetics-development-smoke-profile`.
- `kubectl kustomize kubernetes/apps/synthetics`: passed.
- `python3 tools/architecture/render.py --check`: passed.
- `git diff --check`: passed.
- Development API server dry-run for rendered `synthetics-template.yaml`: passed.
- Development API server dry-run for `/tmp/synthetics-branch.yaml`: passed after creating temporary namespace `synthetics-synthetics-development-smoke-profile`; cleanup deleted the namespace successfully.
- `python3 tools/development/verify_branch_deploy.py --app synthetics --branch codex/synthetics-development-smoke-profile --slug synthetics-development-smoke-profile --push --timeout 10m`: passed against development for exact HEAD `493511671afa51a01006f07647d837997249cd50`; Flux fetched the branch, applied the branch Kustomization, verified ConfigMap and CronJob checks, completed and deleted the JavaScript discovery Job, deleted the branch Kustomization, waited for namespace cleanup, and deleted the branch GitRepository.
- Targeted review of verifier cleanup/failure paths, generated Job shape, branch template naming, branch CronJob suspension, and profile checks: no blocking issues found.

## Notes

- The first attempt to run the live verifier failed before cluster changes because the sibling clone did not have ignored development `terraform.tfvars`; the ignored local config was copied from the main checkout without logging contents and the verifier was rerun successfully.
- A CI workflow edit was removed before push because the available GitHub token lacks `workflow` scope; local verifier and Playwright discovery checks were still run and recorded above.
