### PR TITLE
fix(grafana): align monitoring radar health signals

### DIFF
--- a/kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/monitoring-radar-dashboard.json
@@ -283,7 +283,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(sum(gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) OR vector(0)) + (sum(gatewayapi_httproute_parent_accepted == bool 0) OR vector(0)) + (sum(gatewayapi_tlsroute_parent_accepted == bool 0) OR vector(0)) + (sum(gatewayapi_httproute_parent_resolved_refs == bool 0) OR vector(0)) + (sum(gatewayapi_tlsroute_parent_resolved_refs == bool 0) OR vector(0))",
+          "expr": "(sum((gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) unless on(exported_namespace, name, type) gatewayapi_gateway_status_condition{type=\"Programmed\",exported_namespace=\"gateway\",name=\"public\",reason=\"AddressNotAssigned\"}) OR vector(0)) + (sum(gatewayapi_httproute_parent_accepted == bool 0) OR vector(0)) + (sum(gatewayapi_tlsroute_parent_accepted == bool 0) OR vector(0)) + (sum(gatewayapi_httproute_parent_resolved_refs == bool 0) OR vector(0)) + (sum(gatewayapi_tlsroute_parent_resolved_refs == bool 0) OR vector(0))",
           "refId": "A"
         }
       ],
@@ -356,7 +356,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Pods currently Pending or Failed, excluding retained synthetic-smoke job history in the synthetics namespace.",
+      "description": "Pods currently Failed, excluding retained synthetic-smoke job history in the synthetics namespace.",
       "fieldConfig": {
         "defaults": {
           "mappings": [],
@@ -405,11 +405,11 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, pod, phase) ((kube_pod_status_phase{phase=\"Pending\"} or (kube_pod_status_phase{phase=\"Failed\"} unless (kube_pod_status_phase{phase=\"Failed\",namespace=\"synthetics\",pod=~\"synthetic-smoke-.+\"} or kube_pod_status_phase{exported_namespace=\"synthetics\",phase=\"Failed\",pod=~\"synthetic-smoke-.+\"}))) > bool 0)) OR vector(0)",
+          "expr": "sum(max by (namespace, pod) ((kube_pod_status_phase{phase=\"Failed\"} unless (kube_pod_status_phase{phase=\"Failed\",namespace=\"synthetics\",pod=~\"synthetic-smoke-.+\"} or kube_pod_status_phase{exported_namespace=\"synthetics\",phase=\"Failed\",pod=~\"synthetic-smoke-.+\"})) > bool 0)) OR vector(0)",
           "refId": "A"
         }
       ],
-      "title": "Failed Or Pending Pods",
+      "title": "Failed Pods",
       "type": "stat"
     },
     {
@@ -1411,7 +1411,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) OR vector(0)",
+          "expr": "sum((gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) unless on(exported_namespace, name, type) gatewayapi_gateway_status_condition{type=\"Programmed\",exported_namespace=\"gateway\",name=\"public\",reason=\"AddressNotAssigned\"}) OR vector(0)",
           "refId": "A"
         }
       ],
@@ -1659,7 +1659,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) OR vector(0)",
+          "expr": "sum((gatewayapi_gateway_status_condition{type=\"Programmed\"} == bool 0) unless on(exported_namespace, name, type) gatewayapi_gateway_status_condition{type=\"Programmed\",exported_namespace=\"gateway\",name=\"public\",reason=\"AddressNotAssigned\"}) OR vector(0)",
           "legendFormat": "Gateways not programmed",
           "refId": "A"
         },


### PR DESCRIPTION
## Summary

Align the Monitoring Radar dashboard health signals with the fixed Kubernetes dashboard and Gateway/Cilium alert semantics.

## Important changes

- Panel 6 is now titled `Failed Pods`, describes only Failed-phase pods, and uses the exact failed-pod PromQL from Kubernetes dashboard panel 102 while preserving the retained synthetic-smoke job-history exclusion.
- Gateway Programmed checks in Monitoring Radar panels 4, 25, and 29 target A now exclude the expected `gateway/public` `AddressNotAssigned` condition, matching the Gateway/Cilium alert rule exception.
- Route acceptance and resolved-ref expressions were left unchanged.

## Documentation impact

No documentation changes. This is a dashboard behavior-only correction, with no runbook, generated architecture, or decision-record behavior change needed.

## Tests and evidence

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- Parsed all dashboard JSON files under `kubernetes/infra/monitoring/grafana/dashboards`; all parsed successfully.
- Asserted Monitoring Radar panel 6 expression exactly equals Kubernetes dashboard panel 102 expression; passed.
- Asserted Monitoring Radar gateway Programmed expressions include the same `gateway/public` `AddressNotAssigned` exception as `alert-rules-gateway-cilium.yaml`; passed.
- `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` passed and rendered the dashboard bundle.
- `python3 tools/architecture/render.py --check` passed.

## Development validation

Risk tier: medium.

Development validation exception: the development cluster omits Grafana/monitoring, so there is no representative live Grafana dashboard smoke path for this change. Substitute evidence is the local dashboard JSON parse, exact expression parity assertion, Gateway/Cilium alert-rule exception assertion, `kubectl kustomize` render, and architecture check above.
