### PR TITLE
refactor: split renderer modules

### DIFF
--- a/tools/architecture/architecture/__init__.py
+++ b/tools/architecture/architecture/__init__.py
@@ -1,0 +1,49 @@
+"""Importable architecture renderer package."""
+
+from .flux import cluster_flux_kustomizations, flux_table, kustomize_table
+from .gateway import gateway_routes
+from .kubernetes import (
+    Manifest,
+    cluster_vars,
+    component,
+    kustomize_resources,
+    lines_after,
+    list_maps,
+    list_scalars,
+    manifests_under,
+    metadata_value,
+    read,
+    relative,
+    scalar,
+    secret_relationships,
+    split_documents,
+)
+from .markdown import render
+from .storage import storage_relationships
+from .terraform import hcl_attr, hcl_blocks, terraform_relationships
+
+__all__ = [
+    "Manifest",
+    "cluster_flux_kustomizations",
+    "cluster_vars",
+    "component",
+    "flux_table",
+    "gateway_routes",
+    "hcl_attr",
+    "hcl_blocks",
+    "kustomize_resources",
+    "kustomize_table",
+    "lines_after",
+    "list_maps",
+    "list_scalars",
+    "manifests_under",
+    "metadata_value",
+    "read",
+    "relative",
+    "render",
+    "scalar",
+    "secret_relationships",
+    "split_documents",
+    "storage_relationships",
+    "terraform_relationships",
+]

--- a/tools/architecture/architecture/flux.py
+++ b/tools/architecture/architecture/flux.py
@@ -1,0 +1,41 @@
+"""Flux and Kustomize relationship extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .kubernetes import Manifest, kustomize_resources, list_maps, manifests_under, read, relative, scalar
+
+
+def cluster_flux_kustomizations(root: Path, *, repo_root: Path) -> list[Manifest]:
+    items = [
+        item
+        for item in manifests_under(root / "infra", root / "apps", repo_root=repo_root)
+        if item.kind == "Kustomization"
+    ]
+    return sorted(items, key=lambda item: (item.relpath, item.name))
+
+
+def flux_table(items: list[tuple[str, Manifest]]) -> list[str]:
+    rows: list[str] = []
+    for cluster, item in items:
+        path_value = scalar(item.text, "path")
+        depends = ", ".join(f"`{dep.get('name', '')}`" for dep in list_maps(item.text, "dependsOn")) or "(none)"
+        substitution = ", ".join(ref.get("name", "") for ref in list_maps(item.text, "substituteFrom")) or "(none)"
+        decrypts = "sops" if "decryption:" in item.text and "provider: sops" in item.text else "no"
+        rows.append(
+            f"| `{cluster}` | `{item.name}` | `{path_value}` | {depends} | `{substitution}` | `{decrypts}` |"
+        )
+    return rows
+
+
+def kustomize_table(root: Path, *, repo_root: Path) -> list[str]:
+    rows: list[str] = []
+    for path in sorted(root.rglob("kustomization.yaml")):
+        resources = kustomize_resources(path)
+        if not resources:
+            continue
+        rows.append(
+            f"| `{relative(path.parent, root=repo_root)}` | {', '.join(f'`{item}`' for item in resources)} |"
+        )
+    return rows

--- a/tools/architecture/architecture/gateway.py
+++ b/tools/architecture/architecture/gateway.py
@@ -1,0 +1,33 @@
+"""Gateway API route extraction for the architecture renderer."""
+
+from __future__ import annotations
+
+from .kubernetes import Manifest, list_maps, list_scalars
+
+
+def gateway_routes(manifests: list[Manifest]) -> list[str]:
+    rows: list[str] = []
+    for item in manifests:
+        if item.kind not in {"HTTPRoute", "TLSRoute"}:
+            continue
+        parents = list_maps(item.text, "parentRefs")
+        parent = ", ".join(
+            "/".join(
+                part
+                for part in [
+                    ref.get("namespace") or item.namespace or "default",
+                    ref.get("name", ""),
+                    ref.get("sectionName", ""),
+                ]
+                if part
+            )
+            for ref in parents
+        )
+        hosts = ", ".join(list_scalars(item.text, "hostnames")) or "(none)"
+        backends = ", ".join(
+            f"{ref.get('name', '?')}:{ref.get('port', '?')}" for ref in list_maps(item.text, "backendRefs")
+        )
+        rows.append(
+            f"| `{item.kind}` | `{item.namespace}/{item.name}` | `{hosts}` | `{parent or '(none)'}` | `{backends or '(none)'}` |"
+        )
+    return sorted(rows)

--- a/tools/architecture/architecture/kubernetes.py
+++ b/tools/architecture/architecture/kubernetes.py
@@ -1,0 +1,154 @@
+"""Kubernetes manifest extraction helpers for the architecture renderer."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Manifest:
+    path: Path
+    text: str
+    kind: str
+    name: str
+    namespace: str
+    root: Path = field(default_factory=lambda: Path(__file__).resolve().parents[3])
+
+    @property
+    def relpath(self) -> str:
+        return self.path.relative_to(self.root).as_posix()
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def relative(path: Path, *, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def split_documents(text: str) -> list[str]:
+    return [doc.strip() for doc in re.split(r"(?m)^---\s*$", text) if doc.strip()]
+
+
+def scalar(text: str, key: str) -> str:
+    match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*(.+?)\s*$", text)
+    if not match:
+        return ""
+    return match.group(1).strip().strip('"')
+
+
+def metadata_value(text: str, key: str) -> str:
+    match = re.search(r"(?ms)^metadata:\n(?P<body>(?:  .+\n?)*)", text)
+    if not match:
+        return ""
+    return scalar(match.group("body"), key)
+
+
+def lines_after(lines: list[str], key: str) -> list[str]:
+    for index, line in enumerate(lines):
+        if line.strip() in {f"{key}:", f"- {key}:"}:
+            indent = len(line) - len(line.lstrip())
+            block: list[str] = []
+            for child in lines[index + 1 :]:
+                if not child.strip():
+                    continue
+                child_indent = len(child) - len(child.lstrip())
+                if child_indent <= indent:
+                    break
+                block.append(child)
+            return block
+    return []
+
+
+def list_scalars(text: str, key: str) -> list[str]:
+    values: list[str] = []
+    for line in lines_after(text.splitlines(), key):
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            values.append(stripped[2:].strip().strip('"'))
+    return values
+
+
+def list_maps(text: str, key: str) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in lines_after(text.splitlines(), key):
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            if current:
+                items.append(current)
+            current = {}
+            stripped = stripped[2:].strip()
+            if ":" in stripped:
+                k, v = stripped.split(":", 1)
+                current[k.strip()] = v.strip().strip('"')
+        elif current is not None and ":" in stripped:
+            k, v = stripped.split(":", 1)
+            current[k.strip()] = v.strip().strip('"')
+    if current:
+        items.append(current)
+    return items
+
+
+def manifests_under(*roots: Path, repo_root: Path) -> list[Manifest]:
+    manifests: list[Manifest] = []
+    for root in roots:
+        for path in sorted(root.rglob("*.yaml")):
+            text = read(path)
+            for doc in split_documents(text):
+                kind = scalar(doc, "kind")
+                name = metadata_value(doc, "name")
+                namespace = metadata_value(doc, "namespace")
+                if kind and name:
+                    manifests.append(Manifest(path, doc, kind, name, namespace, repo_root))
+    return manifests
+
+
+def kustomize_resources(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return list_scalars(read(path), "resources")
+
+
+def cluster_vars(root: Path) -> list[tuple[str, str]]:
+    path = root / "cluster-vars.yaml"
+    if not path.exists():
+        return []
+    text = read(path)
+    body = re.search(r"(?ms)^data:\n(?P<body>(?:  .+\n?)*)", text)
+    if not body:
+        return []
+    values: list[tuple[str, str]] = []
+    for line in body.group("body").splitlines():
+        stripped = line.strip()
+        if ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        values.append((key.strip(), value.strip().strip('"')))
+    return sorted(values)
+
+
+def component(path: Path, *, root: Path) -> str:
+    parts = path.relative_to(root).parts
+    if len(parts) >= 3 and parts[0] == "kubernetes" and parts[1] in {"apps", "infra"}:
+        if parts[1] == "apps":
+            return parts[2]
+        if parts[2] in {"controllers", "monitoring", "network"} and len(parts) >= 4:
+            return "/".join(parts[2:4])
+        return parts[2]
+    return path.parent.name
+
+
+def secret_relationships(manifests: list[Manifest], *, root: Path) -> list[str]:
+    rows: list[str] = []
+    for item in manifests:
+        if item.kind != "Secret":
+            continue
+        encrypted = "yes" if "ENC[" in item.text or re.search(r"(?m)^sops:", item.text) else "unknown"
+        rows.append(
+            f"| `{component(item.path, root=root)}` | `{item.namespace or 'default'}/{item.name}` | `{encrypted}` | `{item.relpath}` |"
+        )
+    return sorted(rows)

--- a/tools/architecture/architecture/markdown.py
+++ b/tools/architecture/architecture/markdown.py
@@ -1,0 +1,151 @@
+"""Markdown rendering for the generated architecture document."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .flux import cluster_flux_kustomizations, flux_table, kustomize_table
+from .gateway import gateway_routes
+from .kubernetes import Manifest, cluster_vars, kustomize_resources, manifests_under, relative, secret_relationships
+from .storage import storage_relationships
+from .terraform import terraform_relationships
+
+
+def render(
+    *,
+    root: Path,
+    clusters: dict[str, Path],
+    terraform_roots: dict[str, Path],
+) -> str:
+    manifests = manifests_under(root / "kubernetes", repo_root=root)
+    flux_items: list[tuple[str, Manifest]] = []
+    for cluster, cluster_root in clusters.items():
+        flux_items.extend(
+            (cluster, item)
+            for item in cluster_flux_kustomizations(cluster_root, repo_root=root)
+        )
+    app_flux = [(cluster, item) for cluster, item in flux_items if "/apps/" in item.relpath]
+    infra_flux = [(cluster, item) for cluster, item in flux_items if "/infra/" in item.relpath]
+
+    lines: list[str] = [
+        "# Architecture",
+        "",
+        "<!-- GENERATED: do not edit by hand. Run `python3 tools/architecture/render.py --write`. -->",
+        "",
+        "This document is generated for agentic repo navigation. It records relationships that must stay aligned with the Kubernetes, Flux, and Terraform source of truth.",
+        "",
+        "## Cluster Entrypoints",
+        "",
+    ]
+    for cluster, cluster_root in clusters.items():
+        lines.extend(
+            [
+                f"### {cluster.title()}",
+                "",
+                f"- Root Kustomization: `{relative(cluster_root / 'kustomization.yaml', root=root)}`.",
+                f"- Root resources: {', '.join(f'`{item}`' for item in kustomize_resources(cluster_root / 'kustomization.yaml'))}.",
+                f"- Infra activation list: {', '.join(f'`{item}`' for item in kustomize_resources(cluster_root / 'infra' / 'kustomization.yaml'))}.",
+                f"- App activation list: {', '.join(f'`{item}`' for item in kustomize_resources(cluster_root / 'apps' / 'kustomization.yaml'))}.",
+                "",
+            ]
+        )
+        branch_templates = cluster_root / "branches" / "kustomization.yaml"
+        if branch_templates.exists():
+            lines.append(
+                f"- Branch environment templates: {', '.join(f'`{item}`' for item in kustomize_resources(branch_templates))}."
+            )
+            lines.append("")
+
+    lines.extend(
+        [
+            "### Flux Substitution Variables",
+            "",
+            "| Cluster | Variable | Value |",
+            "| --- | --- | --- |",
+        ]
+    )
+    for cluster, cluster_root in clusters.items():
+        lines.extend(f"| `{cluster}` | `{key}` | `{value}` |" for key, value in cluster_vars(cluster_root))
+
+    lines.extend(
+        [
+            "",
+            "## Flux Dependencies",
+            "",
+            "### Infrastructure",
+            "",
+            "| Cluster | Kustomization | Path | Depends on | Substitute from | SOPS |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(flux_table(infra_flux))
+    lines.extend(
+        [
+            "",
+            "### Applications",
+            "",
+            "| Cluster | Kustomization | Path | Depends on | Substitute from | SOPS |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(flux_table(app_flux))
+
+    lines.extend(
+        [
+            "",
+            "## Kustomize Resource Relationships",
+            "",
+            "| Component path | Listed resources |",
+            "| --- | --- |",
+        ]
+    )
+    lines.extend(kustomize_table(root / "kubernetes" / "infra", repo_root=root))
+    lines.extend(kustomize_table(root / "kubernetes" / "apps", repo_root=root))
+
+    lines.extend(
+        [
+            "",
+            "## Gateway Routes",
+            "",
+            "| Kind | Route | Hostnames | Parent Gateway | Backend refs |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(gateway_routes(manifests))
+
+    lines.extend(
+        [
+            "",
+            "## Storage Relationships",
+            "",
+            "| Source | Owner | StorageClass | Path |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(storage_relationships(manifests, root=root))
+
+    lines.extend(
+        [
+            "",
+            "## Secret Manifests",
+            "",
+            "This lists secret manifest presence only. Secret values are not rendered.",
+            "",
+            "| Component | Secret | SOPS encrypted | Path |",
+            "| --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(secret_relationships(manifests, root=root))
+
+    lines.extend(
+        [
+            "",
+            "## Terraform Substrate",
+            "",
+            "| Root | Type | Name | Source | References |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    lines.extend(terraform_relationships(terraform_roots))
+    lines.append("")
+    return "\n".join(lines)

--- a/tools/architecture/architecture/storage.py
+++ b/tools/architecture/architecture/storage.py
@@ -1,0 +1,27 @@
+"""Storage and PVC relationship extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .kubernetes import Manifest, component, read, relative, scalar
+
+
+def storage_relationships(manifests: list[Manifest], *, root: Path) -> list[str]:
+    rows: set[str] = set()
+    for item in manifests:
+        if item.kind == "PersistentVolumeClaim":
+            storage_class = scalar(item.text, "storageClassName")
+            if storage_class:
+                rows.add(f"| PVC | `{item.namespace}/{item.name}` | `{storage_class}` | `{item.relpath}` |")
+        if item.kind == "HelmRelease" and "nfs-csi-storage" in item.text:
+            rows.add(
+                f"| HelmRelease values | `{item.namespace or 'default'}/{item.name}` | `nfs-csi-storage` | `{item.relpath}` |"
+            )
+    for path in sorted((root / "kubernetes").rglob("values.yaml")):
+        text = read(path)
+        if "nfs-csi-storage" in text:
+            rows.add(
+                f"| Values file | `{component(path, root=root)}` | `nfs-csi-storage` | `{relative(path, root=root)}` |"
+            )
+    return sorted(rows)

--- a/tools/architecture/architecture/terraform.py
+++ b/tools/architecture/architecture/terraform.py
@@ -1,0 +1,51 @@
+"""Regex-based Terraform relationship extraction."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .kubernetes import read
+
+
+def hcl_attr(text: str, key: str) -> str:
+    match = re.search(rf'(?m)^\s*{re.escape(key)}\s*=\s*"([^"]*)"', text)
+    return match.group(1) if match else ""
+
+
+def hcl_blocks(text: str, block_type: str) -> list[tuple[str, str]]:
+    blocks: list[tuple[str, str]] = []
+    lines = text.splitlines()
+    index = 0
+    pattern = re.compile(rf'^\s*{block_type}\s+"([^"]+)"(?:\s+"([^"]+)")?\s*\{{')
+    while index < len(lines):
+        match = pattern.match(lines[index])
+        if not match:
+            index += 1
+            continue
+        name = match.group(1) if match.group(2) is None else f"{match.group(1)}.{match.group(2)}"
+        start = index
+        depth = lines[index].count("{") - lines[index].count("}")
+        index += 1
+        while index < len(lines) and depth > 0:
+            depth += lines[index].count("{") - lines[index].count("}")
+            index += 1
+        blocks.append((name, "\n".join(lines[start:index])))
+    return blocks
+
+
+def terraform_relationships(terraform_roots: dict[str, Path]) -> list[str]:
+    rows: list[str] = []
+    for root_name, root in terraform_roots.items():
+        main_path = root / "main.tf"
+        if not main_path.exists():
+            continue
+        main = read(main_path)
+        for name, body in hcl_blocks(main, "module"):
+            source = hcl_attr(body, "source")
+            deps = ", ".join(re.findall(r"module\.([A-Za-z0-9_-]+)", body)) or "(none)"
+            rows.append(f"| `{root_name}` | Module | `{name}` | `{source}` | `{deps}` |")
+        for name, body in hcl_blocks(main, "resource"):
+            refs = ", ".join(sorted(set(re.findall(r"module\.([A-Za-z0-9_-]+)", body)))) or "(none)"
+            rows.append(f"| `{root_name}` | Root resource | `{name}` | `(root)` | `{refs}` |")
+    return sorted(rows)

--- a/tools/architecture/render.py
+++ b/tools/architecture/render.py
@@ -5,10 +5,37 @@ from __future__ import annotations
 
 import argparse
 import difflib
-import re
 import sys
-from dataclasses import dataclass
 from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from architecture.flux import cluster_flux_kustomizations as _cluster_flux_kustomizations
+from architecture.flux import flux_table, kustomize_table as _kustomize_table
+from architecture.gateway import gateway_routes
+from architecture.kubernetes import (
+    Manifest,
+    cluster_vars,
+    component as _component,
+    kustomize_resources,
+    lines_after,
+    list_maps,
+    list_scalars,
+    manifests_under as _manifests_under,
+    metadata_value,
+    read,
+    relative as _relative,
+    scalar,
+    secret_relationships as _secret_relationships,
+    split_documents,
+)
+from architecture.markdown import render as _render
+from architecture.storage import storage_relationships as _storage_relationships
+from architecture.terraform import hcl_attr, hcl_blocks
+from architecture.terraform import terraform_relationships as _terraform_relationships
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -23,405 +50,40 @@ TERRAFORM_ROOTS = {
 }
 
 
-@dataclass(frozen=True)
-class Manifest:
-    path: Path
-    text: str
-    kind: str
-    name: str
-    namespace: str
-
-    @property
-    def relpath(self) -> str:
-        return self.path.relative_to(ROOT).as_posix()
-
-
-def read(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
 def relative(path: Path) -> str:
-    return path.relative_to(ROOT).as_posix()
-
-
-def split_documents(text: str) -> list[str]:
-    return [doc.strip() for doc in re.split(r"(?m)^---\s*$", text) if doc.strip()]
-
-
-def scalar(text: str, key: str) -> str:
-    match = re.search(rf"(?m)^\s*{re.escape(key)}:\s*(.+?)\s*$", text)
-    if not match:
-        return ""
-    return match.group(1).strip().strip('"')
-
-
-def metadata_value(text: str, key: str) -> str:
-    match = re.search(r"(?ms)^metadata:\n(?P<body>(?:  .+\n?)*)", text)
-    if not match:
-        return ""
-    return scalar(match.group("body"), key)
-
-
-def lines_after(lines: list[str], key: str) -> list[str]:
-    for index, line in enumerate(lines):
-        if line.strip() in {f"{key}:", f"- {key}:"}:
-            indent = len(line) - len(line.lstrip())
-            block: list[str] = []
-            for child in lines[index + 1 :]:
-                if not child.strip():
-                    continue
-                child_indent = len(child) - len(child.lstrip())
-                if child_indent <= indent:
-                    break
-                block.append(child)
-            return block
-    return []
-
-
-def list_scalars(text: str, key: str) -> list[str]:
-    values: list[str] = []
-    for line in lines_after(text.splitlines(), key):
-        stripped = line.strip()
-        if stripped.startswith("- "):
-            values.append(stripped[2:].strip().strip('"'))
-    return values
-
-
-def list_maps(text: str, key: str) -> list[dict[str, str]]:
-    items: list[dict[str, str]] = []
-    current: dict[str, str] | None = None
-    for line in lines_after(text.splitlines(), key):
-        stripped = line.strip()
-        if stripped.startswith("- "):
-            if current:
-                items.append(current)
-            current = {}
-            stripped = stripped[2:].strip()
-            if ":" in stripped:
-                k, v = stripped.split(":", 1)
-                current[k.strip()] = v.strip().strip('"')
-        elif current is not None and ":" in stripped:
-            k, v = stripped.split(":", 1)
-            current[k.strip()] = v.strip().strip('"')
-    if current:
-        items.append(current)
-    return items
+    return _relative(path, root=ROOT)
 
 
 def manifests_under(*roots: Path) -> list[Manifest]:
-    manifests: list[Manifest] = []
-    for root in roots:
-        for path in sorted(root.rglob("*.yaml")):
-            text = read(path)
-            for doc in split_documents(text):
-                kind = scalar(doc, "kind")
-                name = metadata_value(doc, "name")
-                namespace = metadata_value(doc, "namespace")
-                if kind and name:
-                    manifests.append(Manifest(path, doc, kind, name, namespace))
-    return manifests
+    return _manifests_under(*roots, repo_root=ROOT)
 
 
 def cluster_flux_kustomizations(root: Path) -> list[Manifest]:
-    items = [
-        item
-        for item in manifests_under(root / "infra", root / "apps")
-        if item.kind == "Kustomization"
-    ]
-    return sorted(items, key=lambda item: (item.relpath, item.name))
-
-
-def kustomize_resources(path: Path) -> list[str]:
-    if not path.exists():
-        return []
-    return list_scalars(read(path), "resources")
-
-
-def cluster_vars(root: Path) -> list[tuple[str, str]]:
-    path = root / "cluster-vars.yaml"
-    if not path.exists():
-        return []
-    text = read(path)
-    body = re.search(r"(?ms)^data:\n(?P<body>(?:  .+\n?)*)", text)
-    if not body:
-        return []
-    values: list[tuple[str, str]] = []
-    for line in body.group("body").splitlines():
-        stripped = line.strip()
-        if ":" not in stripped:
-            continue
-        key, value = stripped.split(":", 1)
-        values.append((key.strip(), value.strip().strip('"')))
-    return sorted(values)
+    return _cluster_flux_kustomizations(root, repo_root=ROOT)
 
 
 def component(path: Path) -> str:
-    parts = path.relative_to(ROOT).parts
-    if len(parts) >= 3 and parts[0] == "kubernetes" and parts[1] in {"apps", "infra"}:
-        if parts[1] == "apps":
-            return parts[2]
-        if parts[2] in {"controllers", "monitoring", "network"} and len(parts) >= 4:
-            return "/".join(parts[2:4])
-        return parts[2]
-    return path.parent.name
-
-
-def gateway_routes(manifests: list[Manifest]) -> list[str]:
-    rows: list[str] = []
-    for item in manifests:
-        if item.kind not in {"HTTPRoute", "TLSRoute"}:
-            continue
-        parents = list_maps(item.text, "parentRefs")
-        parent = ", ".join(
-            "/".join(
-                part
-                for part in [
-                    ref.get("namespace") or item.namespace or "default",
-                    ref.get("name", ""),
-                    ref.get("sectionName", ""),
-                ]
-                if part
-            )
-            for ref in parents
-        )
-        hosts = ", ".join(list_scalars(item.text, "hostnames")) or "(none)"
-        backends = ", ".join(
-            f"{ref.get('name', '?')}:{ref.get('port', '?')}" for ref in list_maps(item.text, "backendRefs")
-        )
-        rows.append(
-            f"| `{item.kind}` | `{item.namespace}/{item.name}` | `{hosts}` | `{parent or '(none)'}` | `{backends or '(none)'}` |"
-        )
-    return sorted(rows)
+    return _component(path, root=ROOT)
 
 
 def storage_relationships(manifests: list[Manifest]) -> list[str]:
-    rows: set[str] = set()
-    for item in manifests:
-        if item.kind == "PersistentVolumeClaim":
-            storage_class = scalar(item.text, "storageClassName")
-            if storage_class:
-                rows.add(
-                    f"| PVC | `{item.namespace}/{item.name}` | `{storage_class}` | `{item.relpath}` |"
-                )
-        if item.kind == "HelmRelease" and "nfs-csi-storage" in item.text:
-            rows.add(
-                f"| HelmRelease values | `{item.namespace or 'default'}/{item.name}` | `nfs-csi-storage` | `{item.relpath}` |"
-            )
-    for path in sorted((ROOT / "kubernetes").rglob("values.yaml")):
-        text = read(path)
-        if "nfs-csi-storage" in text:
-            rows.add(f"| Values file | `{component(path)}` | `nfs-csi-storage` | `{relative(path)}` |")
-    return sorted(rows)
+    return _storage_relationships(manifests, root=ROOT)
 
 
 def secret_relationships(manifests: list[Manifest]) -> list[str]:
-    rows: list[str] = []
-    for item in manifests:
-        if item.kind != "Secret":
-            continue
-        encrypted = "yes" if "ENC[" in item.text or re.search(r"(?m)^sops:", item.text) else "unknown"
-        rows.append(
-            f"| `{component(item.path)}` | `{item.namespace or 'default'}/{item.name}` | `{encrypted}` | `{item.relpath}` |"
-        )
-    return sorted(rows)
-
-
-def flux_table(items: list[tuple[str, Manifest]]) -> list[str]:
-    rows: list[str] = []
-    for cluster, item in items:
-        path_value = scalar(item.text, "path")
-        depends = ", ".join(f"`{dep.get('name', '')}`" for dep in list_maps(item.text, "dependsOn")) or "(none)"
-        substitution = ", ".join(ref.get("name", "") for ref in list_maps(item.text, "substituteFrom")) or "(none)"
-        decrypts = "sops" if "decryption:" in item.text and "provider: sops" in item.text else "no"
-        rows.append(
-            f"| `{cluster}` | `{item.name}` | `{path_value}` | {depends} | `{substitution}` | `{decrypts}` |"
-        )
-    return rows
+    return _secret_relationships(manifests, root=ROOT)
 
 
 def kustomize_table(root: Path) -> list[str]:
-    rows: list[str] = []
-    for path in sorted(root.rglob("kustomization.yaml")):
-        resources = kustomize_resources(path)
-        if not resources:
-            continue
-        rows.append(f"| `{relative(path.parent)}` | {', '.join(f'`{item}`' for item in resources)} |")
-    return rows
-
-
-def hcl_attr(text: str, key: str) -> str:
-    match = re.search(rf'(?m)^\s*{re.escape(key)}\s*=\s*"([^"]*)"', text)
-    return match.group(1) if match else ""
-
-
-def hcl_blocks(text: str, block_type: str) -> list[tuple[str, str]]:
-    blocks: list[tuple[str, str]] = []
-    lines = text.splitlines()
-    index = 0
-    pattern = re.compile(rf'^\s*{block_type}\s+"([^"]+)"(?:\s+"([^"]+)")?\s*\{{')
-    while index < len(lines):
-        match = pattern.match(lines[index])
-        if not match:
-            index += 1
-            continue
-        name = match.group(1) if match.group(2) is None else f"{match.group(1)}.{match.group(2)}"
-        start = index
-        depth = lines[index].count("{") - lines[index].count("}")
-        index += 1
-        while index < len(lines) and depth > 0:
-            depth += lines[index].count("{") - lines[index].count("}")
-            index += 1
-        blocks.append((name, "\n".join(lines[start:index])))
-    return blocks
+    return _kustomize_table(root, repo_root=ROOT)
 
 
 def terraform_relationships() -> list[str]:
-    rows: list[str] = []
-    for root_name, root in TERRAFORM_ROOTS.items():
-        main_path = root / "main.tf"
-        if not main_path.exists():
-            continue
-        main = read(main_path)
-        for name, body in hcl_blocks(main, "module"):
-            source = hcl_attr(body, "source")
-            deps = ", ".join(re.findall(r"module\.([A-Za-z0-9_-]+)", body)) or "(none)"
-            rows.append(f"| `{root_name}` | Module | `{name}` | `{source}` | `{deps}` |")
-        for name, body in hcl_blocks(main, "resource"):
-            refs = ", ".join(sorted(set(re.findall(r"module\.([A-Za-z0-9_-]+)", body)))) or "(none)"
-            rows.append(f"| `{root_name}` | Root resource | `{name}` | `(root)` | `{refs}` |")
-    return sorted(rows)
+    return _terraform_relationships(TERRAFORM_ROOTS)
 
 
 def render() -> str:
-    manifests = manifests_under(ROOT / "kubernetes")
-    flux_items: list[tuple[str, Manifest]] = []
-    for cluster, root in CLUSTERS.items():
-        flux_items.extend((cluster, item) for item in cluster_flux_kustomizations(root))
-    app_flux = [(cluster, item) for cluster, item in flux_items if "/apps/" in item.relpath]
-    infra_flux = [(cluster, item) for cluster, item in flux_items if "/infra/" in item.relpath]
-
-    lines: list[str] = [
-        "# Architecture",
-        "",
-        "<!-- GENERATED: do not edit by hand. Run `python3 tools/architecture/render.py --write`. -->",
-        "",
-        "This document is generated for agentic repo navigation. It records relationships that must stay aligned with the Kubernetes, Flux, and Terraform source of truth.",
-        "",
-        "## Cluster Entrypoints",
-        "",
-    ]
-    for cluster, root in CLUSTERS.items():
-        lines.extend(
-            [
-                f"### {cluster.title()}",
-                "",
-                f"- Root Kustomization: `{relative(root / 'kustomization.yaml')}`.",
-                f"- Root resources: {', '.join(f'`{item}`' for item in kustomize_resources(root / 'kustomization.yaml'))}.",
-                f"- Infra activation list: {', '.join(f'`{item}`' for item in kustomize_resources(root / 'infra' / 'kustomization.yaml'))}.",
-                f"- App activation list: {', '.join(f'`{item}`' for item in kustomize_resources(root / 'apps' / 'kustomization.yaml'))}.",
-                "",
-            ]
-        )
-        branch_templates = root / "branches" / "kustomization.yaml"
-        if branch_templates.exists():
-            lines.append(
-                f"- Branch environment templates: {', '.join(f'`{item}`' for item in kustomize_resources(branch_templates))}."
-            )
-            lines.append("")
-
-    lines.extend(
-        [
-            "### Flux Substitution Variables",
-        "",
-            "| Cluster | Variable | Value |",
-            "| --- | --- | --- |",
-        ]
-    )
-    for cluster, root in CLUSTERS.items():
-        lines.extend(f"| `{cluster}` | `{key}` | `{value}` |" for key, value in cluster_vars(root))
-
-    lines.extend(
-        [
-            "",
-            "## Flux Dependencies",
-            "",
-            "### Infrastructure",
-            "",
-            "| Cluster | Kustomization | Path | Depends on | Substitute from | SOPS |",
-            "| --- | --- | --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(flux_table(infra_flux))
-    lines.extend(
-        [
-            "",
-            "### Applications",
-            "",
-            "| Cluster | Kustomization | Path | Depends on | Substitute from | SOPS |",
-            "| --- | --- | --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(flux_table(app_flux))
-
-    lines.extend(
-        [
-            "",
-            "## Kustomize Resource Relationships",
-            "",
-            "| Component path | Listed resources |",
-            "| --- | --- |",
-        ]
-    )
-    lines.extend(kustomize_table(ROOT / "kubernetes" / "infra"))
-    lines.extend(kustomize_table(ROOT / "kubernetes" / "apps"))
-
-    lines.extend(
-        [
-            "",
-            "## Gateway Routes",
-            "",
-            "| Kind | Route | Hostnames | Parent Gateway | Backend refs |",
-            "| --- | --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(gateway_routes(manifests))
-
-    lines.extend(
-        [
-            "",
-            "## Storage Relationships",
-            "",
-            "| Source | Owner | StorageClass | Path |",
-            "| --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(storage_relationships(manifests))
-
-    lines.extend(
-        [
-            "",
-            "## Secret Manifests",
-            "",
-            "This lists secret manifest presence only. Secret values are not rendered.",
-            "",
-            "| Component | Secret | SOPS encrypted | Path |",
-            "| --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(secret_relationships(manifests))
-
-    lines.extend(
-        [
-            "",
-            "## Terraform Substrate",
-            "",
-            "| Root | Type | Name | Source | References |",
-            "| --- | --- | --- | --- | --- |",
-        ]
-    )
-    lines.extend(terraform_relationships())
-    lines.append("")
-    return "\n".join(lines)
+    return _render(root=ROOT, clusters=CLUSTERS, terraform_roots=TERRAFORM_ROOTS)
 
 
 def check(expected: str) -> int:

--- a/tools/context-pack/context_pack/__init__.py
+++ b/tools/context-pack/context_pack/__init__.py
@@ -1,0 +1,32 @@
+"""Importable context-pack renderer package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+TOOLS_LIB = Path(__file__).resolve().parents[2] / "lib"
+if str(TOOLS_LIB) not in sys.path:
+    sys.path.insert(0, str(TOOLS_LIB))
+
+from .frontmatter import is_inactive, split_frontmatter
+from .manifest import parse_manifest
+from .models import Source
+from .rendering import commit_sha, excerpt, metadata_line, render_pack
+from .selection import excluded, score_source, select_sources, tokenize
+
+__all__ = [
+    "Source",
+    "commit_sha",
+    "excluded",
+    "excerpt",
+    "is_inactive",
+    "metadata_line",
+    "parse_manifest",
+    "render_pack",
+    "score_source",
+    "select_sources",
+    "split_frontmatter",
+    "tokenize",
+]

--- a/tools/context-pack/context_pack/frontmatter.py
+++ b/tools/context-pack/context_pack/frontmatter.py
@@ -1,0 +1,31 @@
+"""Frontmatter helpers for context-pack source filtering."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from homelab_tools.yamlish import parse_frontmatter_text, strip_quotes
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, object], str]:
+    metadata, body, errors = parse_frontmatter_text(text, strip_values=True)
+    if errors and (
+        "missing opening frontmatter marker" in errors
+        or "missing closing frontmatter marker" in errors
+    ):
+        return {}, text
+    return metadata, body
+
+
+def is_inactive(metadata: dict[str, object], today: date) -> bool:
+    superseded_by = metadata.get("superseded_by")
+    if isinstance(superseded_by, list) and superseded_by:
+        return True
+
+    review_after = metadata.get("review_after")
+    if isinstance(review_after, str):
+        try:
+            return today > date.fromisoformat(strip_quotes(review_after))
+        except ValueError:
+            return False
+    return False

--- a/tools/context-pack/context_pack/manifest.py
+++ b/tools/context-pack/context_pack/manifest.py
@@ -1,0 +1,25 @@
+"""Retrieval manifest parsing for context packs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from homelab_tools.yamlish import parse_retrieval_manifest_file, strip_quotes
+
+
+def parse_manifest(path: Path, index_name: str) -> dict[str, list[str]]:
+    for index in parse_retrieval_manifest_file(path):
+        if index.get("name") == index_name:
+            return {
+                "include": _string_list(index.get("include", [])),
+                "exclude": _string_list(index.get("exclude", [])),
+                "required_metadata": _string_list(index.get("required_metadata", [])),
+            }
+
+    raise SystemExit(f"retrieval index not found: {index_name}")
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [strip_quotes(item) for item in value if isinstance(item, str)]

--- a/tools/context-pack/context_pack/models.py
+++ b/tools/context-pack/context_pack/models.py
@@ -1,0 +1,19 @@
+"""Data models for context-pack rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Source:
+    path: Path
+    metadata: dict[str, object]
+    body: str
+    score: int
+    root: Path = field(default_factory=lambda: Path(__file__).resolve().parents[3])
+
+    @property
+    def relative_path(self) -> str:
+        return self.path.relative_to(self.root).as_posix()

--- a/tools/context-pack/context_pack/rendering.py
+++ b/tools/context-pack/context_pack/rendering.py
@@ -1,0 +1,71 @@
+"""Markdown rendering for context packs."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from .models import Source
+
+
+def render_pack(
+    task: str,
+    sources: list[Source],
+    *,
+    commit_func: Callable[[], str] | None = None,
+) -> str:
+    if commit_func is None:
+        def default_commit_sha() -> str:
+            return commit_sha(Path(__file__).resolve().parents[3])
+
+        commit_func = default_commit_sha
+
+    lines = [
+        "# Context Pack",
+        "",
+        f"Task: {task}",
+        f"Commit: {commit_func()}",
+        "",
+        "## Sources",
+    ]
+    for source in sources:
+        lines.extend(
+            [
+                "",
+                f"### {source.relative_path}",
+                "",
+                metadata_line(source),
+                "",
+                excerpt(source.body),
+            ]
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def metadata_line(source: Source) -> str:
+    metadata = source.metadata
+    fields = {
+        "kind": metadata.get("kind", "document"),
+        "status": metadata.get("status", "unknown"),
+        "authority": metadata.get("authority", "unspecified"),
+        "scope": ",".join(metadata.get("scope", [])) if isinstance(metadata.get("scope"), list) else "",
+    }
+    return "Metadata: " + "; ".join(f"{key}={value}" for key, value in fields.items() if value)
+
+
+def excerpt(body: str, *, max_lines: int = 16) -> str:
+    selected = [line.rstrip() for line in body.splitlines() if line.strip()]
+    return "\n".join(selected[:max_lines])
+
+
+def commit_sha(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() or "unknown"

--- a/tools/context-pack/context_pack/selection.py
+++ b/tools/context-pack/context_pack/selection.py
@@ -1,0 +1,59 @@
+"""Source discovery and scoring for context packs."""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .frontmatter import is_inactive, split_frontmatter
+from .models import Source
+
+
+ALWAYS_INCLUDE = ("AGENTS.md",)
+
+
+def select_sources(
+    task: str,
+    manifest: dict[str, list[str]],
+    *,
+    limit: int,
+    root: Path,
+    always_include: tuple[str, ...] = ALWAYS_INCLUDE,
+) -> list[Source]:
+    task_terms = tokenize(task)
+    today = datetime.now(timezone.utc).date()
+    candidates: dict[str, Path] = {}
+
+    for pattern in manifest["include"]:
+        for path in root.glob(pattern):
+            if path.is_file() and not excluded(path, manifest["exclude"], root=root):
+                candidates[path.relative_to(root).as_posix()] = path
+
+    sources: list[Source] = []
+    for relative_path, path in sorted(candidates.items()):
+        metadata, body = split_frontmatter(path.read_text(encoding="utf-8"))
+        if is_inactive(metadata, today):
+            continue
+        score = score_source(relative_path, body, task_terms)
+        if relative_path in always_include:
+            score += 100
+        if score > 0:
+            sources.append(Source(path=path, metadata=metadata, body=body, score=score, root=root))
+
+    return sorted(sources, key=lambda source: (-source.score, source.relative_path))[:limit]
+
+
+def score_source(path: str, body: str, task_terms: set[str]) -> int:
+    haystack = tokenize(path) | tokenize(body)
+    return len(task_terms & haystack)
+
+
+def excluded(path: Path, exclude_patterns: list[str], *, root: Path) -> bool:
+    relative = path.relative_to(root).as_posix()
+    return any(fnmatch.fnmatch(relative, pattern) for pattern in exclude_patterns)
+
+
+def tokenize(value: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", value.lower()) if len(token) > 2}

--- a/tools/context-pack/render.py
+++ b/tools/context-pack/render.py
@@ -4,31 +4,32 @@
 from __future__ import annotations
 
 import argparse
-import fnmatch
-import re
-import subprocess
-from dataclasses import dataclass
-from datetime import date, datetime, timezone
+import sys
+from datetime import date
 from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from context_pack.frontmatter import is_inactive as _is_inactive
+from context_pack.frontmatter import split_frontmatter
+from context_pack.manifest import parse_manifest
+from context_pack.models import Source
+from context_pack.rendering import commit_sha as _commit_sha
+from context_pack.rendering import excerpt, metadata_line
+from context_pack.rendering import render_pack as _render_pack
+from context_pack.selection import ALWAYS_INCLUDE, score_source, tokenize
+from context_pack.selection import excluded as _excluded
+from context_pack.selection import select_sources as _select_sources
+from homelab_tools.yamlish import strip_quotes
 
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ".codex/retrieval.yaml"
 DEFAULT_INDEX = "binding-agent-context"
 DEFAULT_LIMIT = 8
-ALWAYS_INCLUDE = ("AGENTS.md",)
-
-
-@dataclass(frozen=True)
-class Source:
-    path: Path
-    metadata: dict[str, object]
-    body: str
-    score: int
-
-    @property
-    def relative_path(self) -> str:
-        return self.path.relative_to(ROOT).as_posix()
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -45,184 +46,30 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def parse_manifest(path: Path, index_name: str) -> dict[str, list[str]]:
-    indexes: list[dict[str, object]] = []
-    current: dict[str, object] | None = None
-    current_list: str | None = None
-
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
-        if not line.strip() or line.strip() in {"---", "indexes:"}:
-            continue
-        if line.startswith("  - name: "):
-            current = {"name": strip_quotes(line.split(":", 1)[1].strip())}
-            indexes.append(current)
-            current_list = None
-            continue
-        if current is None:
-            continue
-        if line.startswith("    ") and line.endswith(":"):
-            current_list = line.strip()[:-1]
-            current[current_list] = []
-            continue
-        if line.startswith("      - ") and current_list:
-            values = current[current_list]
-            if isinstance(values, list):
-                values.append(strip_quotes(line.strip()[2:].strip()))
-
-    for index in indexes:
-        if index.get("name") == index_name:
-            return {
-                "include": list(index.get("include", [])),
-                "exclude": list(index.get("exclude", [])),
-                "required_metadata": list(index.get("required_metadata", [])),
-            }
-
-    raise SystemExit(f"retrieval index not found: {index_name}")
-
-
 def select_sources(task: str, manifest: dict[str, list[str]], *, limit: int) -> list[Source]:
-    task_terms = tokenize(task)
-    today = datetime.now(timezone.utc).date()
-    candidates: dict[str, Path] = {}
-
-    for pattern in manifest["include"]:
-        for path in ROOT.glob(pattern):
-            if path.is_file() and not excluded(path, manifest["exclude"]):
-                candidates[path.relative_to(ROOT).as_posix()] = path
-
-    sources: list[Source] = []
-    for relative_path, path in sorted(candidates.items()):
-        metadata, body = split_frontmatter(path.read_text(encoding="utf-8"))
-        if is_inactive(metadata, today):
-            continue
-        score = score_source(relative_path, body, task_terms)
-        if relative_path in ALWAYS_INCLUDE:
-            score += 100
-        if score > 0:
-            sources.append(Source(path=path, metadata=metadata, body=body, score=score))
-
-    return sorted(sources, key=lambda source: (-source.score, source.relative_path))[:limit]
+    return _select_sources(
+        task,
+        manifest,
+        limit=limit,
+        root=ROOT,
+        always_include=ALWAYS_INCLUDE,
+    )
 
 
 def render_pack(task: str, sources: list[Source]) -> str:
-    lines = [
-        "# Context Pack",
-        "",
-        f"Task: {task}",
-        f"Commit: {commit_sha()}",
-        "",
-        "## Sources",
-    ]
-    for source in sources:
-        lines.extend(
-            [
-                "",
-                f"### {source.relative_path}",
-                "",
-                metadata_line(source),
-                "",
-                excerpt(source.body),
-            ]
-        )
-    return "\n".join(lines).rstrip() + "\n"
-
-
-def metadata_line(source: Source) -> str:
-    metadata = source.metadata
-    fields = {
-        "kind": metadata.get("kind", "document"),
-        "status": metadata.get("status", "unknown"),
-        "authority": metadata.get("authority", "unspecified"),
-        "scope": ",".join(metadata.get("scope", [])) if isinstance(metadata.get("scope"), list) else "",
-    }
-    return "Metadata: " + "; ".join(f"{key}={value}" for key, value in fields.items() if value)
-
-
-def split_frontmatter(text: str) -> tuple[dict[str, object], str]:
-    lines = text.splitlines()
-    if not lines or lines[0] != "---":
-        return {}, text
-    try:
-        end = lines[1:].index("---") + 1
-    except ValueError:
-        return {}, text
-
-    metadata: dict[str, object] = {}
-    current_list: str | None = None
-    for line in lines[1:end]:
-        if not line.strip():
-            continue
-        if line.startswith("  - ") and current_list:
-            values = metadata[current_list]
-            if isinstance(values, list):
-                values.append(strip_quotes(line[4:].strip()))
-            continue
-        current_list = None
-        if ":" not in line:
-            continue
-        key, raw_value = line.split(":", 1)
-        key = key.strip()
-        value = raw_value.strip()
-        if value == "[]":
-            metadata[key] = []
-        elif value == "":
-            metadata[key] = []
-            current_list = key
-        else:
-            metadata[key] = strip_quotes(value)
-    return metadata, "\n".join(lines[end + 1 :]).strip()
+    return _render_pack(task, sources, commit_func=commit_sha)
 
 
 def is_inactive(metadata: dict[str, object], today: date) -> bool:
-    superseded_by = metadata.get("superseded_by")
-    if isinstance(superseded_by, list) and superseded_by:
-        return True
-
-    review_after = metadata.get("review_after")
-    if isinstance(review_after, str):
-        try:
-            return today > date.fromisoformat(review_after)
-        except ValueError:
-            return False
-    return False
-
-
-def score_source(path: str, body: str, task_terms: set[str]) -> int:
-    haystack = tokenize(path) | tokenize(body)
-    return len(task_terms & haystack)
+    return _is_inactive(metadata, today)
 
 
 def excluded(path: Path, exclude_patterns: list[str]) -> bool:
-    relative = path.relative_to(ROOT).as_posix()
-    return any(fnmatch.fnmatch(relative, pattern) for pattern in exclude_patterns)
-
-
-def excerpt(body: str, *, max_lines: int = 16) -> str:
-    selected = [line.rstrip() for line in body.splitlines() if line.strip()]
-    return "\n".join(selected[:max_lines])
-
-
-def tokenize(value: str) -> set[str]:
-    return {token for token in re.findall(r"[a-z0-9]+", value.lower()) if len(token) > 2}
-
-
-def strip_quotes(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
+    return _excluded(path, exclude_patterns, root=ROOT)
 
 
 def commit_sha() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=ROOT,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    return result.stdout.strip() or "unknown"
+    return _commit_sha(ROOT)
 
 
 if __name__ == "__main__":

--- a/tools/lib/homelab_tools/yamlish.py
+++ b/tools/lib/homelab_tools/yamlish.py
@@ -99,16 +99,18 @@ def parse_simple_yaml_file(path: Path) -> dict[str, object]:
     return values
 
 
-def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], list[str]]:
-    """Parse simple Markdown frontmatter and return metadata plus parse errors."""
-    lines = path.read_text(encoding="utf-8").splitlines()
+def parse_frontmatter_text(
+    text: str, *, strip_values: bool = False
+) -> tuple[dict[str, Any], str, list[str]]:
+    """Parse simple Markdown frontmatter and return metadata, body, and errors."""
+    lines = text.splitlines()
     if not lines or lines[0] != "---":
-        return {}, ["missing opening frontmatter marker"]
+        return {}, text, ["missing opening frontmatter marker"]
 
     try:
         end = lines[1:].index("---") + 1
     except ValueError:
-        return {}, ["missing closing frontmatter marker"]
+        return {}, text, ["missing closing frontmatter marker"]
 
     metadata: dict[str, Any] = {}
     errors: list[str] = []
@@ -122,6 +124,8 @@ def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], list[str]]:
                 errors.append(f"line {lineno}: list item without list key")
                 continue
             value = line[4:].strip()
+            if strip_values:
+                value = strip_quotes(value)
             if value:
                 current_value = metadata[current_list]
                 if isinstance(current_value, list):
@@ -134,6 +138,8 @@ def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], list[str]]:
         key, raw_value = line.split(":", 1)
         key = key.strip()
         value = raw_value.strip()
+        if strip_values:
+            value = strip_quotes(value)
         if value == "[]":
             metadata[key] = []
         elif value == "":
@@ -142,4 +148,52 @@ def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], list[str]]:
         else:
             metadata[key] = value
 
+    return metadata, "\n".join(lines[end + 1 :]).strip(), errors
+
+
+def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], list[str]]:
+    """Parse simple Markdown frontmatter and return metadata plus parse errors."""
+    metadata, _body, errors = parse_frontmatter_text(path.read_text(encoding="utf-8"))
     return metadata, errors
+
+
+def parse_retrieval_manifest_file(path: Path, *, strict: bool = False) -> list[dict[str, object]]:
+    """Parse the retrieval manifest subset shared by policy checks and context rendering."""
+    indexes: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    current_list: str | None = None
+    in_indexes = False
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line.strip() or line.strip() == "---":
+            continue
+        if line == "indexes:":
+            in_indexes = True
+            continue
+        if not in_indexes:
+            if strict:
+                raise ValueError(f"line {line_number}: only indexes is supported at top level")
+            continue
+        if line.startswith("  - name: "):
+            current = {"name": strip_quotes(line.split(":", 1)[1].strip())}
+            indexes.append(current)
+            current_list = None
+            continue
+        if current is None:
+            if strict:
+                raise ValueError(f"line {line_number}: index item must start with name")
+            continue
+        if line.startswith("    ") and line.endswith(":"):
+            current_list = line.strip()[:-1]
+            current[current_list] = []
+            continue
+        if line.startswith("      - ") and current_list:
+            current_value = current[current_list]
+            if isinstance(current_value, list):
+                current_value.append(strip_quotes(line.strip()[2:].strip()))
+            continue
+        if strict:
+            raise ValueError(f"line {line_number}: unsupported manifest syntax")
+
+    return indexes

--- a/tools/policy/check_retrieval_manifest.py
+++ b/tools/policy/check_retrieval_manifest.py
@@ -11,7 +11,7 @@ if str(TOOLS_LIB) not in sys.path:
     sys.path.insert(0, str(TOOLS_LIB))
 
 from homelab_tools.reporting import CheckResult
-from homelab_tools.yamlish import strip_quotes
+from homelab_tools.yamlish import parse_retrieval_manifest_file
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -93,42 +93,7 @@ def main() -> int:
 def parse_manifest(path: Path) -> list[dict[str, object]]:
     if not path.exists():
         raise ValueError(f"{path.relative_to(ROOT)} is missing")
-
-    indexes: list[dict[str, object]] = []
-    current: dict[str, object] | None = None
-    current_list: str | None = None
-    in_indexes = False
-
-    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-        line = raw_line.split("#", 1)[0].rstrip()
-        if not line.strip() or line.strip() == "---":
-            continue
-        if line == "indexes:":
-            in_indexes = True
-            continue
-        if not in_indexes:
-            raise ValueError(f"line {line_number}: only indexes is supported at top level")
-        if line.startswith("  - name: "):
-            current = {"name": line.split(":", 1)[1].strip()}
-            indexes.append(current)
-            current_list = None
-            continue
-        if current is None:
-            raise ValueError(f"line {line_number}: index item must start with name")
-        if line.startswith("    ") and line.endswith(":"):
-            current_list = line.strip()[:-1]
-            current[current_list] = []
-            continue
-        if line.startswith("      - ") and current_list:
-            value = line.strip()[2:].strip()
-            value = strip_quotes(value)
-            current_value = current[current_list]
-            if isinstance(current_value, list):
-                current_value.append(value)
-            continue
-        raise ValueError(f"line {line_number}: unsupported manifest syntax")
-
-    return indexes
+    return parse_retrieval_manifest_file(path, strict=True)
 
 
 def matches_repo_file(pattern: str) -> bool:

--- a/tools/tests/test_homelab_tools.py
+++ b/tools/tests/test_homelab_tools.py
@@ -21,7 +21,12 @@ from homelab_tools.reporting import (
     format_issues_json,
     format_issues_text,
 )
-from homelab_tools.yamlish import parse_simple_yaml_file, parse_scalar_yaml_file
+from homelab_tools.yamlish import (
+    parse_frontmatter_text,
+    parse_retrieval_manifest_file,
+    parse_scalar_yaml_file,
+    parse_simple_yaml_file,
+)
 
 
 class HomelabToolsTest(unittest.TestCase):
@@ -57,6 +62,49 @@ class HomelabToolsTest(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "duplicate field role"):
                 parse_scalar_yaml_file(path)
+
+    def test_parse_frontmatter_text_returns_body(self) -> None:
+        metadata, body, errors = parse_frontmatter_text(
+            "---\nstatus: \"current\"\nscope:\n  - tools\n---\n\n# Body\n",
+            strip_values=True,
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(metadata, {"status": "current", "scope": ["tools"]})
+        self.assertEqual(body, "# Body")
+
+    def test_parse_retrieval_manifest_file_preserves_index_lists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "retrieval.yaml"
+            path.write_text(
+                "\n".join(
+                    [
+                        "---",
+                        "indexes:",
+                        "  - name: binding-agent-context",
+                        "    include:",
+                        "      - AGENTS.md",
+                        "    exclude:",
+                        "      - '**/secret.yaml'",
+                        "    required_metadata:",
+                        "      - source_path",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                parse_retrieval_manifest_file(path, strict=True),
+                [
+                    {
+                        "name": "binding-agent-context",
+                        "include": ["AGENTS.md"],
+                        "exclude": ["**/secret.yaml"],
+                        "required_metadata": ["source_path"],
+                    }
+                ],
+            )
 
     def test_check_result_collects_and_reports_exit_code(self) -> None:
         result = CheckResult("example failed:")


### PR DESCRIPTION
## Summary

Refactor the context-pack and architecture renderers into importable Python modules while keeping the existing direct-script entrypoints and compatibility names stable.

## Important Changes

- Split `tools/context-pack/render.py` into `context_pack` modules for retrieval manifest parsing, frontmatter handling, source selection and scoring, data models, and Markdown rendering.
- Kept `tools/context-pack/render.py` as the direct CLI shim and compatibility module, including support for existing tests that monkeypatch `ROOT` and `commit_sha`.
- Split `tools/architecture/render.py` into `architecture` modules for Kubernetes extraction, Flux/Kustomize relationships, Gateway routes, storage/PVC relationships, Terraform extraction, and Markdown rendering.
- Kept `tools/architecture/render.py` as the direct CLI shim with unchanged `--check`, `--write`, output path, generated header, and stale/missing messages.
- Added shared `homelab_tools.yamlish` helpers for frontmatter text parsing and retrieval manifest parsing, and reused the retrieval helper from the policy check.
- Added unit coverage for the new shared YAML/frontmatter helper behavior.

## Documentation Impact

No user-facing documentation changed. This is a behavior-preserving local Python renderer refactor. `python3 tools/architecture/render.py --check` passed and `docs/architecture.md` did not change.

## Tests

- PASS: `python3 -m unittest discover -s tools/context-pack/tests`
- PASS: `python3 -m unittest discover -s tools/tests`
- PASS: `python3 -m unittest discover -s tools/development/tests`
- PASS: `python3 -m unittest discover -s tools/codex-harness/tests`
- PASS: `python3 tools/policy/check_mcp_config_consistency.py`
- PASS: `python3 tools/policy/check_synology_oauth_redirect.py`
- PASS: `python3 tools/policy/check_retrieval_manifest.py`
- PASS: `python3 tools/policy/check_decision_metadata.py`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `python3 tools/context-pack/render.py --task 'add app with gateway route and secret' --limit 3`
- PASS: `pre-commit run --all-files`
- PASS: `uv run --project tools/agent-memory pytest tools/agent-memory/tests`

## Verification

- Workflow active marker, implementation plan, and owner attestation were created before tracked edits and validated successfully.
- Direct scripts work from repo root for the required context-pack smoke command and architecture check.
- Generated architecture output remains stable; no generated-doc refresh was needed.

## Development Validation

Exception recorded: no live development-cluster validation was required or run because this low-risk implementation only refactors local Python renderer code and does not change Kubernetes manifests, Terraform desired state, Flux wiring, Gateway routes, storage, secrets references, or live app behavior.

## Owner Execution Note

The main agent remained planner/coordinator; tracked edits and the commit were owned by `implementation-agent-renderers-yaml-cleanup` in the sibling clone `/workspaces/homelab-ideas/renderers-yaml-cleanup`.
