### PR TITLE
feat(jellyfin): add native metrics dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,7 +109,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
 | `kubernetes/infra/monitoring/alloy` | `repositories.yaml`, `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-kubernetes.yaml`, `alert-rules-certificates.yaml`, `alert-rules-gateway-cilium.yaml`, `alert-rules-observability.yaml`, `alert-rules-apps.yaml`, `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml`, `alert-rules-synthetics.yaml` |
-| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml`, `synthetic-smoke-dashboard.yaml`, `monitoring-radar-dashboard.yaml` |
+| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `jellyfin-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml`, `synthetic-smoke-dashboard.yaml`, `monitoring-radar-dashboard.yaml` |
 | `kubernetes/infra/monitoring/grafana` | `namespace.yaml`, `repositories.yaml`, `app.yaml`, `secret.yaml`, `grafana-env.yaml`, `gateway.yaml`, `grafana-instance.yaml`, `folders.yaml`, `dashboards`, `alerting` |
 | `kubernetes/infra/monitoring/kube-state-metrics` | `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring` | `namespace.yaml`, `kube-state-metrics`, `snmp-exporter`, `pretty-discord-alerts` |
@@ -147,8 +147,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |
 | `HTTPRoute` | `grafana/monitoring` | `monitoring.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `grafana:80` |
-| `HTTPRoute` | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `jellyfin-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin-${branch_slug}:8096` |
-| `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `jellyfin:8096` |
+| `HTTPRoute` | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `jellyfin-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin-${branch_slug}-metrics-deny:8096` |
+| `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `jellyfin-metrics-deny:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |
 | `HTTPRoute` | `pihole/pihole-httproute` | `pihole.${cluster_domain}` | `gateway/internal/https-gateway` | `pihole-web:80` |
 | `HTTPRoute` | `whoami-${branch_slug}/whoami-${branch_slug}` | `whoami-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `whoami-${branch_slug}:80` |

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -76,6 +76,15 @@ spec:
         storageClass: nfs-csi-storage
       media:
         enabled: false
+    service:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8096"
+        prometheus.io/path: /metrics
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: false
     startupProbe:
       tcpSocket:
         port: http
@@ -130,8 +139,31 @@ spec:
     - matches:
         - path:
             type: PathPrefix
+            value: /metrics
+      backendRefs:
+        - name: jellyfin-${branch_slug}-metrics-deny
+          port: 8096
+          weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
             value: /
       backendRefs:
         - name: jellyfin-${branch_slug}
           port: 8096
           weight: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-${branch_slug}-metrics-deny
+  namespace: jellyfin-${branch_slug}
+  labels:
+    app.kubernetes.io/name: jellyfin
+    homelab.petebeegle.com/branch-slug: ${branch_slug}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8096
+      targetPort: 8096

--- a/kubernetes/apps/jellyfin/httproute.yaml
+++ b/kubernetes/apps/jellyfin/httproute.yaml
@@ -18,9 +18,28 @@ spec:
     - matches:
         - path:
             type: PathPrefix
+            value: /metrics
+      backendRefs:
+        - name: jellyfin-metrics-deny
+          port: 8096
+          weight: 1
+    - matches:
+        - path:
+            type: PathPrefix
             value: /
-
       backendRefs:
         - name: jellyfin
           port: 8096
           weight: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin-metrics-deny
+  namespace: jellyfin
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8096
+      targetPort: 8096

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -5,6 +5,15 @@ persistence:
     storageClass: nfs-csi-storage
   media:
     enabled: false
+service:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8096"
+    prometheus.io/path: /metrics
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: false
 startupProbe:
   tcpSocket:
     port: http

--- a/kubernetes/infra/monitoring/grafana/dashboards/jellyfin-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/jellyfin-dashboard.json
@@ -1,0 +1,491 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(max by (exported_namespace, pod) (kube_pod_status_phase{exported_namespace=\"jellyfin\", pod=~\"jellyfin-.*\", phase=\"Running\"} > bool 0)) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Running Pods",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(http_server_request_duration_seconds_count{namespace=\"jellyfin\", service=\"jellyfin\"}[5m])) OR sum(rate(http_requests_received_total{namespace=\"jellyfin\", service=\"jellyfin\"}[5m])) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_memory_usage_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR process_resident_memory_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Process Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{exported_namespace=\"jellyfin\", pod=~\"jellyfin-.*\"}[24h])) OR vector(0)",
+          "refId": "A"
+        }
+      ],
+      "title": "Restarts 24h",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_server_request_duration_seconds_bucket{namespace=\"jellyfin\", service=\"jellyfin\"}[5m]))) OR vector(0)",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{namespace=\"jellyfin\", service=\"jellyfin\"}[5m]))) OR vector(0)",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"jellyfin\", pod=~\"jellyfin-.*\", container!=\"\", container!=\"POD\"}[5m])) OR on() vector(0)",
+          "legendFormat": "{{pod}} container",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(process_cpu_time_seconds_total{namespace=\"jellyfin\", service=\"jellyfin\"}[5m]) OR rate(process_cpu_seconds_total{namespace=\"jellyfin\", service=\"jellyfin\"}[5m]) OR vector(0)",
+          "legendFormat": "process",
+          "refId": "B"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"jellyfin\", pod=~\"jellyfin-.*\", container!=\"\", container!=\"POD\"}) OR on() vector(0)",
+          "legendFormat": "{{pod}} working set",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_memory_usage_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR process_resident_memory_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR vector(0)",
+          "legendFormat": "process",
+          "refId": "B"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "dotnet_gc_heap_size_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR dotnet_gc_committed_memory_bytes{namespace=\"jellyfin\", service=\"jellyfin\"} OR vector(0)",
+          "legendFormat": "heap",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "dotnet_thread_pool_thread_count{namespace=\"jellyfin\", service=\"jellyfin\"} OR dotnet_threadpool_num_threads{namespace=\"jellyfin\", service=\"jellyfin\"} OR vector(0)",
+          "legendFormat": "thread pool",
+          "refId": "B"
+        }
+      ],
+      "title": ".NET Runtime",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "jellyfin",
+    "media",
+    "dotnet"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Jellyfin - Overview",
+  "uid": "jellyfin-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/infra/monitoring/grafana/dashboards/jellyfin-dashboard.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/jellyfin-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: jellyfin-overview
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "jellyfin"
+  configMapRef:
+    name: jellyfin-dashboard
+    key: dashboard.json

--- a/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
@@ -27,6 +27,12 @@ configMapGenerator:
       - dashboard.json=authentik-dashboard.json
     options:
       disableNameSuffixHash: true
+  - name: jellyfin-dashboard
+    namespace: grafana
+    files:
+      - dashboard.json=jellyfin-dashboard.json
+    options:
+      disableNameSuffixHash: true
   - name: observability-health-dashboard
     namespace: grafana
     files:
@@ -56,6 +62,7 @@ resources:
   - flux-dashboard.yaml
   - kubernetes-dashboard.yaml
   - authentik-dashboard.yaml
+  - jellyfin-dashboard.yaml
   - observability-health-dashboard.yaml
   - codex-operations-dashboard.yaml
   - synthetic-smoke-dashboard.yaml

--- a/kubernetes/infra/monitoring/grafana/folders.yaml
+++ b/kubernetes/infra/monitoring/grafana/folders.yaml
@@ -57,6 +57,17 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
+  name: jellyfin
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: "Jellyfin"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
   name: synthetics
   namespace: grafana
 spec:


### PR DESCRIPTION
# jellyfin-metrics-dashboard

## Summary

Enable Jellyfin native metrics scraping for Alloy, deny Gateway access to `/metrics`, and add a Grafana Jellyfin dashboard backed by the `prometheus` datasource.

## Important Changes

- Enabled Jellyfin chart metrics in production and branch overlay values with `metrics.enabled: true` and `metrics.serviceMonitor.enabled: false`.
- Added service annotations for Alloy service discovery: `prometheus.io/scrape: "true"`, `prometheus.io/port: "8096"`, and `prometheus.io/path: /metrics`.
- Added selectorless `jellyfin-metrics-deny` Services in production and branch overlay and placed `PathPrefix /metrics` HTTPRoute rules before the normal `/` route.
- Added Grafana folder `jellyfin`, `jellyfin-dashboard` ConfigMap wiring, `jellyfin-overview` GrafanaDashboard CR, and `jellyfin-dashboard.json`.
- Refreshed generated `docs/architecture.md` with `python3 tools/architecture/render.py --write` after `--check` reported staleness.

## Documentation Impact

Generated documentation changed: `docs/architecture.md` was updated by the architecture renderer to include the new Jellyfin dashboard manifest and revised Jellyfin route backend summary. No standalone prose docs were changed because the new behavior is fully represented in desired-state manifests and this PR summary records validation evidence.

## Validation Evidence

- PASS: `kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict` with exported production cluster vars from `kubernetes/clusters/production/cluster-vars.yaml`; rendered 152 lines to `/tmp/jellyfin-prod-render.yaml`.
- PASS: `kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict` with `branch_slug=jellyfin-metrics` and exported development cluster vars from `kubernetes/clusters/development/cluster-vars.yaml`; rendered 168 lines to `/tmp/jellyfin-branch-render.yaml`.
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`; rendered 8118 lines to `/tmp/grafana-dashboards-render.yaml`.
- PASS: `jq empty kubernetes/infra/monitoring/grafana/dashboards/jellyfin-dashboard.json`.
- PASS after regeneration: `python3 tools/architecture/render.py --check`.
- PASS: `git diff --check`.
- PASS: workflow marker, implementation plan, and owner attestation validators.
- PASS: `python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-metrics-dashboard --slug jellyfin-metrics --push`.
  - GitRepository fetched `codex/jellyfin-metrics-dashboard@sha1:775d1fdf1cb027bf72fb1a9e3e6fc70b6bfdf020`.
  - Flux Kustomization `branch-jellyfin-jellyfin-metrics` applied that revision.
  - HelmRelease `jellyfin-jellyfin-metrics` Ready.
  - Pod `jellyfin-jellyfin-metrics-58f5d59d88-xmrp8` Ready.
  - PVC `jellyfin-config-jellyfin-metrics` Bound with `nfs-csi-storage`.
  - Service and HTTPRoute checks passed.
  - Built-in HTTP service probe for `/` matched Jellyfin content.
  - Verifier cleanup deleted the branch Kustomization, namespace, and GitRepository.

## Manual Development Smoke

Deployed the same branch again with `--keep` for manual smoke, then cleaned it up manually.

- PASS: HTTPRoute `jellyfin-jellyfin-metrics` reported `Accepted=True` and `ResolvedRefs=True`; Cilium accepted the selectorless deny Service reference, so the tiny 404 workload fallback was not needed.
- PASS: direct service `/metrics` returned Prometheus text after Jellyfin completed startup; sample included `# TYPE dotnet_contention_total counter` and `dotnet_threadpool_num_threads`.
- PASS: Gateway-routed `/metrics` returned non-success `503 text/plain` with body `no healthy upstream`, proving the empty deny Service blocks external metrics access.
- PASS: Gateway-routed `/` via `https://jellyfin-jellyfin-metrics.development.lab.petebeegle.com/` and internal Gateway IP `192.168.30.225` followed to `200 text/html` and contained `Jellyfin`.
- PASS: manual cleanup removed `branch-jellyfin-jellyfin-metrics` and namespace `jellyfin-jellyfin-metrics`; both were NotFound after cleanup.

## Notes And Exceptions

- The first verifier attempt pushed the branch but stopped at Terraform plan because the sibling clone did not yet have ignored development Terraform variables. The ignored `terraform/development/terraform.tfvars` from the main checkout was installed into the sibling clone without logging contents, and the verifier then passed.
- Plain `flux envsubst --strict` requires variables to be exported for local rendering; the passing render checks used values from the repo cluster-vars manifests.
- Terraform plan completed with detailed-exitcode `2`, which the verifier accepts; no Terraform apply was run.

## Final State

- Final HEAD: `775d1fdf1cb027bf72fb1a9e3e6fc70b6bfdf020`
- Commit: `775d1fd feat(jellyfin): add native metrics dashboard`
- Branch pushed: `origin/codex/jellyfin-metrics-dashboard`
- PR not created: awaiting verifier approval for exact HEAD.
