### PR TITLE
Implementation: grafana-pod-failure-signal

### DIFF
--- a/kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json
@@ -105,7 +105,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Pods in Failed phase",
+      "description": "Pods in Failed phase, excluding retained synthetic-smoke job history in the synthetics namespace.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -157,7 +157,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod) (kube_pod_status_phase{phase=\"Failed\"} > bool 0)) OR vector(0)",
+          "expr": "sum(max by (namespace, pod) ((kube_pod_status_phase{phase=\"Failed\"} unless (kube_pod_status_phase{phase=\"Failed\",namespace=\"synthetics\",pod=~\"synthetic-smoke-.+\"} or kube_pod_status_phase{exported_namespace=\"synthetics\",phase=\"Failed\",pod=~\"synthetic-smoke-.+\"})) > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],

--- a/kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json
@@ -356,7 +356,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Pods currently in Failed or Pending phase across the cluster.",
+      "description": "Pods currently Pending or Failed, excluding retained synthetic-smoke job history in the synthetics namespace.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -405,7 +405,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Failed|Pending\"} > bool 0)) OR vector(0)",
+          "expr": "sum(max by (namespace, pod, phase) ((kube_pod_status_phase{phase=\"Pending\"} or (kube_pod_status_phase{phase=\"Failed\"} unless (kube_pod_status_phase{phase=\"Failed\",namespace=\"synthetics\",pod=~\"synthetic-smoke-.+\"} or kube_pod_status_phase{exported_namespace=\"synthetics\",phase=\"Failed\",pod=~\"synthetic-smoke-.+\"}))) > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -478,7 +478,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Current high-signal Kubernetes problems. Use this to pick the first namespace or node to inspect.",
+      "description": "Current high-signal Kubernetes problems. Retained synthetic-smoke job history in the synthetics namespace is excluded from failed pod phase rows.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -537,7 +537,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max by (namespace, pod, phase) (kube_pod_status_phase{phase=~\"Pending|Failed|Unknown\"} > bool 0)",
+          "expr": "max by (namespace, pod, phase) ((kube_pod_status_phase{phase=~\"Pending|Unknown\"} or (kube_pod_status_phase{phase=\"Failed\"} unless (kube_pod_status_phase{phase=\"Failed\",namespace=\"synthetics\",pod=~\"synthetic-smoke-.+\"} or kube_pod_status_phase{exported_namespace=\"synthetics\",phase=\"Failed\",pod=~\"synthetic-smoke-.+\"}))) > bool 0)",
           "format": "table",
           "instant": true,
           "refId": "B"


### PR DESCRIPTION
## Summary
# grafana-pod-failure-signal

## Summary

Exclude retained `synthetics/synthetic-smoke-*` Failed pod history from Grafana pod failure signal panels while preserving general Pending pod visibility.

## Risk Tier

Medium.

## Important Changes

- Updated `monitoring-radar-dashboard.json` so `Failed Or Pending Pods` counts Pending pods generally, but excludes Failed `synthetic-smoke-.+` pods when either `namespace="synthetics"` or `exported_namespace="synthetics"` is present.
- Applied the same Failed synthetic-smoke exclusion to the `Current Workload Problems` pod phase table target.
- Updated `kubernetes-dashboard.json` so the `Failed Pods` stat uses the same Failed synthetic-smoke exclusion.
- Left raw inventory panels such as `Pods by Phase` unchanged.

## Documentation Impact

No separate docs changed because panel descriptions carry the operator-facing semantics. The affected panel descriptions now state that retained synthetic-smoke job history is excluded.

## Development Validation

Exception: development does not activate the Grafana monitoring stack.

Substitute checks:

- Local dashboard JSON validation.
- Local kustomize render validation for Grafana dashboards and the Grafana stack.
- Architecture render check.
- Read-only production failed pod evidence.

## Checks

- PASS: `jq empty kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json`
- PASS: `jq empty kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json`
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`

## Production Evidence

Command:

```bash
kubectl --kubeconfig ~/.kube/homelab-production.config get pods -A --field-selector=status.phase=Failed -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,PHASE:.status.phase,START:.status.startTime,REASON:.status.reason' --sort-by=.status.startTime
```

Observation: production Failed pods are only retained `synthetics/synthetic-smoke-*` pods. The command returned 12 Failed pods, all in namespace `synthetics`, all named `synthetic-smoke-*`, with start times from `2026-05-16T18:15:00Z` through `2026-05-16T22:45:24Z`.

## Workflow Notes

- Implementation owner identity: `implementation-agent-grafana-pod-failure-signal`.
- Branch: `codex/grafana-pod-failure-signal`.
- Commit: `69521596c8e42ef3d770c1cc73b9b24b4bf59d5e`.
- Tracked implementation was delegated to `implementation-agent-grafana-pod-failure-signal` in the sibling clone.


## Changes
- kubernetes/infra/monitoring/grafana/dashboards/kubernetes-dashboard.json
- kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json

## Commits
- 6952159 fix(grafana): exclude retained synthetic smoke pod failures

## Verification
- Verified HEAD: `69521596c8e42ef3d770c1cc73b9b24b4bf59d5e`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
