### PR TITLE
Implementation: grafana-home-dashboard-refresh

### DIFF
--- a/kubernetes/infra/monitoring/grafana/app.yaml
+++ b/kubernetes/infra/monitoring/grafana/app.yaml
@@ -36,7 +36,7 @@ spec:
         domain: monitoring.${cluster_domain}
         root_url: https://monitoring.${cluster_domain}
       dashboards:
-        default_home_dashboard_path: /var/lib/grafana/dashboards/home/monitoring-radar.json
+        default_home_dashboard_path: /var/lib/grafana/dashboards/home/dashboard.json
       metrics:
         enabled: true
       auth.generic_oauth:
@@ -59,8 +59,7 @@ spec:
     extraConfigmapMounts:
       - name: monitoring-radar-dashboard
         configMap: monitoring-radar-dashboard
-        mountPath: /var/lib/grafana/dashboards/home/monitoring-radar.json
-        subPath: dashboard.json
+        mountPath: /var/lib/grafana/dashboards/home
         readOnly: true
     sidecar:
       dashboards:


### PR DESCRIPTION
## Summary
## Summary

Refreshes the Grafana Home dashboard ConfigMap mount so Kubernetes projects the `monitoring-radar-dashboard` ConfigMap as a live directory instead of a stale `subPath` file mount.

## Important Changes

- Updated `grafana.ini.dashboards.default_home_dashboard_path` to `/var/lib/grafana/dashboards/home/dashboard.json`.
- Changed the `monitoring-radar-dashboard` `extraConfigmapMounts` entry to mount `/var/lib/grafana/dashboards/home` as a read-only directory.
- Removed `subPath: dashboard.json` from that mount so ConfigMap updates can refresh through the normal projected-volume behavior.

## Tests And Evidence

- PASS: Owner marker validation:
  `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: Implementation plan validation:
  `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: Owner attestation validation:
  `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: Rendered Grafana manifests:
  `kubectl kustomize kubernetes/infra/monitoring/grafana >/tmp/grafana-render.yaml`
- PASS: Render inspection found `default_home_dashboard_path: /var/lib/grafana/dashboards/home/dashboard.json`, `mountPath: /var/lib/grafana/dashboards/home`, `readOnly: true`, and no `subPath: dashboard.json`:
  `python3 - <<'PY' ...`
- PASS: Architecture check:
  `python3 tools/architecture/render.py --check`
- PASS: Diff whitespace check:
  `git diff --check`

## Development Validation Exception

Risk tier: medium. Development-cluster validation is excepted because the development cluster does not deploy the Grafana/monitoring stack per `docs/architecture.md`; this production Grafana integration cannot be represented by the current development branch deploy profiles. Substitute checks were local manifest rendering, focused rendered-value inspection, and the architecture check.

Production read-only validation was not run because kubeconfig exists but contains no configured contexts:
`kubectl config current-context` returned `error: current-context is not set`, and `kubectl config get-contexts` listed no contexts. No production mutation was attempted.

## Documentation Impact

No documentation changed. This is internal deployment plumbing for how Grafana consumes the existing Home dashboard ConfigMap and does not alter operator-facing behavior, runbooks, architecture relationships, or generated docs.

## Workflow Note

The user explicitly assigned this runtime as the implementation owner for `grafana-home-dashboard-refresh`; tracked edits were made only in `/workspaces/homelab-ideas/grafana-home-dashboard-refresh`.


## Changes
- kubernetes/infra/monitoring/grafana/app.yaml

## Commits
- 87ee28d fix(grafana): keep home dashboard configmap live

## Verification
- Verified HEAD: `87ee28d4fde16b368b48a849d9a4cae50480f6b5`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
