### PR TITLE
feat(flux): wire private transfer app source

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
-- App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`.
+- App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`, `private`.
 
 ### Development
 
@@ -88,6 +88,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-foundryvtt` | `./kubernetes/apps/foundryvtt` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
+| `production` | `app-transfer` | `./kubernetes/apps/transfer` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-renovate` | `./kubernetes/apps/renovate` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-synthetics` | `./kubernetes/apps/synthetics` | `gateway`, `grafana`, `authentik`, `app-whoami`, `app-jellyfin`, `app-pihole`, `app-foundryvtt` | `cluster-vars` | `no` |
 | `production` | `app-valheim` | `./kubernetes/apps/valheim` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
@@ -190,6 +191,7 @@ This lists secret manifest presence only. Secret values are not rendered.
 | `monitoring/pretty-discord-alerts` | `monitoring/grafana-env` | `yes` | `kubernetes/infra/monitoring/pretty-discord-alerts/grafana-env.yaml` |
 | `network/vpn` | `wireguard/wireguard-env` | `yes` | `kubernetes/infra/network/vpn/secret.yaml` |
 | `pihole` | `pihole/pihole-admin-password` | `yes` | `kubernetes/apps/pihole/secret.yaml` |
+| `private` | `flux-system/homelab-private-deploy-key` | `yes` | `kubernetes/clusters/production/apps/private/secret.yaml` |
 | `renovate` | `renovate/renovate-secret` | `yes` | `kubernetes/apps/renovate/secret.yaml` |
 | `valheim` | `valheim/valheim-secret` | `yes` | `kubernetes/apps/valheim/secret.yaml` |
 

--- a/kubernetes/clusters/production/apps/kustomization.yaml
+++ b/kubernetes/clusters/production/apps/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - foundryvtt.yaml
   - valheim.yaml
   - synthetics.yaml
+  - private

--- a/kubernetes/clusters/production/apps/private/kustomization.yaml
+++ b/kubernetes/clusters/production/apps/private/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secret.yaml
+  - source.yaml
+  - transfer.yaml

--- a/kubernetes/clusters/production/apps/private/secret.yaml
+++ b/kubernetes/clusters/production/apps/private/secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: homelab-private-deploy-key
+    namespace: flux-system
+type: Opaque
+stringData:
+    identity: ENC[AES256_GCM,data:nwPUcCp449rO/xYO3AxJ+T5VVaa8rmuENJ+Pc4uNVLxqMAdyi4XwgnAYrPUB1zNau24Elqi1q1A53q1poFskh3BvU/uDZZ7vati7XXHPgoP7Q4zZweL6Pir+gBm/XtzVoU+MDOPFfQxVzw++fH6DOiXy5whAdhnZcP4kJKTuKlQn3WUmuBWxldNAhPpq7SkqDGIAZtzUvf/RsZgLprVzhwCfYn42YPbPBVTMfwxvn97n+BbQ4i/AiYJpGdjLvvDRDE0MabuhnfR/XGI15jNn7Yu7s2/J1P9/UTYoP1VM2+ygN0tLaUkPhfZturzSnadzNzN3hczs7qbzDA5bEfHiQVoPMIaUB97601Et/P3FG359DejIX927mCMfUu+NBr45dcVkNeIfcljLu8TxCmmT2nnEd8uT0eRwFee1bjtd8tVfIzWtzKT6w79i+LfVK4Pjb4Oupujz0LA2P8J2uv760Dnk/8OxzieJPzlc49RWT2E8K+p3G5z/eiDZRINdGO574458I9FAstvBIpc05mIGR0JDCLpsNPtdkBQa91B1RqU3gMo=,iv:kfoFrr+WIyyR9uWh8uo32qezzLFwls2lviMuVOVCgXU=,tag:7z/ntCdkrg1OiJrqRB58iQ==,type:str]
+    known_hosts: ENC[AES256_GCM,data:475M2HAtLrmgBCaJKyQ1/DH+nFlqN+XvTntqADR2oj0t5auebwksck1Oipz44EHRkm1zdS+QAJ0p5S761MUQ4/UBJfmB8DI8AHJu0wfyCIiV6uqo71yBaQo8Z8uTZABQ0J5K3C9EzMq5ecaDBzD6JXaNPBu0Ej1SU97mjdKYP1yN4PcmXxWahpXoGrTyDFPw+5cgrkhMEQVF0yoka7r7e6X/3y15KG1Vr51ch/rbfRGcKycFvfhdIkEjt16DvFIFq5wd6vptI5b8hcIW3GdkIpKUM3YUzal/RINSUIYrYK3OLYBlf1oqHFVHg5yGACy4XauE6lcJUo+j0KBm9vgZWIDClf2WlZkmHdlBAneRRf7h13VwmIrTXsuJPXTMoZLKU+hVv3MltHI5EqKONvJOKhsBO2BOnoowqJUk1g+pb19y4rcRJngRlCcvNk7/qu6zCLzJ2jT+Fb95iBTakA5RvHeQdMmA859VHJfwyi6Qqodp9e5K+ysOnb6+nquFVJLi6HRf3943MKs3lRDbpBabyCSfA7ELPsIAEA1liJlR+slDVR2sBHOuJosi/0MzV4maGbcaKIX1SEI8pSZF0m1BCL7jGggR4O0LGquOgeWAhMXSCgmXjMUOx/fQAF348VAiIWnDlFWgc05luxpS9s9Z9cnR744jNZ/Cb4LTLOqdKr4ZCpzukyEL9KL3ds78JbBhUoqLoaPkARa5Kf27lG6BSi/tfzIDQGyWt+7IwZunNNXLCzPIp0OiHNIJlNmGQpU0a9a45+V/9suoVrOWl0brdJCfA7hbysCsV2a/P1dGYcDleN+F74/B8cHi7DpBeedtkKSXJgI/R/2SZBNyFH7T3dLIjVHymcUCGcecsD5ByxInnhWmY/Z7lduLy4sY5gQuM5cLVcW38MBX9lDXOJTBXbgvPPq7lhZwamOsRa+IkSpJp0kUI5NVrAY9i0+VarZBgp18xyJuhzESL7mR26mOGscF9DFitcbHpGKntx1rAXgDJ9XU5/ze/soWmrEeK8IFmDmM/5oZvvAp6Yceb2/NAduXBu1Bh+rLqIaWBcbD2du5qVd2EZvmVVSAQPc3Bcyex+AKNqdmcYgAqUfs,iv:vjyDWLOdyehGR5zzqlPkp31TEugCpJcQYwASN/aFtww=,tag:ENm1qQXsFRKItXgw0lBc3Q==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxNUF2LzRUMzJGWVVUc2tN
+            YlgyaWlmY3owR3NPYlQzWkRoNW01SGpHOTNNCmZVb0pPVnRraCtLMGJuMlIvejQ4
+            eEJxaDFPa2lpRTJlQkp0dVBnK1FZRkUKLS0tIGhiVXV0cWltUlZNRG1VZzJKZGNu
+            THZtbHdwb1JHbmsySC9RS2JlRDBRLzAK7kD3kuxf5BLFVh4p61olmVTddonHSc52
+            2Z32Sb/rp2L65oeiMTOkkHM3yVdnjIGfu1k7/6ehtFkL5H4og5Ijdg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-17T18:47:19Z"
+    mac: ENC[AES256_GCM,data:oAo+/eJWZOD5CSt6zbXrGI/KzwX/tuvGvD5o1CdieDvygS13RSwP0bX5DCpqjlJ0nHJKbPefp2S8Y9saUsPdyQIA3BqX3SXVaC/EqqJJNPlqZjvHiptJPOAtFKpShgAuERIXht716YGvXUGd1Prm+c0OaS0Al3mPNpSLen9KW14=,iv:wVhiNW3NSI+jmaRGrTkhw+W32j8+Mdzh+KPwG4GnB6A=,tag:ae4Lq7HI56XxT/sQyoer3w==,type:str]
+    version: 3.13.0

--- a/kubernetes/clusters/production/apps/private/source.yaml
+++ b/kubernetes/clusters/production/apps/private/source.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: homelab-private
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: ssh://git@github.com/petebeegle/homelab-private
+  ref:
+    branch: main
+  secretRef:
+    name: homelab-private-deploy-key

--- a/kubernetes/clusters/production/apps/private/transfer.yaml
+++ b/kubernetes/clusters/production/apps/private/transfer.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-transfer
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./kubernetes/apps/transfer
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-private
+  dependsOn:
+    - name: gateway
+    - name: nfs-csi
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars


### PR DESCRIPTION
## Summary

Adds production Flux wiring for the private transfer app source from `petebeegle/homelab-private` using neutral public resource names.

## Dependency

This PR depends on merging the `homelab-private` transfer app PR first so the private repository contains `./kubernetes/apps/transfer` before Flux reconciles `app-transfer`.

## Important Changes

- Added `kubernetes/clusters/production/apps/private/` with:
  - SOPS-encrypted `homelab-private-deploy-key` Secret in `flux-system`.
  - `homelab-private` GitRepository pointing at the private repository over SSH.
  - `app-transfer` Flux Kustomization targeting `./kubernetes/apps/transfer` from the private source.
- Wired the private directory into `kubernetes/clusters/production/apps/kustomization.yaml`.
- Refreshed generated `docs/architecture.md` after the architecture check reported it stale.

## Documentation Impact

- Updated generated architecture documentation via `python3 tools/architecture/render.py --write`.

## Tests

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `sops --decrypt kubernetes/clusters/production/apps/private/secret.yaml >/dev/null`
- PASS: `sops --decrypt --output-type json kubernetes/clusters/production/apps/private/secret.yaml | python3 -c '...'`
- PASS: `kubectl kustomize kubernetes/clusters/production/apps >/tmp/transfer-private-flux-kustomize.yaml`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`

## Development Validation

Risk tier: medium. Development live validation was not run because this public Flux wiring depends on the private repository source and transfer app path being merged and reachable from Flux before a meaningful branch reconcile can validate it. Substitute checks rendered the production app kustomization locally, verified the encrypted Secret decrypts structurally without printing values, and refreshed/checked generated architecture docs. Follow-up development validation should reconcile `app-transfer` after the private repo branch is merged and the deploy key is available in the target cluster.
