### PR TITLE
Add Authentik OIDC to Jellyfin

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/foundry-bluegreen-fixture` | `namespace.yaml`, `pvc-blue.yaml`, `pvc-green.yaml`, `deployment-blue.yaml`, `deployment-green.yaml`, `service-blue.yaml`, `service-green.yaml`, `httproute-green-preview.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml`, `httproute-public.yaml` |
 | `kubernetes/apps/jellyfin/branch` | `jellyfin.yaml` |
-| `kubernetes/apps/jellyfin` | `./app.yaml`, `./pvc.yaml`, `./httproute.yaml` |
+| `kubernetes/apps/jellyfin` | `./app.yaml`, `./pvc.yaml`, `./httproute.yaml`, `./secret.yaml`, `./sso-bootstrap.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
 | `kubernetes/apps/renovate` | `app.yaml`, `secret.yaml` |
 | `kubernetes/apps/synthetics` | `namespace.yaml`, `cronjob.yaml` |
@@ -185,6 +185,7 @@ This lists secret manifest presence only. Secret values are not rendered.
 | `cloudflare-tunnels` | `cloudflare/tunnel-credentials` | `yes` | `kubernetes/apps/cloudflare-tunnels/secret.yaml` |
 | `controllers/cert-manager` | `cert-manager/cloudflare-api-token` | `yes` | `kubernetes/infra/controllers/cert-manager/secret.yaml` |
 | `foundryvtt` | `foundryvtt/foundryvtt-secret` | `yes` | `kubernetes/apps/foundryvtt/secret.yaml` |
+| `jellyfin` | `jellyfin/jellyfin-secrets` | `yes` | `kubernetes/apps/jellyfin/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-credentials` | `yes` | `kubernetes/infra/monitoring/grafana/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-env` | `yes` | `kubernetes/infra/monitoring/grafana/grafana-env.yaml` |
 | `monitoring/pretty-discord-alerts` | `monitoring/grafana-env` | `yes` | `kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml` |

--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -1,0 +1,26 @@
+---
+status: current
+scope:
+  - jellyfin
+  - authentik
+  - sso
+last_verified: 2026-05-17
+---
+
+# Jellyfin Authentik SSO
+
+Jellyfin web SSO is provided by the 9p4 SSO Authentication plugin, pinned in GitOps to release `v4.0.0.4`. The Authentik setup follows the community integration guide at <https://integrations.goauthentik.io/media/jellyfin/>.
+
+Authentik owns the `jellyfin` OAuth2/OpenID provider and Jellyfin application. The provider name visible to Jellyfin is `authentik`, with client ID `jellyfin`, redirect URL `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`, and launch URL `https://jellyfin.${cluster_domain}/sso/OID/start/authentik`.
+
+Group membership is exposed through the `groups` OIDC scope and claim. Users must be in `Jellyfin Users` or `Jellyfin Admins` to pass plugin authorization. Members of `Jellyfin Admins` are mapped to Jellyfin administrators.
+
+Native Jellyfin login is intentionally preserved. Keep at least one local administrator or QuickConnect-capable fallback available for native clients and for recovery if Authentik, group claims, or the SSO plugin fail. The plugin does not provide an SSO logout callback; logging out of Jellyfin only ends the Jellyfin session.
+
+After reconcile, acceptance should confirm:
+
+1. Authentik has the `jellyfin` application and `authentik` OAuth provider.
+2. Jellyfin starts with the SSO Authentication plugin installed.
+3. The Jellyfin login page shows the SSO button and starts at `/sso/OID/start/authentik`.
+4. A `Jellyfin Users` member can sign in.
+5. A `Jellyfin Admins` member receives Jellyfin administrator access.

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -27,6 +27,118 @@ spec:
     requests:
       storage: 5Gi
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jellyfin-${branch_slug}-sso-bootstrap
+  namespace: jellyfin-${branch_slug}
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+data:
+  bootstrap-sso.py: |
+    import hashlib
+    import os
+    import shutil
+    import sys
+    import tempfile
+    import urllib.request
+    import zipfile
+    from pathlib import Path
+    from xml.sax.saxutils import escape
+
+    plugin_version = "4.0.0.4"
+    plugin_url = "https://github.com/9p4/jellyfin-plugin-sso/releases/download/v4.0.0.4/sso-authentication_4.0.0.4.zip"
+    plugin_sha256 = "c09f16ba31059a434ddd7f811e4f9608d4b4c4514cc80a5bf1ca33bee61e1107"
+    config_root = Path("/config")
+    plugin_dir = config_root / "plugins" / f"SSO Authentication_{plugin_version}"
+    plugin_config = config_root / "plugins" / "configurations" / "SSO-Auth.xml"
+    branding_config = config_root / "config" / "branding.xml"
+    public_url = os.environ["JELLYFIN_PUBLIC_URL"].rstrip("/")
+    oid_endpoint = os.environ["JELLYFIN_OIDC_ENDPOINT"]
+    client_secret = os.environ["JELLYFIN_OAUTH_CLIENT_SECRET"]
+
+    try:
+        plugin_dir.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive = Path(temp_dir) / "sso-authentication.zip"
+            with urllib.request.urlopen(plugin_url, timeout=60) as response:
+                archive.write_bytes(response.read())
+            if hashlib.sha256(archive.read_bytes()).hexdigest() != plugin_sha256:
+                raise RuntimeError("SSO Authentication plugin checksum mismatch")
+            if plugin_dir.exists():
+                shutil.rmtree(plugin_dir)
+            plugin_dir.mkdir(parents=True)
+            with zipfile.ZipFile(archive) as plugin_zip:
+                plugin_zip.extractall(plugin_dir)
+
+        plugin_config.parent.mkdir(parents=True, exist_ok=True)
+        plugin_config.write_text(f"""<?xml version='1.0' encoding='utf-8'?>
+    <PluginConfiguration>
+      <SamlConfigs />
+      <OidConfigs>
+        <item>
+          <key><string>authentik</string></key>
+          <value>
+            <OidConfig>
+              <OidEndpoint>{escape(oid_endpoint)}</OidEndpoint>
+              <OidClientId>jellyfin</OidClientId>
+              <OidSecret>{escape(client_secret)}</OidSecret>
+              <Enabled>true</Enabled>
+              <EnableAuthorization>true</EnableAuthorization>
+              <EnableAllFolders>true</EnableAllFolders>
+              <EnabledFolders />
+              <AdminRoles><string>Jellyfin Admins</string></AdminRoles>
+              <Roles><string>Jellyfin Users</string><string>Jellyfin Admins</string></Roles>
+              <EnableFolderRoles>false</EnableFolderRoles>
+              <EnableLiveTvRoles>false</EnableLiveTvRoles>
+              <EnableLiveTv>true</EnableLiveTv>
+              <EnableLiveTvManagement>false</EnableLiveTvManagement>
+              <LiveTvRoles />
+              <LiveTvManagementRoles />
+              <FolderRoleMappings />
+              <RoleClaim>groups</RoleClaim>
+              <OidScopes><string>groups</string></OidScopes>
+              <DefaultProvider />
+              <SchemeOverride />
+              <NewPath>true</NewPath>
+              <CanonicalLinks />
+              <DefaultUsernameClaim>preferred_username</DefaultUsernameClaim>
+              <AvatarUrlFormat />
+              <DisableHttps>false</DisableHttps>
+              <DisablePushedAuthorization>false</DisablePushedAuthorization>
+              <DoNotValidateEndpoints>false</DoNotValidateEndpoints>
+              <DoNotValidateIssuerName>false</DoNotValidateIssuerName>
+              <DoNotLoadProfile>false</DoNotLoadProfile>
+            </OidConfig>
+          </value>
+        </item>
+      </OidConfigs>
+    </PluginConfiguration>
+    """, encoding="utf-8")
+
+        branding_config.parent.mkdir(parents=True, exist_ok=True)
+        branding_config.write_text(f"""<?xml version='1.0' encoding='utf-8'?>
+    <BrandingOptions>
+      <LoginDisclaimer>&lt;form action=&quot;{escape(public_url)}/sso/OID/start/authentik&quot;&gt;
+      &lt;button class=&quot;raised block emby-button button-submit&quot;&gt;
+        Sign in with SSO
+      &lt;/button&gt;
+    &lt;/form&gt;</LoginDisclaimer>
+      <CustomCss>a.raised.emby-button {{
+      padding: 0.9em 1em;
+      color: inherit !important;
+    }}
+    .disclaimerContainer {{
+      display: block;
+    }}</CustomCss>
+      <SplashscreenEnabled>false</SplashscreenEnabled>
+    </BrandingOptions>
+    """, encoding="utf-8")
+    except Exception as exc:
+        print(f"Jellyfin branch SSO bootstrap failed: {exc}", file=sys.stderr)
+        raise
+---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
@@ -96,6 +208,30 @@ spec:
       failureThreshold: 6
       periodSeconds: 10
       timeoutSeconds: 5
+    extraInitContainers:
+      - name: install-sso-auth
+        image: python:3.13-alpine
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: JELLYFIN_OAUTH_CLIENT_SECRET
+            value: branch-placeholder-not-secret
+          - name: JELLYFIN_PUBLIC_URL
+            value: https://jellyfin-${branch_slug}.${cluster_domain}
+          - name: JELLYFIN_OIDC_ENDPOINT
+            value: https://authentik.${cluster_domain}/application/o/jellyfin/.well-known/openid-configuration
+        command:
+          - python3
+          - /opt/jellyfin-sso/bootstrap-sso.py
+        volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: jellyfin-sso-bootstrap
+            mountPath: /opt/jellyfin-sso
+            readOnly: true
+    volumes:
+      - name: jellyfin-sso-bootstrap
+        configMap:
+          name: jellyfin-${branch_slug}-sso-bootstrap
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant

--- a/kubernetes/apps/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/jellyfin/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ./app.yaml
   - ./pvc.yaml
   - ./httproute.yaml
+  - ./secret.yaml
+  - ./sso-bootstrap.yaml
 configMapGenerator:
   - name: jellyfin-values
     namespace: jellyfin

--- a/kubernetes/apps/jellyfin/secret.yaml
+++ b/kubernetes/apps/jellyfin/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: jellyfin-secrets
+    namespace: jellyfin
+type: Opaque
+stringData:
+    JELLYFIN_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:4yTnQCUDHBKOV/PHiITDB3vYD+Q0eDzRKp/K4UeSyGu+dohM7G8IwQN0rK25WWcpmDk6mUkohlEPeIm9YJhvwg==,iv:psRzeTVjhw/3y519Bb3sPTYetUnBkCvGhCiUPMdjMy0=,tag:Z0emUrATGqGm7wFqa2dsLA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCWk55OVQ4cWNUaVlFamdw
+            c0hteXRKdHpnN2FtMk9wSm4vSTZEaWxBZUNjCkdpL0U4eXUyY200ZEl6UXQ2dWNz
+            bEVvTFYwbHUrSVZXSmN4TnNOb1pPdEEKLS0tIGViRXp6SFVwQU9FYzBka0IvR3JV
+            VTBON0ZBZDVpQnVxMlQrMXpNNjFJVGsKhJuPsxtX4xDCMtccH6pF0luC7YHT+l1V
+            fn6ED8sLot/9cAqbuPIoN87oADC2PbxZNr/LYRjRZ/irMTdxMOPx9g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-17T00:51:25Z"
+    mac: ENC[AES256_GCM,data:t5Zml82LbJTk79pxlunHWjwZrSwkOQfNzN9AYyqy9ReieG+thZ4M0bH9xILhzZ7m6zuhVtSPPLZfrvv6L4XW1E4UVQM/XALNGvi9wEU3SuvVGx30L8mQUB0AKF8O4i4vp2GwNvW67KG4kSX5MyxCdSuJqc05wWtVogvGREBt3xI=,iv:lc/dRREKBlUxLdLY2+YheVAOuucuOFa22PLFpG775vs=,tag:Yx3svXkVwH7ul5WMfAJccQ==,type:str]
+    version: 3.13.0

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jellyfin-sso-bootstrap
+  namespace: jellyfin
+data:
+  bootstrap-sso.py: |
+    import hashlib
+    import os
+    import shutil
+    import sys
+    import tempfile
+    import urllib.request
+    import zipfile
+    import xml.etree.ElementTree as ET
+    from pathlib import Path
+
+    PLUGIN_VERSION = "4.0.0.4"
+    PLUGIN_URL = "https://github.com/9p4/jellyfin-plugin-sso/releases/download/v4.0.0.4/sso-authentication_4.0.0.4.zip"
+    PLUGIN_SHA256 = "c09f16ba31059a434ddd7f811e4f9608d4b4c4514cc80a5bf1ca33bee61e1107"
+    PROVIDER_NAME = "authentik"
+    CLIENT_ID = "jellyfin"
+    OID_ENDPOINT = os.environ["JELLYFIN_OIDC_ENDPOINT"]
+    PUBLIC_URL = os.environ["JELLYFIN_PUBLIC_URL"].rstrip("/")
+    CLIENT_SECRET = os.environ["JELLYFIN_OAUTH_CLIENT_SECRET"]
+
+    CONFIG_ROOT = Path("/config")
+    PLUGIN_DIR = CONFIG_ROOT / "plugins" / f"SSO Authentication_{PLUGIN_VERSION}"
+    PLUGIN_CONFIG = CONFIG_ROOT / "plugins" / "configurations" / "SSO-Auth.xml"
+    BRANDING_CONFIG = CONFIG_ROOT / "config" / "branding.xml"
+
+    def indent(element, level=0):
+        spacing = "\n" + level * "  "
+        child_spacing = "\n" + (level + 1) * "  "
+        if len(element):
+            if not element.text or not element.text.strip():
+                element.text = child_spacing
+            for child in element:
+                indent(child, level + 1)
+            if not child.tail or not child.tail.strip():
+                child.tail = spacing
+        if level and (not element.tail or not element.tail.strip()):
+            element.tail = spacing
+
+    def set_text(parent, name, value):
+        child = parent.find(name)
+        if child is None:
+            child = ET.SubElement(parent, name)
+        child.text = value
+        return child
+
+    def set_bool(parent, name, value):
+        set_text(parent, name, "true" if value else "false")
+
+    def set_string_array(parent, name, values):
+        existing = parent.find(name)
+        if existing is not None:
+            parent.remove(existing)
+        array = ET.SubElement(parent, name)
+        for value in values:
+            item = ET.SubElement(array, "string")
+            item.text = value
+        return array
+
+    def key_text(item):
+        key = item.find("key")
+        if key is None:
+            return None
+        string = key.find("string")
+        return string.text if string is not None else None
+
+    def install_plugin():
+        PLUGIN_DIR.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            archive = Path(temp_dir) / "sso-authentication.zip"
+            with urllib.request.urlopen(PLUGIN_URL, timeout=60) as response:
+                archive.write_bytes(response.read())
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            if digest != PLUGIN_SHA256:
+                raise RuntimeError("SSO Authentication plugin checksum mismatch")
+            if PLUGIN_DIR.exists():
+                shutil.rmtree(PLUGIN_DIR)
+            PLUGIN_DIR.mkdir(parents=True)
+            with zipfile.ZipFile(archive) as plugin_zip:
+                plugin_zip.extractall(PLUGIN_DIR)
+
+    def build_oid_config(canonical_links):
+        oid_config = ET.Element("OidConfig")
+        set_text(oid_config, "OidEndpoint", OID_ENDPOINT)
+        set_text(oid_config, "OidClientId", CLIENT_ID)
+        set_text(oid_config, "OidSecret", CLIENT_SECRET)
+        set_bool(oid_config, "Enabled", True)
+        set_bool(oid_config, "EnableAuthorization", True)
+        set_bool(oid_config, "EnableAllFolders", True)
+        set_string_array(oid_config, "EnabledFolders", [])
+        set_string_array(oid_config, "AdminRoles", ["Jellyfin Admins"])
+        set_string_array(oid_config, "Roles", ["Jellyfin Users", "Jellyfin Admins"])
+        set_bool(oid_config, "EnableFolderRoles", False)
+        set_bool(oid_config, "EnableLiveTvRoles", False)
+        set_bool(oid_config, "EnableLiveTv", True)
+        set_bool(oid_config, "EnableLiveTvManagement", False)
+        set_string_array(oid_config, "LiveTvRoles", [])
+        set_string_array(oid_config, "LiveTvManagementRoles", [])
+        ET.SubElement(oid_config, "FolderRoleMappings")
+        set_text(oid_config, "RoleClaim", "groups")
+        set_string_array(oid_config, "OidScopes", ["groups"])
+        set_text(oid_config, "DefaultProvider", "")
+        set_text(oid_config, "SchemeOverride", "")
+        set_bool(oid_config, "NewPath", True)
+        if canonical_links is not None:
+            oid_config.append(canonical_links)
+        else:
+            ET.SubElement(oid_config, "CanonicalLinks")
+        set_text(oid_config, "DefaultUsernameClaim", "preferred_username")
+        set_text(oid_config, "AvatarUrlFormat", "")
+        set_bool(oid_config, "DisableHttps", False)
+        set_bool(oid_config, "DisablePushedAuthorization", False)
+        set_bool(oid_config, "DoNotValidateEndpoints", False)
+        set_bool(oid_config, "DoNotValidateIssuerName", False)
+        set_bool(oid_config, "DoNotLoadProfile", False)
+        return oid_config
+
+    def configure_sso():
+        PLUGIN_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        canonical_links = None
+        if PLUGIN_CONFIG.exists():
+            root = ET.parse(PLUGIN_CONFIG).getroot()
+        else:
+            root = ET.Element("PluginConfiguration")
+
+        saml_configs = root.find("SamlConfigs")
+        if saml_configs is None:
+            saml_configs = ET.Element("SamlConfigs")
+            root.insert(0, saml_configs)
+
+        oid_configs = root.find("OidConfigs")
+        if oid_configs is None:
+            oid_configs = ET.SubElement(root, "OidConfigs")
+
+        for item in list(oid_configs.findall("item")):
+            if key_text(item) == PROVIDER_NAME:
+                existing = item.find("./value/OidConfig/CanonicalLinks")
+                if existing is not None:
+                    canonical_links = existing
+                oid_configs.remove(item)
+
+        item = ET.SubElement(oid_configs, "item")
+        key = ET.SubElement(item, "key")
+        set_text(key, "string", PROVIDER_NAME)
+        value = ET.SubElement(item, "value")
+        value.append(build_oid_config(canonical_links))
+
+        indent(root)
+        ET.ElementTree(root).write(PLUGIN_CONFIG, encoding="utf-8", xml_declaration=True)
+
+    def configure_branding():
+        BRANDING_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        if BRANDING_CONFIG.exists():
+            root = ET.parse(BRANDING_CONFIG).getroot()
+        else:
+            root = ET.Element("BrandingOptions")
+
+        disclaimer = root.find("LoginDisclaimer")
+        if disclaimer is None:
+            disclaimer = ET.SubElement(root, "LoginDisclaimer")
+        existing_disclaimer = disclaimer.text or ""
+        sso_button = (
+            f'<form action="{PUBLIC_URL}/sso/OID/start/authentik">\n'
+            '  <button class="raised block emby-button button-submit">\n'
+            "    Sign in with SSO\n"
+            "  </button>\n"
+            "</form>"
+        )
+        if "/sso/OID/start/authentik" not in existing_disclaimer:
+            disclaimer.text = "\n\n".join(part for part in [existing_disclaimer.strip(), sso_button] if part)
+
+        custom_css = root.find("CustomCss")
+        if custom_css is None:
+            custom_css = ET.SubElement(root, "CustomCss")
+        existing_css = custom_css.text or ""
+        sso_css = (
+            "a.raised.emby-button {\n"
+            "  padding: 0.9em 1em;\n"
+            "  color: inherit !important;\n"
+            "}\n"
+            ".disclaimerContainer {\n"
+            "  display: block;\n"
+            "}"
+        )
+        if ".disclaimerContainer" not in existing_css:
+            custom_css.text = "\n\n".join(part for part in [existing_css.strip(), sso_css] if part)
+
+        splash = root.find("SplashscreenEnabled")
+        if splash is None:
+            set_bool(root, "SplashscreenEnabled", False)
+
+        indent(root)
+        ET.ElementTree(root).write(BRANDING_CONFIG, encoding="utf-8", xml_declaration=True)
+
+    try:
+        install_plugin()
+        configure_sso()
+        configure_branding()
+    except Exception as exc:
+        print(f"Jellyfin SSO bootstrap failed: {exc}", file=sys.stderr)
+        raise

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -25,11 +25,37 @@ readinessProbe:
   failureThreshold: 6
   periodSeconds: 10
   timeoutSeconds: 5
+extraInitContainers:
+  - name: install-sso-auth
+    image: python:3.13-alpine
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: JELLYFIN_OAUTH_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: jellyfin-secrets
+            key: JELLYFIN_OAUTH_CLIENT_SECRET
+      - name: JELLYFIN_PUBLIC_URL
+        value: https://jellyfin.${cluster_domain}
+      - name: JELLYFIN_OIDC_ENDPOINT
+        value: https://authentik.${cluster_domain}/application/o/jellyfin/.well-known/openid-configuration
+    command:
+      - python3
+      - /opt/jellyfin-sso/bootstrap-sso.py
+    volumeMounts:
+      - name: config
+        mountPath: /config
+      - name: jellyfin-sso-bootstrap
+        mountPath: /opt/jellyfin-sso
+        readOnly: true
 volumes:
   - name: custom-media
     nfs:
       server: ${nfs_server}
       path: /volume1/Media/Jellyfin
+  - name: jellyfin-sso-bootstrap
+    configMap:
+      name: jellyfin-sso-bootstrap
 volumeMounts:
   - name: custom-media
     mountPath: /custom-media

--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -37,6 +37,7 @@ spec:
     blueprints:
       configMaps:
         - grafana-oauth-blueprint
+        - jellyfin-oauth-blueprint
         - synology-oauth-blueprint
   valuesFrom:
     - kind: ConfigMap

--- a/kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml
+++ b/kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+---
+version: 1
+metadata:
+  name: jellyfin-oauth2-setup
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+context:
+  jellyfin_client_id: jellyfin
+  jellyfin_client_secret: !Env JELLYFIN_OAUTH_CLIENT_SECRET
+
+entries:
+  - identifiers:
+      name: Jellyfin Users
+    model: authentik_core.group
+    attrs:
+      name: Jellyfin Users
+
+  - identifiers:
+      name: Jellyfin Admins
+    model: authentik_core.group
+    attrs:
+      name: Jellyfin Admins
+
+  - identifiers:
+      managed: goauthentik.io/providers/oauth2/jellyfin-groups
+    model: authentik_providers_oauth2.scopemapping
+    attrs:
+      name: Jellyfin Groups Mapping
+      scope_name: groups
+      expression: |
+        return {
+          "groups": [group.name for group in request.user.ak_groups.all()],
+        }
+
+  - identifiers:
+      name: jellyfin
+    model: authentik_providers_oauth2.oauth2provider
+    attrs:
+      name: jellyfin
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
+      client_type: confidential
+      client_id: !Context jellyfin_client_id
+      client_secret: !Context jellyfin_client_secret
+      redirect_uris:
+        - matching_mode: strict
+          url: https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/jellyfin-groups]]
+      sub_mode: hashed_user_id
+      issuer_mode: per_provider
+      access_code_validity: minutes=1
+      access_token_validity: minutes=5
+      refresh_token_validity: days=30
+
+  - identifiers:
+      slug: jellyfin
+    model: authentik_core.application
+    attrs:
+      name: Jellyfin
+      slug: jellyfin
+      provider: !Find [authentik_providers_oauth2.oauth2provider, [name, jellyfin]]
+      policy_engine_mode: any
+      meta_launch_url: https://jellyfin.${cluster_domain}/sso/OID/start/authentik
+      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/jellyfin.png
+      meta_description: Media streaming
+      open_in_new_tab: true

--- a/kubernetes/infra/authentik/blueprints/kustomization.yaml
+++ b/kubernetes/infra/authentik/blueprints/kustomization.yaml
@@ -8,6 +8,9 @@ configMapGenerator:
   - name: grafana-oauth-blueprint
     files:
       - grafana-oauth.yaml
+  - name: jellyfin-oauth-blueprint
+    files:
+      - jellyfin-oauth.yaml
   - name: synology-oauth-blueprint
     files:
       - synology-oauth.yaml

--- a/kubernetes/infra/authentik/secret.yaml
+++ b/kubernetes/infra/authentik/secret.yaml
@@ -13,10 +13,10 @@ stringData:
     AUTHENTIK_BOOTSTRAP_PASSWORD: ENC[AES256_GCM,data:oJDQu6F6l7wOp1vp/GOM3QwdS0s23Xcg5nnAjou4LOe9AgxD3V2ibrkKQkY=,iv:MR3q9pHqSWPHXE6L9mqZOAq3iyCYCpFcN00LFE0zVqU=,tag:BWhm20qEZNC+9yX1I11ACQ==,type:str]
     GRAFANA_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:ouwdCzLNVuEWCy9IxNOE3OslV5c2v+QP3d3R30dj/biIfLUVN6JHaLCW9Hk=,iv:e2yqT7v7aPXimR58D0W/W7h/pPx6q49MM9/ADXO1Y24=,tag:redPch785bWj4I8NzwdkAw==,type:str]
     SYNOLOGY_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:sNe5JPmDp1PhAjjzPM9u91bS8zonGZdsYNciKlakf/bX5u5oItmbD6M0rSs=,iv:syI+JsjrD9icu4vhCHU9PG7mYdkxMWIxaJQjX/7E0js=,tag:hTfG07v1r7USOOQnkGJq7Q==,type:str]
+    JELLYFIN_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:fmpS7LCwzhkuTidXMcIH+G5wCtfIhCc27QAsPHV61BM6K6aC1Ha/i1gDWlOTjnn8gybXsVAxvF9AsVOosvxYLw==,iv:nyI0s2Y59Roq/ORDQK1IG2RheByv+EIy38rKUNQjuyA=,tag:1aAMvr76gOdReuam7IczUg==,type:str]
 sops:
     age:
-        - recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
             YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1UmQvdGZTbTZ6am1hdGg2
             NEFYYnN3aTVvTlVKZzNGSXNCWWJOSE9nM1N3Ck5BWWRyczF1YlYvNHRBS011SlIx
@@ -24,7 +24,8 @@ sops:
             Q0tBWllzZkFZR3VuTXJlN3V0ZWl4cHcKmzI5pPza/qn15zY85GPLNlpEsXyc0vN1
             pUGasUW2DJj3lzAWl+uPmn5J+eDtIeldGyv3W0UM+0tLX3mK6cp1yA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-16T04:52:01Z"
-    mac: ENC[AES256_GCM,data:yn1zQchKy8OHkdex3u8e2k2tpvuS1a7cjyXWQ/y73SgSjQL31Yi0GLlyl5MV/bRxPD9LHqzqq62x5TyhpqNCK1NXQwAm2rS7gT6ytrnMpqLoIVJJlwLt2GwEKe45HusQfegb7Vap+iLT9gKVMqmMANXZMlpNEZf75R+XM/w9S0w=,iv:Jn6FyGM6K7rE0z+l4BEy3XoqyxMnOR46xb/pkLGY4Mo=,tag:f8fB2rU+JODqhpBaO3Tghw==,type:str]
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-17T00:53:08Z"
+    mac: ENC[AES256_GCM,data:Ze0KESK6urn3Zpsz/i83edcon+Y/XUFN+4xS3Sz3yLqz3UAipn3Thf4tmOFa8M/rZtRqrSEtz0WsOm/BY0/Wj8m1GdLkf5P9WbYJ496WTxMVDiD4AXYGQrnSfUdfN+Nuq951OqSVI3prayN43KcDVIjqWj88A7654j7zuaCj9mk=,iv:sDQyhiag+tfeW7QzvC9ODMYg5nytwScNp/XPRqe8w/U=,tag:bwB8lfrzHXItoZzNH7L0cA==,type:str]
     version: 3.11.0


### PR DESCRIPTION
# jellyfin-authentik-sso

## Summary

Adds declarative Jellyfin Authentik OIDC SSO while preserving native Jellyfin login and QuickConnect-capable fallback paths.

## Important Changes

- Added an Authentik Jellyfin OAuth/OIDC blueprint with provider/application `jellyfin`, client ID `jellyfin`, redirect URL `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`, launch URL `https://jellyfin.${cluster_domain}/sso/OID/start/authentik`, `Jellyfin Users` and `Jellyfin Admins` groups, and a `groups` scope/claim mapping.
- Added encrypted shared `JELLYFIN_OAUTH_CLIENT_SECRET` values to Authentik and Jellyfin secrets. The plaintext secret was not logged.
- Added a Jellyfin SSO bootstrap ConfigMap and Helm values to install `9p4/jellyfin-plugin-sso` release `v4.0.0.4` after verifying SHA256 `c09f16ba31059a434ddd7f811e4f9608d4b4c4514cc80a5bf1ca33bee61e1107`.
- Seeds Jellyfin `SSO-Auth.xml` with plugin provider `authentik`, Authentik OIDC discovery, authorization enabled, `Jellyfin Users` and `Jellyfin Admins` roles, admin role `Jellyfin Admins`, role claim `groups`, and extra scope `groups`.
- Appends the Authentik-recommended SSO login button and CSS to Jellyfin branding when absent, without replacing existing branding.
- Added Jellyfin branch overlay placeholder bootstrap values for development smoke coverage without committing real branch secrets.

## Documentation Impact

- Added `docs/runbooks/jellyfin-authentik-sso.md` documenting Jellyfin web SSO behavior, Authentik group names, native-client fallback, and the Authentik integration guide source.
- Regenerated `docs/architecture.md` after adding Jellyfin secret/bootstrap resources.

## Checks

- PASS: owner workflow marker validation.
- PASS: owner implementation plan validation.
- PASS: owner attestation validation.
- PASS: `kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict` with dummy `cluster_domain` and `nfs_server`.
- PASS: `kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict` with dummy `cluster_domain` and `nfs_server`.
- PASS: `kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict` with dummy `cluster_domain`, `nfs_server`, and `branch_slug`.
- PASS: touched `secret.yaml` files decrypt with `sops -d >/dev/null`.
- PASS: Authentik and Jellyfin decrypted `JELLYFIN_OAUTH_CLIENT_SECRET` values match; values were not printed.
- PASS: production and branch bootstrap scripts compile with `py_compile`.
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `git diff --check`.

## Development Validation

- Attempted: `python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-authentik-sso --slug jellyfin-authentik-sso --push`.
- Result: branch push succeeded; remote `origin/codex/jellyfin-authentik-sso` points to `f633b51a78785d33a05295399e1f4950c469b114`.
- Result: development smoke did not reach cluster reconcile. The verifier stopped during `terraform -chdir=terraform/development plan -detailed-exitcode -input=false -no-color` because required local development credentials/variables were unavailable: `pm_api_url`, `pm_api_token_id`, `pm_api_token_secret`, `github_token`, `github_user`, `docker_user`, `docker_password`, and `talos_version`.
- Substitute evidence: local kustomize/Flux renders for Authentik, Jellyfin production, and Jellyfin branch overlay passed; SOPS decryptability and shared-secret equality passed; architecture check passed.

## Manual Acceptance Notes

- Not performed: Authentik app/provider after reconcile. Blocked by unavailable development Terraform variables before cluster reconcile.
- Not performed: Jellyfin pod plugin install. Blocked by unavailable development Terraform variables before cluster reconcile.
- Not performed: SSO start URL. Blocked by unavailable development Terraform variables before cluster reconcile.
- Not performed: `Jellyfin Users` login. Requires live Authentik/Jellyfin reconcile and group membership.
- Not performed: `Jellyfin Admins` admin mapping. Requires live Authentik/Jellyfin reconcile and group membership.

## Risk Notes

- Risk tier: high, due to authentication behavior and secret handling.
- TDD exception: manifests and encrypted secrets do not have a useful pre-change failing unit test seam; render, script compile, SOPS, architecture, and attempted development validation were used instead.
- Verifier must not approve until they are satisfied with the documented development validation exception or can rerun smoke with the missing credentials.
