### PR TITLE
Codex/jellyfin fresh external smoke

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,7 +20,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`.
 - App activation list: `whoami.yaml`, `foundry-bluegreen-fixture.yaml`.
 
-- Branch environment templates: `whoami-template.yaml`.
+- Branch environment templates: `whoami-template.yaml`, `jellyfin-template.yaml`.
 
 ### Flux Substitution Variables
 
@@ -127,7 +127,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
 | `kubernetes/apps/foundry-bluegreen-fixture` | `namespace.yaml`, `pvc-blue.yaml`, `pvc-green.yaml`, `deployment-blue.yaml`, `deployment-green.yaml`, `service-blue.yaml`, `service-green.yaml`, `httproute-green-preview.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml`, `httproute-public.yaml` |
-| `kubernetes/apps/jellyfin` | `./app.yaml`, `./httproute.yaml` |
+| `kubernetes/apps/jellyfin/branch` | `jellyfin.yaml` |
+| `kubernetes/apps/jellyfin` | `./app.yaml`, `./pvc.yaml`, `./httproute.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
 | `kubernetes/apps/renovate` | `app.yaml`, `secret.yaml` |
 | `kubernetes/apps/synthetics` | `namespace.yaml`, `cronjob.yaml` |
@@ -146,7 +147,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `grafana:80` |
-| `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin:8096` |
+| `HTTPRoute` | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `jellyfin-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin-${branch_slug}:8096` |
+| `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `jellyfin:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |
 | `HTTPRoute` | `pihole/pihole-httproute` | `pihole.${cluster_domain}` | `gateway/internal/https-gateway` | `pihole-web:80` |
 | `HTTPRoute` | `whoami-${branch_slug}/whoami-${branch_slug}` | `whoami-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `whoami-${branch_slug}:80` |
@@ -162,10 +164,13 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Source | Owner | StorageClass | Path |
 | --- | --- | --- | --- |
+| HelmRelease values | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/branch/jellyfin.yaml` |
 | HelmRelease values | `valheim/valheim-server` | `nfs-csi-storage` | `kubernetes/apps/valheim/app.yaml` |
 | PVC | `foundry-bluegreen-fixture/foundry-fixture-blue` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-blue.yaml` |
 | PVC | `foundry-bluegreen-fixture/foundry-fixture-green` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-green.yaml` |
 | PVC | `foundryvtt/foundryvtt-data-pvc` | `nfs-csi-storage` | `kubernetes/apps/foundryvtt/pvc.yaml` |
+| PVC | `jellyfin-${branch_slug}/jellyfin-config-${branch_slug}` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/branch/jellyfin.yaml` |
+| PVC | `jellyfin/jellyfin-config-v2` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/pvc.yaml` |
 | PVC | `wireguard/wireguard-pvc` | `nfs-csi-storage` | `kubernetes/infra/network/vpn/pvc.yaml` |
 | Values file | `authentik` | `nfs-csi-storage` | `kubernetes/infra/authentik/values.yaml` |
 | Values file | `jellyfin` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/values.yaml` |

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -128,17 +128,17 @@ Branch environments are for app-scoped validation on the development cluster. Us
 <app>-${branch_slug}.development.lab.petebeegle.com
 ```
 
-Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. V1 supports `whoami` only. The tool renders the activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, checks the whoami Service and HTTPRoute, and then removes the temporary branch Flux resources unless `--keep` is set.
+Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. The tool loads JSON smoke profiles from `tools/development/smoke-profiles/`, renders the matching activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, runs profile resource checks, and then removes the temporary branch Flux resources unless `--keep` is set. Automated profiles currently cover `whoami` and `jellyfin`.
 
-The current deployment verifier is intentionally limited to the `whoami` smoke path while the app profile model is expanded. Treat non-`whoami` app smoke as manual or helper-run evidence for now: use the matrix below, record the exact commands and observations, and document any missing profile instead of adding ad hoc harness behavior.
+The `whoami` profile checks the branch namespace, active pods, Service, and HTTPRoute. The `jellyfin` profile checks the branch namespace, branch Flux Kustomization readiness, HelmRelease readiness, active pods, config PVC binding on `nfs-csi-storage`, Service, HTTPRoute, and an in-cluster HTTP probe for the Jellyfin web shell.
 
-The initial activation template is in `kubernetes/clusters/development/branches/`, and the first branch-aware app payload overlay is `kubernetes/apps/whoami/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The template is not referenced from the live development entrypoint and is suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
+Activation templates are in `kubernetes/clusters/development/branches/`, and branch-aware app payload overlays live under paths such as `kubernetes/apps/whoami/branch/` and `kubernetes/apps/jellyfin/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The templates are not referenced from the live development entrypoint and are suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
 
 ### Dev-First Requirement
 
 Run covered cluster-affecting changes through the development cluster before production-oriented PR completion. Covered changes include Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, branch overlays, and app behavior. Docs-only and purely local tooling changes do not require live development validation unless they alter cluster behavior.
 
-Use the `whoami` branch verifier when the supported profile fits the change. Use manual development smoke evidence for apps without automated profiles. Add `--include-cluster-base` for shared cluster base changes before app acceptance. Production remains GitOps-first; development live validation is evidence, not a substitute for durable repository changes.
+Use the matching branch verifier profile when it fits the change, such as `--app whoami` or `--app jellyfin`. Use manual development smoke evidence for apps without automated profiles. Add `--include-cluster-base` for shared cluster base changes before app acceptance. Production remains GitOps-first; development live validation is evidence, not a substitute for durable repository changes.
 
 If the development cluster, kubeconfig, staged development secrets, or required credentials are unavailable, record `smoke_profile: none` with the blocker, substitute checks, and any follow-up needed. Do not treat an actual development validation failure as an exception; fix the change and rerun validation before production-oriented completion.
 
@@ -150,12 +150,18 @@ Prerequisites:
 - `terraform`, `kubectl`, and `flux` are installed locally.
 - The default kubeconfig exists at `~/.kube/homelab-development.config`, or pass `--kubeconfig <path>`.
 - The branch named by `--branch` is available on origin. Use `--push` to push the current HEAD to origin as that branch before activation.
-- `--slug` is deterministic and DNS-safe: lowercase letters, numbers, and hyphens; starts and ends with an alphanumeric character; and is short enough for `whoami-${branch_slug}` Kubernetes names.
+- `--slug` is deterministic and DNS-safe: lowercase letters, numbers, and hyphens; starts and ends with an alphanumeric character; and is short enough for the selected app's `${app}-${branch_slug}` Kubernetes names.
 
-Normal live verification:
+Normal live verification for whoami:
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+Normal live verification for Jellyfin:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-change --slug jellyfin-change --push
 ```
 
 Run Terraform apply first when the development cluster base may need to be created or repaired:
@@ -192,7 +198,7 @@ kubectl --kubeconfig ~/.kube/homelab-development.config wait namespace/whoami-ex
 kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gitrepository.source.toolkit.fluxcd.io/branch-example-change
 ```
 
-This proves that the pushed branch can be fetched by Flux, the whoami branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, the Service exists, and the HTTPRoute reports `Accepted` and `ResolvedRefs`. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps other than `whoami`.
+This proves that the pushed branch can be fetched by Flux, the selected app branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, and the selected profile checks pass. For `whoami`, that includes Service existence and an HTTPRoute with `Accepted` and `ResolvedRefs`. For `jellyfin`, that also includes HelmRelease readiness, config PVC binding, and an in-cluster Jellyfin web-shell probe. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps without a selected smoke profile.
 
 ### Touched-App Smoke Matrix
 
@@ -209,11 +215,12 @@ For each implementation that changes app behavior, manifests, Gateway routing, s
 
 ### Smoke Profiles
 
-The target model is a config-driven smoke profile per app. A profile should name the app, branch overlay path, activation template, expected namespace, workloads, Services, routes, PVCs, app-specific probes, cleanup expectations, and any required development-only secret/config prerequisites. Profiles should allow the verifier to choose consistent checks without hard-coding each app into the harness.
+Smoke profiles are JSON files under `tools/development/smoke-profiles/`. A profile names the app, branch GitRepository, activation template, expected namespace, Services, routes, PVCs, HelmReleases, app-specific probes, and any other checks the verifier can run consistently for that app.
 
-Until profile expansion lands, use `whoami` as the only automated profile and document one of:
+Document one of:
 
 - `smoke_profile: whoami` with the exact `verify_branch_deploy.py` command and result.
+- `smoke_profile: jellyfin` with the exact `verify_branch_deploy.py` command and result.
 - `smoke_profile: manual` with commands and observations for the touched app.
 - `smoke_profile: none` with the reason, such as docs-only, local-only, unavailable development cluster or credentials, missing app branch overlay that cannot be safely emulated manually, or production-only integration.
 
@@ -234,6 +241,7 @@ Local manifest verification does not require pushing a branch:
 export branch_slug=example
 export cluster_domain=development.lab.petebeegle.com
 kubectl kustomize kubernetes/apps/whoami/branch | flux envsubst --strict
+kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict
 
 kubectl kustomize kubernetes/clusters/development
 

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jellyfin-${branch_slug}
+  labels:
+    name: jellyfin-${branch_slug}
+    app.kubernetes.io/name: jellyfin
+    app.kubernetes.io/part-of: branch-environment
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config-${branch_slug}
+  namespace: jellyfin-${branch_slug}
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-csi-storage
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jellyfin-${branch_slug}
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  interval: 12h
+  url: https://jellyfin.github.io/jellyfin-helm
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: jellyfin-${branch_slug}
+  namespace: jellyfin-${branch_slug}
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  interval: 5m
+  releaseName: jellyfin-${branch_slug}
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: jellyfin
+      sourceRef:
+        kind: HelmRepository
+        name: jellyfin-${branch_slug}
+        namespace: flux-system
+      version: "3.2.0"
+  values:
+    fullnameOverride: jellyfin-${branch_slug}
+    persistence:
+      config:
+        enabled: true
+        existingClaim: jellyfin-config-${branch_slug}
+        storageClass: nfs-csi-storage
+      media:
+        enabled: false
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: jellyfin-${branch_slug}-to-internal-gateway
+  namespace: gateway
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: jellyfin-${branch_slug}
+  to:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin-${branch_slug}
+  namespace: jellyfin-${branch_slug}
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  parentRefs:
+    - name: internal
+      namespace: gateway
+      sectionName: https-gateway
+  hostnames:
+    - jellyfin-${branch_slug}.${cluster_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jellyfin-${branch_slug}
+          port: 8096
+          weight: 1

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -77,23 +77,21 @@ spec:
       media:
         enabled: false
     startupProbe:
-      tcpSocket: null
-      httpGet:
-        path: /health
+      tcpSocket:
         port: http
       failureThreshold: 60
       periodSeconds: 10
       timeoutSeconds: 5
     livenessProbe:
-      httpGet:
-        path: /health
+      httpGet: null
+      tcpSocket:
         port: http
       failureThreshold: 6
       periodSeconds: 10
       timeoutSeconds: 5
     readinessProbe:
-      httpGet:
-        path: /health
+      httpGet: null
+      tcpSocket:
         port: http
       failureThreshold: 6
       periodSeconds: 10

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -76,6 +76,27 @@ spec:
         storageClass: nfs-csi-storage
       media:
         enabled: false
+    startupProbe:
+      httpGet:
+        path: /health
+        port: http
+      failureThreshold: 60
+      periodSeconds: 10
+      timeoutSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 5
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 5
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -77,6 +77,7 @@ spec:
       media:
         enabled: false
     startupProbe:
+      tcpSocket: null
       httpGet:
         path: /health
         port: http

--- a/kubernetes/apps/jellyfin/branch/kustomization.yaml
+++ b/kubernetes/apps/jellyfin/branch/kustomization.yaml
@@ -2,5 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - whoami-template.yaml
-  - jellyfin-template.yaml
+  - jellyfin.yaml

--- a/kubernetes/apps/jellyfin/httproute.yaml
+++ b/kubernetes/apps/jellyfin/httproute.yaml
@@ -9,6 +9,9 @@ spec:
     - name: internal
       namespace: gateway
       sectionName: https-gateway
+    - name: external
+      namespace: gateway
+      sectionName: https-gateway
   hostnames:
     - jellyfin.${cluster_domain}
   rules:

--- a/kubernetes/apps/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/jellyfin/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./app.yaml
+  - ./pvc.yaml
   - ./httproute.yaml
 configMapGenerator:
   - name: jellyfin-values

--- a/kubernetes/apps/jellyfin/pvc.yaml
+++ b/kubernetes/apps/jellyfin/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config-v2
+  namespace: jellyfin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-csi-storage
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -6,6 +6,7 @@ persistence:
   media:
     enabled: false
 startupProbe:
+  tcpSocket: null
   httpGet:
     path: /health
     port: http

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -1,6 +1,7 @@
 persistence:
   config:
     enabled: true
+    existingClaim: jellyfin-config-v2
     storageClass: nfs-csi-storage
   media:
     enabled: false

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -5,6 +5,27 @@ persistence:
     storageClass: nfs-csi-storage
   media:
     enabled: false
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 6
+  periodSeconds: 10
+  timeoutSeconds: 5
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 6
+  periodSeconds: 10
+  timeoutSeconds: 5
 volumes:
   - name: custom-media
     nfs:

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -6,23 +6,21 @@ persistence:
   media:
     enabled: false
 startupProbe:
-  tcpSocket: null
-  httpGet:
-    path: /health
+  tcpSocket:
     port: http
   failureThreshold: 60
   periodSeconds: 10
   timeoutSeconds: 5
 livenessProbe:
-  httpGet:
-    path: /health
+  httpGet: null
+  tcpSocket:
     port: http
   failureThreshold: 6
   periodSeconds: 10
   timeoutSeconds: 5
 readinessProbe:
-  httpGet:
-    path: /health
+  httpGet: null
+  tcpSocket:
     port: http
   failureThreshold: 6
   periodSeconds: 10

--- a/kubernetes/clusters/development/branches/jellyfin-template.yaml
+++ b/kubernetes/clusters/development/branches/jellyfin-template.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: branch-jellyfin-${branch_slug}
+  namespace: flux-system
+spec:
+  interval: 1m
+  suspend: true
+  ref:
+    branch: ${branch_name}
+  secretRef:
+    name: flux-system
+  url: ssh://git@github.com/petebeegle/homelab
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: branch-jellyfin-${branch_slug}
+  namespace: flux-system
+spec:
+  interval: 2m
+  retryInterval: 1m
+  path: ./kubernetes/apps/jellyfin/branch
+  prune: true
+  wait: true
+  suspend: true
+  sourceRef:
+    kind: GitRepository
+    name: branch-jellyfin-${branch_slug}
+  dependsOn:
+    - name: gateway
+    - name: nfs-csi
+  postBuild:
+    substitute:
+      branch_slug: ${branch_slug}
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -1,11 +1,17 @@
 # Development Tools
 
-`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. V1 supports `whoami` only. It verifies the branch namespace, active pod readiness, the whoami Service, and the HTTPRoute.
+`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. It loads smoke profiles from `tools/development/smoke-profiles/` and currently supports `whoami` and `jellyfin`.
 
 Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
+```
+
+The Jellyfin profile verifies the branch namespace, Flux Kustomization and HelmRelease readiness, active pod readiness, config PVC binding on `nfs-csi-storage`, Service existence, HTTPRoute attachment, and an in-cluster HTTP probe against the Jellyfin web shell:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-change --slug jellyfin-change --push
 ```
 
 Use `--include-cluster-base` to first reconcile the development base from `--branch` in the known order and restore the `flux-system` GitRepository to `main` before the tool exits:

--- a/tools/development/smoke-profiles/jellyfin.json
+++ b/tools/development/smoke-profiles/jellyfin.json
@@ -1,0 +1,31 @@
+{
+  "app": "jellyfin",
+  "gitRepository": "branch-jellyfin-${branch_slug}",
+  "activationTemplate": "kubernetes/clusters/development/branches/jellyfin-template.yaml",
+  "namespace": "jellyfin-${branch_slug}",
+  "checks": {
+    "helmReleases": [
+      "jellyfin-${branch_slug}"
+    ],
+    "pvcs": [
+      {
+        "name": "jellyfin-config-${branch_slug}",
+        "storageClass": "nfs-csi-storage"
+      }
+    ],
+    "services": [
+      "jellyfin-${branch_slug}"
+    ],
+    "httpRoutes": [
+      "jellyfin-${branch_slug}"
+    ],
+    "httpProbes": [
+      {
+        "service": "jellyfin-${branch_slug}",
+        "port": 8096,
+        "path": "/",
+        "bodyRegex": "Jellyfin|Please sign in|Wizard|Login"
+      }
+    ]
+  }
+}

--- a/tools/development/smoke-profiles/whoami.json
+++ b/tools/development/smoke-profiles/whoami.json
@@ -1,0 +1,14 @@
+{
+  "app": "whoami",
+  "gitRepository": "branch-${branch_slug}",
+  "activationTemplate": "kubernetes/clusters/development/branches/whoami-template.yaml",
+  "namespace": "whoami-${branch_slug}",
+  "checks": {
+    "services": [
+      "whoami-${branch_slug}"
+    ],
+    "httpRoutes": [
+      "whoami-${branch_slug}"
+    ]
+  }
+}

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -397,8 +397,18 @@ class VerifyBranchDeployTest(unittest.TestCase):
 
         self.assertIn("probe-example-change", command)
         self.assertIn("--image=curlimages/curl:8.16.0", command)
+        self.assertIn("--overrides", command)
         self.assertIn("http://jellyfin-example-change.jellyfin-example-change.svc.cluster.local:8096/", command[-1])
         self.assertIn("Jellyfin|Please sign in|Wizard|Login", command[-1])
+        self.assertIn("seq 1 60", command[-1])
+
+    def test_probe_pod_overrides_use_restricted_security_context(self) -> None:
+        overrides = json.loads(verify.probe_pod_overrides("probe-example-change"))
+
+        self.assertTrue(overrides["spec"]["securityContext"]["runAsNonRoot"])
+        self.assertEqual(overrides["spec"]["securityContext"]["seccompProfile"]["type"], "RuntimeDefault")
+        self.assertFalse(overrides["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"])
+        self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["capabilities"]["drop"], ["ALL"])
 
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
         runner = FakeRunner(cluster_pods_json=READY_PODS)

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -406,10 +406,23 @@ class VerifyBranchDeployTest(unittest.TestCase):
         overrides = json.loads(verify.probe_pod_overrides("probe-example-change"))
 
         self.assertTrue(overrides["spec"]["securityContext"]["runAsNonRoot"])
+        self.assertEqual(overrides["spec"]["securityContext"]["runAsUser"], 1000)
         self.assertEqual(overrides["spec"]["securityContext"]["seccompProfile"]["type"], "RuntimeDefault")
         self.assertEqual(overrides["spec"]["containers"][0]["image"], "curlimages/curl:8.16.0")
         self.assertFalse(overrides["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"])
         self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["capabilities"]["drop"], ["ALL"])
+        self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["runAsUser"], 1000)
+
+    def test_jellyfin_fresh_start_values_wait_for_http_health_before_liveness(self) -> None:
+        production_values = (REPO_ROOT / "kubernetes/apps/jellyfin/values.yaml").read_text(encoding="utf-8")
+        branch_values = (REPO_ROOT / "kubernetes/apps/jellyfin/branch/jellyfin.yaml").read_text(encoding="utf-8")
+
+        for text in (production_values, branch_values):
+            self.assertIn("startupProbe:", text)
+            self.assertIn("httpGet:", text)
+            self.assertIn("path: /health", text)
+            self.assertIn("failureThreshold: 60", text)
+            self.assertNotIn("tcpSocket:", text)
 
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
         runner = FakeRunner(cluster_pods_json=READY_PODS)

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -419,10 +419,10 @@ class VerifyBranchDeployTest(unittest.TestCase):
 
         for text in (production_values, branch_values):
             self.assertIn("startupProbe:", text)
+            self.assertIn("tcpSocket: null", text)
             self.assertIn("httpGet:", text)
             self.assertIn("path: /health", text)
             self.assertIn("failureThreshold: 60", text)
-            self.assertNotIn("tcpSocket:", text)
 
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
         runner = FakeRunner(cluster_pods_json=READY_PODS)

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -407,6 +407,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
 
         self.assertTrue(overrides["spec"]["securityContext"]["runAsNonRoot"])
         self.assertEqual(overrides["spec"]["securityContext"]["seccompProfile"]["type"], "RuntimeDefault")
+        self.assertEqual(overrides["spec"]["containers"][0]["image"], "curlimages/curl:8.16.0")
         self.assertFalse(overrides["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"])
         self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["capabilities"]["drop"], ["ALL"])
 

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -398,9 +398,12 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertIn("probe-example-change", command)
         self.assertIn("--image=curlimages/curl:8.16.0", command)
         self.assertIn("--overrides", command)
-        self.assertIn("http://jellyfin-example-change.jellyfin-example-change.svc.cluster.local:8096/", command[-1])
-        self.assertIn("Jellyfin|Please sign in|Wizard|Login", command[-1])
-        self.assertIn("seq 1 60", command[-1])
+        overrides = json.loads(command[command.index("--overrides") + 1])
+        self.assertEqual(overrides["spec"]["containers"][0]["command"], ["sh", "-ec"])
+        script = overrides["spec"]["containers"][0]["args"][0]
+        self.assertIn("http://jellyfin-example-change.jellyfin-example-change.svc.cluster.local:8096/", script)
+        self.assertIn("Jellyfin|Please sign in|Wizard|Login", script)
+        self.assertIn("seq 1 60", script)
 
     def test_probe_pod_overrides_use_restricted_security_context(self) -> None:
         overrides = json.loads(verify.probe_pod_overrides("probe-example-change"))

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -45,6 +45,33 @@ READY_PODS = json.dumps(
     }
 )
 
+READY_JELLYFIN_PODS = json.dumps(
+    {
+        "items": [
+            {
+                "metadata": {"name": "jellyfin-example-change-75f8d", "namespace": "jellyfin-example-change"},
+                "status": {"phase": "Running", "conditions": [{"type": "Ready", "status": "True"}]},
+            }
+        ]
+    }
+)
+
+READY_PVC = json.dumps(
+    {
+        "metadata": {"name": "jellyfin-config-example-change", "namespace": "jellyfin-example-change"},
+        "spec": {"storageClassName": "nfs-csi-storage"},
+        "status": {"phase": "Bound"},
+    }
+)
+
+PENDING_PVC = json.dumps(
+    {
+        "metadata": {"name": "jellyfin-config-example-change", "namespace": "jellyfin-example-change"},
+        "spec": {"storageClassName": "nfs-csi-storage"},
+        "status": {"phase": "Pending"},
+    }
+)
+
 MIXED_PODS = json.dumps(
     {
         "items": [
@@ -114,12 +141,14 @@ class FakeRunner:
         timeout_on: str | None = None,
         pods_json: str = READY_PODS,
         cluster_pods_json: str = READY_PODS,
+        pvc_json: str = READY_PVC,
     ) -> None:
         self.plan_returncode = plan_returncode
         self.fail_on = fail_on
         self.timeout_on = timeout_on
         self.pods_json = pods_json
         self.cluster_pods_json = cluster_pods_json
+        self.pvc_json = pvc_json
         self.calls: list[tuple[list[str], dict[str, object]]] = []
 
     def __call__(self, args: list[str], **kwargs: object) -> SimpleNamespace:
@@ -135,8 +164,10 @@ class FakeRunner:
             return SimpleNamespace(returncode=0, stdout=self.cluster_pods_json)
         if args[-4:] == ["get", "pods", "-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=self.pods_json)
-        if args[-4:] == ["get", "httproute", "whoami-example-change", "-o"] or args[-2:] == ["-o", "json"]:
+        if "get" in args and "httproute" in args and args[-2:] == ["-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=READY_HTTPROUTE)
+        if "get" in args and "pvc" in args and args[-2:] == ["-o", "json"]:
+            return SimpleNamespace(returncode=0, stdout=self.pvc_json)
         return SimpleNamespace(returncode=0, stdout="")
 
     @property
@@ -145,6 +176,32 @@ class FakeRunner:
 
 
 class VerifyBranchDeployTest(unittest.TestCase):
+    def test_profile_loading_discovers_whoami_and_jellyfin(self) -> None:
+        profiles = verify.load_smoke_profiles()
+
+        self.assertEqual(set(profiles), {"jellyfin", "whoami"})
+        self.assertEqual(profiles["whoami"].activation_template, "kubernetes/clusters/development/branches/whoami-template.yaml")
+        self.assertEqual(profiles["whoami"].git_repository, "branch-${branch_slug}")
+        self.assertEqual(profiles["jellyfin"].git_repository, "branch-jellyfin-${branch_slug}")
+        self.assertEqual(profiles["jellyfin"].pvcs[0].name, "jellyfin-config-${branch_slug}")
+
+    def test_supported_apps_are_loaded_from_profile_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            profile_dir = Path(tmp)
+            (profile_dir / "custom.json").write_text(
+                json.dumps(
+                    {
+                        "app": "custom",
+                        "activationTemplate": "template.yaml",
+                        "namespace": "custom-${branch_slug}",
+                        "checks": {"services": ["custom-${branch_slug}"]},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(verify.supported_apps(profile_dir), frozenset({"custom"}))
+
     def test_branch_validation_accepts_common_git_branch_name(self) -> None:
         self.assertEqual(verify.validate_branch("codex/example-change"), "codex/example-change")
 
@@ -299,6 +356,50 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertTrue(any("get service whoami-example-change" in command for command in commands))
         self.assertTrue(any("get httproute whoami-example-change -o json" in command for command in commands))
 
+    def test_jellyfin_profile_checks_helm_pvc_service_route_and_http_probe(self) -> None:
+        runner = FakeRunner(pods_json=READY_JELLYFIN_PODS)
+        config = self._config(app="jellyfin")
+
+        verify.assert_smoke_profile(config, verify.load_smoke_profile("jellyfin"), runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("get namespace jellyfin-example-change" in command for command in commands))
+        self.assertTrue(any("wait helmrelease.helm.toolkit.fluxcd.io/jellyfin-example-change" in command for command in commands))
+        self.assertTrue(any("get pvc jellyfin-config-example-change -o json" in command for command in commands))
+        self.assertTrue(any("get service jellyfin-example-change" in command for command in commands))
+        self.assertTrue(any("get httproute jellyfin-example-change -o json" in command for command in commands))
+        self.assertTrue(any("run probe-example-change" in command and "curlimages/curl:8.16.0" in command for command in commands))
+
+    def test_pvc_assert_requires_bound_phase_and_expected_storage_class(self) -> None:
+        verify.assert_pvc_bound(READY_PVC, pvc_name="jellyfin-config-example-change", storage_class="nfs-csi-storage")
+
+        with self.assertRaisesRegex(verify.VerificationError, "not Bound"):
+            verify.assert_pvc_bound(PENDING_PVC, pvc_name="jellyfin-config-example-change", storage_class="nfs-csi-storage")
+
+        with self.assertRaisesRegex(verify.VerificationError, "storageClassName"):
+            verify.assert_pvc_bound(READY_PVC, pvc_name="jellyfin-config-example-change", storage_class="other")
+
+    def test_jellyfin_http_probe_command_targets_service_and_matches_web_shell(self) -> None:
+        config = self._config(app="jellyfin")
+
+        command = verify.build_http_probe_command(
+            config,
+            namespace=config.namespace,
+            probe=verify.HttpProbe(
+                service="jellyfin-${branch_slug}",
+                port=8096,
+                path="/",
+                body_regex="Jellyfin|Please sign in|Wizard|Login",
+            ),
+            probe_index=0,
+            total_probes=1,
+        )
+
+        self.assertIn("probe-example-change", command)
+        self.assertIn("--image=curlimages/curl:8.16.0", command)
+        self.assertIn("http://jellyfin-example-change.jellyfin-example-change.svc.cluster.local:8096/", command[-1])
+        self.assertIn("Jellyfin|Please sign in|Wizard|Login", command[-1])
+
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:
         runner = FakeRunner(cluster_pods_json=READY_PODS)
 
@@ -392,13 +493,14 @@ class VerifyBranchDeployTest(unittest.TestCase):
     def _config(
         self,
         *,
+        app: str = "whoami",
         push: bool = False,
         terraform_apply: bool = False,
         include_cluster_base: bool = False,
         keep: bool = False,
     ) -> verify.AppConfig:
         return verify.AppConfig(
-            app="whoami",
+            app=app,
             branch="codex/example-change",
             slug="example-change",
             kubeconfig=Path("/tmp/kubeconfig"),

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -402,6 +402,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertEqual(overrides["spec"]["containers"][0]["command"], ["sh", "-ec"])
         script = overrides["spec"]["containers"][0]["args"][0]
         self.assertIn("http://jellyfin-example-change.jellyfin-example-change.svc.cluster.local:8096/", script)
+        self.assertIn("curl -LfsS", script)
         self.assertIn("Jellyfin|Please sign in|Wizard|Login", script)
         self.assertIn("seq 1 60", script)
 

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -416,15 +416,14 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["capabilities"]["drop"], ["ALL"])
         self.assertEqual(overrides["spec"]["containers"][0]["securityContext"]["runAsUser"], 1000)
 
-    def test_jellyfin_fresh_start_values_wait_for_http_health_before_liveness(self) -> None:
+    def test_jellyfin_fresh_start_values_do_not_use_flaky_health_for_pod_readiness(self) -> None:
         production_values = (REPO_ROOT / "kubernetes/apps/jellyfin/values.yaml").read_text(encoding="utf-8")
         branch_values = (REPO_ROOT / "kubernetes/apps/jellyfin/branch/jellyfin.yaml").read_text(encoding="utf-8")
 
         for text in (production_values, branch_values):
             self.assertIn("startupProbe:", text)
-            self.assertIn("tcpSocket: null", text)
-            self.assertIn("httpGet:", text)
-            self.assertIn("path: /health", text)
+            self.assertIn("tcpSocket:", text)
+            self.assertIn("httpGet: null", text)
             self.assertIn("failureThreshold: 60", text)
 
     def test_cluster_base_reconciles_in_order_and_restores_main_on_success(self) -> None:

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -698,7 +698,7 @@ def build_http_probe_command(
     )
 
 
-def probe_pod_overrides(pod_name: str) -> str:
+def probe_pod_overrides(pod_name: str, image: str = "curlimages/curl:8.16.0") -> str:
     return json.dumps(
         {
             "spec": {
@@ -709,6 +709,7 @@ def probe_pod_overrides(pod_name: str) -> str:
                 "containers": [
                     {
                         "name": pod_name,
+                        "image": image,
                         "securityContext": {
                             "allowPrivilegeEscalation": False,
                             "capabilities": {"drop": ["ALL"]},

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -687,18 +687,33 @@ def build_http_probe_command(
         "--restart=Never",
         "--rm=true",
         "--overrides",
-        probe_pod_overrides(pod_name),
+        probe_pod_overrides(pod_name, command=["sh", "-ec"], args=[script]),
         "-i",
         "--quiet",
-        "--command",
-        "--",
-        "sh",
-        "-ec",
-        script,
     )
 
 
-def probe_pod_overrides(pod_name: str, image: str = "curlimages/curl:8.16.0") -> str:
+def probe_pod_overrides(
+    pod_name: str,
+    image: str = "curlimages/curl:8.16.0",
+    command: Sequence[str] | None = None,
+    args: Sequence[str] | None = None,
+) -> str:
+    container: dict[str, object] = {
+        "name": pod_name,
+        "image": image,
+        "securityContext": {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+        },
+    }
+    if command is not None:
+        container["command"] = list(command)
+    if args is not None:
+        container["args"] = list(args)
+
     return json.dumps(
         {
             "spec": {
@@ -708,16 +723,7 @@ def probe_pod_overrides(pod_name: str, image: str = "curlimages/curl:8.16.0") ->
                     "seccompProfile": {"type": "RuntimeDefault"},
                 },
                 "containers": [
-                    {
-                        "name": pod_name,
-                        "image": image,
-                        "securityContext": {
-                            "allowPrivilegeEscalation": False,
-                            "capabilities": {"drop": ["ALL"]},
-                            "runAsNonRoot": True,
-                            "runAsUser": 1000,
-                        },
-                    }
+                    container
                 ],
             }
         },

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -704,6 +704,7 @@ def probe_pod_overrides(pod_name: str, image: str = "curlimages/curl:8.16.0") ->
             "spec": {
                 "securityContext": {
                     "runAsNonRoot": True,
+                    "runAsUser": 1000,
                     "seccompProfile": {"type": "RuntimeDefault"},
                 },
                 "containers": [
@@ -714,6 +715,7 @@ def probe_pod_overrides(pod_name: str, image: str = "curlimages/curl:8.16.0") ->
                             "allowPrivilegeEscalation": False,
                             "capabilities": {"drop": ["ALL"]},
                             "runAsNonRoot": True,
+                            "runAsUser": 1000,
                         },
                     }
                 ],

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -670,7 +670,7 @@ def build_http_probe_command(
     url = f"http://{service}.{namespace}.svc.cluster.local:{probe.port}{probe.path}"
     script = (
         "for attempt in $(seq 1 60); do "
-        f"if body=$(curl -fsS --max-time 20 {shlex.quote(url)}); then "
+        f"if body=$(curl -LfsS --max-time 20 {shlex.quote(url)}); then "
         f"printf '%s' \"$body\" | grep -E {shlex.quote(probe.body_regex)} >/dev/null && exit 0; "
         "fi; "
         "sleep 5; "

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -669,8 +669,13 @@ def build_http_probe_command(
     pod_name = f"probe-{config.slug}" if total_probes == 1 else f"p{probe_index}-{config.slug}"
     url = f"http://{service}.{namespace}.svc.cluster.local:{probe.port}{probe.path}"
     script = (
-        f"body=$(curl -fsS --max-time 20 {shlex.quote(url)}); "
-        f"printf '%s' \"$body\" | grep -E {shlex.quote(probe.body_regex)} >/dev/null"
+        "for attempt in $(seq 1 60); do "
+        f"if body=$(curl -fsS --max-time 20 {shlex.quote(url)}); then "
+        f"printf '%s' \"$body\" | grep -E {shlex.quote(probe.body_regex)} >/dev/null && exit 0; "
+        "fi; "
+        "sleep 5; "
+        "done; "
+        "exit 1"
     )
     return kubectl(
         config,
@@ -681,6 +686,8 @@ def build_http_probe_command(
         "--image=curlimages/curl:8.16.0",
         "--restart=Never",
         "--rm=true",
+        "--overrides",
+        probe_pod_overrides(pod_name),
         "-i",
         "--quiet",
         "--command",
@@ -688,6 +695,30 @@ def build_http_probe_command(
         "sh",
         "-ec",
         script,
+    )
+
+
+def probe_pod_overrides(pod_name: str) -> str:
+    return json.dumps(
+        {
+            "spec": {
+                "securityContext": {
+                    "runAsNonRoot": True,
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+                "containers": [
+                    {
+                        "name": pod_name,
+                        "securityContext": {
+                            "allowPrivilegeEscalation": False,
+                            "capabilities": {"drop": ["ALL"]},
+                            "runAsNonRoot": True,
+                        },
+                    }
+                ],
+            }
+        },
+        separators=(",", ":"),
     )
 
 

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -12,14 +12,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Callable, Sequence
+from typing import Callable, Mapping, Sequence
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PROFILE_DIR = Path(__file__).resolve().parent / "smoke-profiles"
 DEFAULT_KUBECONFIG = Path("~/.kube/homelab-development.config").expanduser()
 DEFAULT_TIMEOUT = "10m"
 FLUX_NAMESPACE = "flux-system"
-SUPPORTED_APPS = {"whoami"}
 DEVELOPMENT_BASE_KUSTOMIZATIONS = (
     "crds",
     "cert-manager",
@@ -73,6 +73,33 @@ class VerificationError(RuntimeError):
 Runner = Callable[..., subprocess.CompletedProcess[str] | SimpleNamespace]
 
 
+@dataclass(frozen=True)
+class PvcCheck:
+    name: str
+    storage_class: str | None = None
+
+
+@dataclass(frozen=True)
+class HttpProbe:
+    service: str
+    port: int
+    path: str
+    body_regex: str
+
+
+@dataclass(frozen=True)
+class SmokeProfile:
+    app: str
+    git_repository: str
+    activation_template: str
+    namespace: str
+    helm_releases: tuple[str, ...]
+    services: tuple[str, ...]
+    http_routes: tuple[str, ...]
+    pvcs: tuple[PvcCheck, ...]
+    http_probes: tuple[HttpProbe, ...]
+
+
 def parse_duration(value: str) -> Duration:
     if not value:
         raise argparse.ArgumentTypeError("duration must not be empty")
@@ -97,8 +124,9 @@ def parse_duration(value: str) -> Duration:
 
 
 def validate_app(app: str) -> str:
-    if app not in SUPPORTED_APPS:
-        raise argparse.ArgumentTypeError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(SUPPORTED_APPS))}")
+    apps = supported_apps()
+    if app not in apps:
+        raise argparse.ArgumentTypeError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(apps))}")
     return app
 
 
@@ -138,11 +166,121 @@ def render_activation_template(template_text: str, *, branch: str, slug: str) ->
     return rendered
 
 
+def load_smoke_profiles(profile_dir: Path = PROFILE_DIR) -> dict[str, SmokeProfile]:
+    profiles: dict[str, SmokeProfile] = {}
+    if not profile_dir.is_dir():
+        raise VerificationError(f"smoke profile directory not found: {profile_dir}")
+
+    for path in sorted(profile_dir.glob("*.json")):
+        profile = load_smoke_profile_file(path)
+        if profile.app in profiles:
+            raise VerificationError(f"duplicate smoke profile for app {profile.app!r}")
+        profiles[profile.app] = profile
+    if not profiles:
+        raise VerificationError(f"no smoke profiles found in {profile_dir}")
+    return profiles
+
+
+def load_smoke_profile_file(path: Path) -> SmokeProfile:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"smoke profile {path} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise VerificationError(f"smoke profile {path} must be a JSON object")
+
+    checks = _mapping(raw.get("checks", {}), f"{path}:checks")
+    app = _required_string(raw, "app", path)
+    profile = SmokeProfile(
+        app=app,
+        git_repository=raw.get("gitRepository") if isinstance(raw.get("gitRepository"), str) else "branch-${branch_slug}",
+        activation_template=_required_string(raw, "activationTemplate", path),
+        namespace=_required_string(raw, "namespace", path),
+        helm_releases=tuple(_string_list(checks.get("helmReleases", []), f"{path}:checks.helmReleases")),
+        services=tuple(_string_list(checks.get("services", []), f"{path}:checks.services")),
+        http_routes=tuple(_string_list(checks.get("httpRoutes", []), f"{path}:checks.httpRoutes")),
+        pvcs=tuple(_pvc_checks(checks.get("pvcs", []), path)),
+        http_probes=tuple(_http_probes(checks.get("httpProbes", []), path)),
+    )
+    return profile
+
+
+def load_smoke_profile(app: str, profile_dir: Path = PROFILE_DIR) -> SmokeProfile:
+    profiles = load_smoke_profiles(profile_dir)
+    try:
+        return profiles[app]
+    except KeyError as exc:
+        raise VerificationError(f"unsupported app {app!r}; supported apps: {', '.join(sorted(profiles))}") from exc
+
+
+def supported_apps(profile_dir: Path = PROFILE_DIR) -> frozenset[str]:
+    try:
+        return frozenset(load_smoke_profiles(profile_dir))
+    except VerificationError:
+        return frozenset()
+
+
+def _required_string(raw: Mapping[str, object], key: str, path: Path) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        raise VerificationError(f"smoke profile {path} field {key!r} must be a non-empty string")
+    return value
+
+
+def _mapping(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise VerificationError(f"{field} must be an object")
+    return value
+
+
+def _string_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise VerificationError(f"{field} must be a list of non-empty strings")
+    return list(value)
+
+
+def _pvc_checks(value: object, path: Path) -> list[PvcCheck]:
+    if not isinstance(value, list):
+        raise VerificationError(f"{path}:checks.pvcs must be a list")
+    checks: list[PvcCheck] = []
+    for index, item in enumerate(value):
+        field = f"{path}:checks.pvcs[{index}]"
+        raw = _mapping(item, field)
+        checks.append(
+            PvcCheck(
+                name=_required_string(raw, "name", path),
+                storage_class=raw.get("storageClass") if isinstance(raw.get("storageClass"), str) else None,
+            )
+        )
+    return checks
+
+
+def _http_probes(value: object, path: Path) -> list[HttpProbe]:
+    if not isinstance(value, list):
+        raise VerificationError(f"{path}:checks.httpProbes must be a list")
+    probes: list[HttpProbe] = []
+    for index, item in enumerate(value):
+        field = f"{path}:checks.httpProbes[{index}]"
+        raw = _mapping(item, field)
+        port = raw.get("port")
+        if not isinstance(port, int) or port <= 0:
+            raise VerificationError(f"{field}.port must be a positive integer")
+        probes.append(
+            HttpProbe(
+                service=_required_string(raw, "service", path),
+                port=port,
+                path=_required_string(raw, "path", path),
+                body_regex=_required_string(raw, "bodyRegex", path),
+            )
+        )
+    return probes
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Verify a whoami branch environment on the homelab development cluster."
+        description="Verify an app branch environment on the homelab development cluster."
     )
-    parser.add_argument("--app", required=True, type=validate_app, choices=sorted(SUPPORTED_APPS))
+    parser.add_argument("--app", required=True, type=validate_app, choices=sorted(supported_apps()))
     parser.add_argument("--branch", required=True, type=validate_branch)
     parser.add_argument("--slug", required=True, type=validate_slug)
     parser.add_argument("--push", action="store_true", help="Push current HEAD to origin as --branch before activation.")
@@ -167,6 +305,7 @@ def run_acceptance(
 ) -> None:
     activated = False
     failure: BaseException | None = None
+    profile = load_smoke_profile(config.app)
 
     try:
         if config.push:
@@ -180,21 +319,21 @@ def run_acceptance(
         rendered = render_activation_template(
             template_text
             if template_text is not None
-            else (repo_root / "kubernetes/clusters/development/branches/whoami-template.yaml").read_text(encoding="utf-8"),
+            else (repo_root / profile.activation_template).read_text(encoding="utf-8"),
             branch=config.branch,
             slug=config.slug,
         )
         apply_activation(config, rendered, runner=runner)
         activated = True
 
-        reconcile_flux(config, runner=runner)
-        assert_whoami(config, runner=runner)
+        reconcile_flux(config, profile, runner=runner)
+        assert_smoke_profile(config, profile, runner=runner)
     except BaseException as exc:
         failure = exc
     finally:
         if activated and not config.keep:
             try:
-                cleanup_branch_environment(config, runner=runner)
+                cleanup_branch_environment(config, profile, runner=runner)
             except BaseException as cleanup_exc:
                 if failure is None:
                     failure = cleanup_exc
@@ -254,9 +393,10 @@ def apply_activation(config: AppConfig, rendered: str, *, runner: Runner) -> Non
     )
 
 
-def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
+def reconcile_flux(config: AppConfig, profile: SmokeProfile, *, runner: Runner) -> None:
+    git_repository = render_profile_value(profile.git_repository, config=config, field="gitRepository")
     run_command(
-        flux(config, "reconcile", "source", "git", config.git_repository, "--namespace", FLUX_NAMESPACE, "--timeout", config.timeout.raw),
+        flux(config, "reconcile", "source", "git", git_repository, "--namespace", FLUX_NAMESPACE, "--timeout", config.timeout.raw),
         runner=runner,
         timeout=config.timeout,
     )
@@ -266,7 +406,7 @@ def reconcile_flux(config: AppConfig, *, runner: Runner) -> None:
             "-n",
             FLUX_NAMESPACE,
             "wait",
-            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            f"gitrepository.source.toolkit.fluxcd.io/{git_repository}",
             "--for=condition=Ready",
             f"--timeout={config.timeout.raw}",
         ),
@@ -423,9 +563,24 @@ def reconcile_flux_kustomization(config: AppConfig, name: str, *, runner: Runner
     )
 
 
-def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
-    name = config.namespace
+def assert_smoke_profile(config: AppConfig, profile: SmokeProfile, *, runner: Runner) -> None:
+    name = render_profile_value(profile.namespace, config=config, field="namespace")
     run_command(kubectl(config, "get", "namespace", name), runner=runner, timeout=config.timeout)
+    for helm_release in profile.helm_releases:
+        resource_name = render_profile_value(helm_release, config=config, field="helmRelease")
+        run_command(
+            kubectl(
+                config,
+                "-n",
+                name,
+                "wait",
+                f"helmrelease.helm.toolkit.fluxcd.io/{resource_name}",
+                "--for=condition=Ready",
+                f"--timeout={config.timeout.raw}",
+            ),
+            runner=runner,
+            timeout=config.timeout,
+        )
     wait_for_active_pods_ready(
         config,
         runner=runner,
@@ -433,14 +588,107 @@ def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
         require_non_terminated=True,
         context=f"namespace {name}",
     )
-    run_command(kubectl(config, "-n", name, "get", "service", name), runner=runner, timeout=config.timeout)
-    route = run_command(
-        kubectl(config, "-n", name, "get", "httproute", name, "-o", "json"),
+    for pvc in profile.pvcs:
+        resource_name = render_profile_value(pvc.name, config=config, field="pvc")
+        assert_pvc_ready(config, namespace=name, pvc_name=resource_name, storage_class=pvc.storage_class, runner=runner)
+    for service in profile.services:
+        resource_name = render_profile_value(service, config=config, field="service")
+        run_command(kubectl(config, "-n", name, "get", "service", resource_name), runner=runner, timeout=config.timeout)
+    for http_route in profile.http_routes:
+        resource_name = render_profile_value(http_route, config=config, field="httpRoute")
+        route = run_command(
+            kubectl(config, "-n", name, "get", "httproute", resource_name, "-o", "json"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+        )
+        assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=resource_name)
+    for index, probe in enumerate(profile.http_probes):
+        run_command(
+            build_http_probe_command(config, namespace=name, probe=probe, probe_index=index, total_probes=len(profile.http_probes)),
+            runner=runner,
+            timeout=config.timeout,
+        )
+
+
+def assert_whoami(config: AppConfig, *, runner: Runner) -> None:
+    assert_smoke_profile(config, load_smoke_profile("whoami"), runner=runner)
+
+
+def render_profile_value(value: str, *, config: AppConfig, field: str) -> str:
+    rendered = (
+        value.replace("${branch_slug}", config.slug)
+        .replace("${branch_name}", config.branch)
+        .replace("${app}", config.app)
+    )
+    if "${" in rendered:
+        raise VerificationError(f"profile field {field} has an unsubstituted placeholder: {value}")
+    return rendered
+
+
+def assert_pvc_ready(
+    config: AppConfig,
+    *,
+    namespace: str,
+    pvc_name: str,
+    storage_class: str | None,
+    runner: Runner,
+) -> None:
+    pvc = run_command(
+        kubectl(config, "-n", namespace, "get", "pvc", pvc_name, "-o", "json"),
         runner=runner,
         timeout=config.timeout,
         capture_output=True,
     )
-    assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=name)
+    assert_pvc_bound(str(getattr(pvc, "stdout", "")), pvc_name=pvc_name, storage_class=storage_class)
+
+
+def assert_pvc_bound(pvc_json: str, *, pvc_name: str, storage_class: str | None) -> None:
+    try:
+        pvc = json.loads(pvc_json)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(f"PVC {pvc_name} did not return valid JSON: {exc}") from exc
+
+    phase = pvc.get("status", {}).get("phase")
+    if phase != "Bound":
+        raise VerificationError(f"PVC {pvc_name} is not Bound; observed phase {phase!r}")
+    if storage_class is not None and pvc.get("spec", {}).get("storageClassName") != storage_class:
+        observed = pvc.get("spec", {}).get("storageClassName")
+        raise VerificationError(f"PVC {pvc_name} storageClassName is {observed!r}, expected {storage_class!r}")
+
+
+def build_http_probe_command(
+    config: AppConfig,
+    *,
+    namespace: str,
+    probe: HttpProbe,
+    probe_index: int,
+    total_probes: int,
+) -> list[str]:
+    service = render_profile_value(probe.service, config=config, field="httpProbe.service")
+    pod_name = f"probe-{config.slug}" if total_probes == 1 else f"p{probe_index}-{config.slug}"
+    url = f"http://{service}.{namespace}.svc.cluster.local:{probe.port}{probe.path}"
+    script = (
+        f"body=$(curl -fsS --max-time 20 {shlex.quote(url)}); "
+        f"printf '%s' \"$body\" | grep -E {shlex.quote(probe.body_regex)} >/dev/null"
+    )
+    return kubectl(
+        config,
+        "-n",
+        namespace,
+        "run",
+        pod_name,
+        "--image=curlimages/curl:8.16.0",
+        "--restart=Never",
+        "--rm=true",
+        "-i",
+        "--quiet",
+        "--command",
+        "--",
+        "sh",
+        "-ec",
+        script,
+    )
 
 
 def wait_for_active_pods_ready(
@@ -545,7 +793,8 @@ def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
     raise VerificationError(f"HTTPRoute {route_name} has no parent with Accepted and ResolvedRefs conditions")
 
 
-def cleanup_branch_environment(config: AppConfig, *, runner: Runner) -> None:
+def cleanup_branch_environment(config: AppConfig, profile: SmokeProfile, *, runner: Runner) -> None:
+    git_repository = render_profile_value(profile.git_repository, config=config, field="gitRepository")
     run_command(
         kubectl(
             config,
@@ -571,7 +820,7 @@ def cleanup_branch_environment(config: AppConfig, *, runner: Runner) -> None:
             "-n",
             FLUX_NAMESPACE,
             "delete",
-            f"gitrepository.source.toolkit.fluxcd.io/{config.git_repository}",
+            f"gitrepository.source.toolkit.fluxcd.io/{git_repository}",
             "--ignore-not-found=true",
             "--wait=true",
             f"--timeout={config.timeout.raw}",


### PR DESCRIPTION
# jellyfin-fresh-external-smoke

## Summary

Implemented Jellyfin recovery and development smoke coverage on branch `codex/jellyfin-fresh-external-smoke`.

Important changes:

- Added Git-managed production PVC `jellyfin-config-v2` using `nfs-csi-storage`, `ReadWriteOnce`, and `5Gi`.
- Wired production Jellyfin values to `persistence.config.existingClaim: jellyfin-config-v2` while preserving the existing NAS media NFS mount.
- Added `gateway/external` HTTPS parentRef to the production Jellyfin HTTPRoute.
- Added Jellyfin development branch activation and branch overlay with branch-scoped names, fresh config PVC, no NAS media mount, internal HTTPRoute, HelmRelease, and ReferenceGrant.
- Set Jellyfin fresh-start pod probes to TCP availability checks so first-run `/health` instability does not restart the container; the branch smoke still verifies the web shell with an HTTP body probe.
- Generalized `tools/development/verify_branch_deploy.py` to load JSON smoke profiles from `tools/development/smoke-profiles/`.
- Preserved the `whoami` smoke profile and added `jellyfin` checks for namespace, Flux Kustomization, HelmRelease, pod readiness, PVC binding, Service, HTTPRoute, and an in-cluster web-shell HTTP probe with numeric non-root UID and redirect following.
- Updated development smoke docs and regenerated `docs/architecture.md`.

## Documentation Impact

Updated:

- `tools/development/README.md`
- `docs/runbooks/development-cluster.md`
- `docs/architecture.md` regenerated with `python3 tools/architecture/render.py --write`

## Test Evidence

All commands below were run in `/workspaces/homelab-ideas/jellyfin-fresh-external-smoke` on final HEAD `a39c80a985d29dcfacd37df6ecab821bca0acfcc`.

- PASS: `python3 -m unittest tools.development.tests.test_verify_branch_deploy`
- PASS: `kubectl kustomize kubernetes/apps/jellyfin`
- PASS: `export branch_slug=jellyfin-fresh-external-smoke cluster_domain=development.lab.petebeegle.com; kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict`
- PASS: `kubectl kustomize kubernetes/clusters/development`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`
- PASS: workflow marker, implementation plan, and owner attestation validation with `tools/codex-harness`.

## Development Smoke Evidence

Requested command:

```sh
python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-fresh-external-smoke --slug jellyfin-fresh-external-smoke --push
```

Evidence:

- `smoke_profile: jellyfin`
- Branch pushed to origin.
- Final pushed HEAD: `a39c80a985d29dcfacd37df6ecab821bca0acfcc`
- Kube context: `admin@homelab-development`
- Terraform init and validate passed. Terraform plan returned detailed exit code 2 with pending development-cluster creates; no apply was requested.
- PASS: Flux GitRepository fetched exact revision `codex/jellyfin-fresh-external-smoke@sha1:a39c80a985d29dcfacd37df6ecab821bca0acfcc`.
- PASS: Branch Kustomization `branch-jellyfin-jellyfin-fresh-external-smoke` applied and reached Ready.
- PASS: Namespace `jellyfin-jellyfin-fresh-external-smoke` became Active.
- PASS: HelmRelease `jellyfin-jellyfin-fresh-external-smoke` reached Ready.
- PASS: Active Jellyfin pod reached Ready.
- PASS: PVC `jellyfin-config-jellyfin-fresh-external-smoke` was checked as `Bound` on `nfs-csi-storage`.
- PASS: Service `jellyfin-jellyfin-fresh-external-smoke` existed.
- PASS: HTTPRoute `jellyfin-jellyfin-fresh-external-smoke` was retrieved and accepted/resolved by the profile check.
- PASS: In-cluster web-shell HTTP probe followed the root redirect and matched `Jellyfin|Please sign in|Wizard|Login`.

Cleanup:

- Deleted temporary branch Kustomization `branch-jellyfin-jellyfin-fresh-external-smoke`.
- Confirmed temporary namespace `jellyfin-jellyfin-fresh-external-smoke` deletion.
- Deleted temporary branch GitRepository `branch-jellyfin-jellyfin-fresh-external-smoke`.

## Commits

- `aad9cd7 feat(jellyfin): add fresh config pvc and branch smoke`
- `c0c2b50 fix(development): retry jellyfin smoke probe`
- `bdfefdf fix(development): include probe image override`
- `efe128b fix(jellyfin): stabilize fresh-start smoke probes`
- `870bb48 fix(jellyfin): clear default tcp startup probe`
- `9920779 fix(development): run smoke probe command from override`
- `739c27e fix(jellyfin): use tcp pod probes for fresh starts`
- `a39c80a fix(development): follow jellyfin smoke redirects`

## Exact HEAD

`a39c80a985d29dcfacd37df6ecab821bca0acfcc`

## Notes For Verifier

No verifier approval files were created by the implementation owner.
