### PR TITLE
feat: add private app aggregator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-foundryvtt` | `./kubernetes/apps/foundryvtt` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
+| `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
 | `production` | `private-source` | `./kubernetes/clusters/production/apps/private/source` | (none) | `(none)` | `sops` |
 | `production` | `app-transfer` | `./kubernetes/apps/transfer` | `private-source`, `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-renovate` | `./kubernetes/apps/renovate` | `gateway` | `cluster-vars` | `sops` |

--- a/kubernetes/clusters/production/apps/private/kustomization.yaml
+++ b/kubernetes/clusters/production/apps/private/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - private-source.yaml
+  - private-apps.yaml
   - transfer.yaml

--- a/kubernetes/clusters/production/apps/private/private-apps.yaml
+++ b/kubernetes/clusters/production/apps/private/private-apps.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: private-apps
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./kubernetes/clusters/production/apps
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: homelab-private
+  dependsOn:
+    - name: private-source
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars


### PR DESCRIPTION
Depends on private PR: https://github.com/petebeegle/homelab-private/pull/2. Merge the private PR first, then merge this public PR so Flux can resolve the private aggregator path.

Verifier approval: verifier attestation validated locally before push for public HEAD 3f45f4218e2802e737e72d079a0f86abe3c41ac2.

# private-arr-foundation

## Summary

Adds the private production app aggregator and initial Radarr workload while leaving the existing public `app-transfer` activation unchanged.

## Commits

- Public homelab: `3f45f4218e2802e737e72d079a0f86abe3c41ac2` (`feat: add private app aggregator`)
- Private homelab-private: `bae3bf2130c9c0680da4569c28e509cb4a4c6f68` (`feat: add private radarr app`)

## Public Changes

- Added `kubernetes/clusters/production/apps/private/private-apps.yaml` for Flux Kustomization `private-apps`.
- Listed `private-apps.yaml` from `kubernetes/clusters/production/apps/private/kustomization.yaml`.
- Regenerated `docs/architecture.md`.
- Confirmed `kubernetes/clusters/production/apps/private/transfer.yaml` has no diff.

## Private Changes

- Added `kubernetes/clusters/production/apps/kustomization.yaml`.
- Added `kubernetes/clusters/production/apps/radarr.yaml` for Flux Kustomization `app-radarr`.
- Added Radarr raw manifests under `kubernetes/apps/radarr`: Namespace, PVC, Deployment, Service, HTTPRoute, and Kustomization.

## Documentation Impact

- Public generated architecture updated with the new `private-apps` Flux Kustomization.
- Private README unchanged because the private repo has no existing app catalog guidance affected by this addition.

## Evidence

- PASS: `kubectl kustomize kubernetes/apps/radarr` in `/workspaces/homelab-ideas/private-arr-foundation-private` rendered 147 lines at private HEAD `bae3bf2130c9c0680da4569c28e509cb4a4c6f68`.
- PASS: `kubectl kustomize kubernetes/clusters/production/apps` in `/workspaces/homelab-ideas/private-arr-foundation-private` rendered 26 lines at private HEAD `bae3bf2130c9c0680da4569c28e509cb4a4c6f68`.
- PASS: `flux envsubst --strict` with production `cluster_domain` and `nfs_server` over the private Radarr render and private production app aggregator render.
- PASS: `kubectl kustomize kubernetes/clusters/production/apps` in `/workspaces/homelab-ideas/private-arr-foundation` rendered 288 lines at public HEAD `3f45f4218e2802e737e72d079a0f86abe3c41ac2`.
- PASS: `flux envsubst --strict` with production `cluster_domain` and `nfs_server` over the public production apps render.
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`.
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`.
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`.
- PASS: `git diff --check` in both public and private clones before commit.
- EXCEPTION: Requested `kustomize build kubernetes/clusters/production/apps` could not run because `/bin/bash: line 1: kustomize: command not found`. The repo CI/runbooks use `kubectl kustomize`; `kubectl version --client=true --output=yaml` reports embedded `kustomizeVersion: v5.8.1`, and the equivalent `kubectl kustomize` check passed.

## Development Smoke

- Read-only availability check found `~/.kube/homelab-development.config`, a Ready development node, and public development Flux resources.
- No live development smoke was applied. Exception: the development cluster currently exposes only the public `flux-system` GitRepository and public development Kustomizations; it does not have the private `homelab-private` source/aggregator needed to reconcile this private production app safely. Creating persistent private source wiring in development is outside this implementation, and Radarr has no automated branch smoke profile. Substitute checks were local Kustomize renders plus strict Flux variable substitution for public and private manifests.

## Notes For Verifier

- This implementation intentionally stops before PR creation and verifier approval files.
- LinuxServer's current Radarr documentation lists running the image as a non-root user with `--user=1000:1000`, which supports the Radarr container `runAsUser: 1000` and `runAsGroup: 1000` settings used here.
