### PR TITLE
refactor: clean up Python tooling structure

### DIFF
--- a/tools/agent-memory/src/agent_memory/lint.py
+++ b/tools/agent-memory/src/agent_memory/lint.py
@@ -4,13 +4,19 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+TOOLS_LIB = Path(__file__).resolve().parents[3] / "lib"
+if str(TOOLS_LIB) not in sys.path:
+    sys.path.insert(0, str(TOOLS_LIB))
+
 from agent_memory.policy import secret_rejection_reason
 from agent_memory.storage import memory_root
+from homelab_tools.yamlish import parse_frontmatter_text
 
 APPROVED_REQUIRED_FIELDS = (
     "status",
@@ -153,13 +159,33 @@ def _lint_approved_markdown(
     if secret_reason is not None:
         issues.append(_issue(path, "error", "secret-like-content", secret_reason, base))
 
-    try:
-        frontmatter, body = _split_frontmatter(text)
-    except ValueError as error:
-        issues.append(_issue(path, "error", "frontmatter-missing", str(error), base))
+    metadata, body, metadata_errors = parse_frontmatter_text(
+        text,
+        strip_values=True,
+        metadata_line_start=1,
+    )
+    if metadata_errors == ["missing opening frontmatter marker"]:
+        issues.append(
+            _issue(
+                path,
+                "error",
+                "frontmatter-missing",
+                "approved Markdown memory must start with frontmatter",
+                base,
+            )
+        )
         return issues
-
-    metadata, metadata_errors = _parse_frontmatter(frontmatter)
+    if metadata_errors == ["missing closing frontmatter marker"]:
+        issues.append(
+            _issue(
+                path,
+                "error",
+                "frontmatter-missing",
+                "approved Markdown memory frontmatter is not closed",
+                base,
+            )
+        )
+        return issues
     issues.extend(_issue(path, "error", "frontmatter-invalid", message, base) for message in metadata_errors)
 
     for field_name in APPROVED_REQUIRED_FIELDS:
@@ -304,55 +330,6 @@ def _lint_record(path: Path, base: Path, record: dict[str, Any], line_number: in
     return issues
 
 
-def _split_frontmatter(text: str) -> tuple[str, str]:
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        raise ValueError("approved Markdown memory must start with frontmatter")
-    for index, line in enumerate(lines[1:], start=1):
-        if line.strip() == "---":
-            return "\n".join(lines[1:index]), "\n".join(lines[index + 1 :])
-    raise ValueError("approved Markdown memory frontmatter is not closed")
-
-
-def _parse_frontmatter(frontmatter: str) -> tuple[dict[str, object], list[str]]:
-    metadata: dict[str, object] = {}
-    errors: list[str] = []
-    current_list_key: str | None = None
-    for line_number, line in enumerate(frontmatter.splitlines(), start=1):
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        if line.startswith("  - "):
-            if current_list_key is None:
-                errors.append(f"line {line_number}: list item without list key")
-                continue
-            value = _strip_quotes(line[4:].strip())
-            if value:
-                current_value = metadata[current_list_key]
-                if isinstance(current_value, list):
-                    current_value.append(value)
-            continue
-
-        current_list_key = None
-        stripped = line.strip()
-        if ":" not in stripped:
-            errors.append(f"line {line_number}: expected key: value")
-            continue
-        key, value = stripped.split(":", 1)
-        key = key.strip()
-        if not key:
-            errors.append(f"line {line_number}: key must not be empty")
-            continue
-        cleaned = value.strip()
-        if cleaned == "[]":
-            metadata[key] = []
-        elif cleaned == "":
-            metadata[key] = []
-            current_list_key = key
-        else:
-            metadata[key] = _strip_quotes(cleaned)
-    return metadata, errors
-
-
 def _parse_date_field(value: object) -> date | None:
     if not isinstance(value, str):
         return None
@@ -370,12 +347,6 @@ def _has_dated_filename(path: Path) -> bool:
 
 def _is_vague(value: object) -> bool:
     return isinstance(value, str) and value.strip().lower() in VAGUE_METADATA_VALUES
-
-
-def _strip_quotes(value: str) -> str:
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
-    return value
 
 
 def _word_count(text: str) -> int:

--- a/tools/agent-memory/tests/test_lint.py
+++ b/tools/agent-memory/tests/test_lint.py
@@ -57,6 +57,41 @@ class MemoryLintTests(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.issues, ())
 
+    def test_approved_markdown_frontmatter_comments_are_ignored(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_approved_memory(root)
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "---\nstatus: approved\n",
+                    "---\n# frontmatter comment\nstatus: approved\n",
+                ),
+                encoding="utf-8",
+            )
+
+            result = lint_memory_root(root, today=date(2026, 5, 10))
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(result.issues, ())
+
+    def test_approved_markdown_empty_frontmatter_key_is_invalid(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = write_approved_memory(root)
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    "---\nstatus: approved\n",
+                    "---\n: bad\nstatus: approved\n",
+                ),
+                encoding="utf-8",
+            )
+
+            result = lint_memory_root(root, today=date(2026, 5, 10))
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("frontmatter-invalid", {issue.code for issue in result.issues})
+            self.assertIn("line 1: key must not be empty", {issue.message for issue in result.issues})
+
     def test_invalid_approved_markdown_reports_errors(self):
         cases = {
             "missing-frontmatter.md": "# Missing Frontmatter\n\nBody.\n",

--- a/tools/codex-harness/tests/test_create_implementation_pr.py
+++ b/tools/codex-harness/tests/test_create_implementation_pr.py
@@ -12,6 +12,7 @@ SCRIPT_SOURCE = REPO_ROOT / ".codex" / "scripts" / "create_implementation_pr.sh"
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 
@@ -72,6 +73,7 @@ def _install_harness_files(root: Path, sibling_root: Path) -> None:
     shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
     shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
     shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+    shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
     _patch_sibling_root(
         sibling_root,

--- a/tools/codex-harness/tests/test_implementation_workflow_guard.py
+++ b/tools/codex-harness/tests/test_implementation_workflow_guard.py
@@ -15,6 +15,7 @@ USER_PROMPT_HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "user_prompt_submit.s
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 
@@ -216,6 +217,7 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
         shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
         shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
         shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+        shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
         shutil.copytree(TOOLS_LIB_SOURCE, target_root / "tools" / "lib")
         self._patch_sibling_root(
             hook_path,

--- a/tools/codex-harness/tests/test_verifier_push_guard.py
+++ b/tools/codex-harness/tests/test_verifier_push_guard.py
@@ -12,6 +12,7 @@ HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "verifier_push_guard.sh"
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 
@@ -71,6 +72,7 @@ def _install_harness_files(root: Path, sibling_root: Path) -> None:
     shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
     shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
     shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+    shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
     _patch_sibling_root(
         sibling_root,

--- a/tools/codex-harness/validate_active_implementation.py
+++ b/tools/codex-harness/validate_active_implementation.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 TOOLS_LIB = Path(__file__).resolve().parents[2] / "tools" / "lib"
 if str(TOOLS_LIB) not in sys.path:
     sys.path.insert(0, str(TOOLS_LIB))
 
 from homelab_tools.git import discover_git_branch, discover_git_root
-from homelab_tools.yamlish import parse_key_value_file
+from validation_common import ValidationResult, load_marker, path_from_cwd, require_fields
 
 
 REQUIRED_FIELDS = (
@@ -32,19 +35,9 @@ GENERIC_OWNER_AGENTS = frozenset(
 SIBLING_CLONE_ROOT = Path("/workspaces/homelab-ideas")
 
 
-@dataclass(frozen=True)
-class ValidationResult:
-    marker: Mapping[str, str]
-    errors: tuple[str, ...]
-
-    @property
-    def ok(self) -> bool:
-        return not self.errors
-
-
 def parse_marker(marker_path: Path) -> dict[str, str]:
     """Parse a key=value marker file."""
-    return parse_key_value_file(marker_path, quote_chars='"')
+    return load_marker(marker_path)
 
 
 def validate_marker(
@@ -55,9 +48,7 @@ def validate_marker(
 ) -> ValidationResult:
     errors: list[str] = []
 
-    for field in REQUIRED_FIELDS:
-        if field not in marker:
-            errors.append(f"Missing required field '{field}'.")
+    require_fields(marker, REQUIRED_FIELDS, errors)
 
     implementation = marker.get("implementation", "")
     branch = marker.get("branch", "")
@@ -112,7 +103,7 @@ def validate_marker(
                 f"Field 'clone_path' must match current repository root '{root}', got '{clone_path}'."
             )
 
-    return ValidationResult(marker=marker, errors=tuple(errors))
+    return ValidationResult(marker, tuple(errors))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -139,9 +130,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    marker_path = Path(args.marker)
-    if not marker_path.is_absolute():
-        marker_path = Path.cwd() / marker_path
+    marker_path = path_from_cwd(args.marker)
 
     if not marker_path.is_file():
         print(f"Active implementation marker not found: {marker_path}", file=sys.stderr)

--- a/tools/codex-harness/validate_implementation_plan.py
+++ b/tools/codex-harness/validate_implementation_plan.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 TOOLS_LIB = Path(__file__).resolve().parents[2] / "tools" / "lib"
 if str(TOOLS_LIB) not in sys.path:
     sys.path.insert(0, str(TOOLS_LIB))
 
-from homelab_tools.yamlish import parse_simple_yaml_file
+from validation_common import ValidationResult, load_plan, path_from_cwd, require_fields
 from validate_active_implementation import parse_marker
 
 
@@ -37,19 +40,12 @@ REQUIRED_LIST_FIELDS = (
 ALL_REQUIRED_FIELDS = REQUIRED_SCALAR_FIELDS + REQUIRED_LIST_FIELDS
 
 
-@dataclass(frozen=True)
-class PlanValidationResult:
-    plan: Mapping[str, object]
-    errors: tuple[str, ...]
-
-    @property
-    def ok(self) -> bool:
-        return not self.errors
+PlanValidationResult = ValidationResult
 
 
 def parse_plan(plan_path: Path) -> dict[str, object]:
     """Parse the simple YAML subset used by .codex/tmp/implementation-plan.yaml."""
-    return parse_simple_yaml_file(plan_path)
+    return load_plan(plan_path)
 
 
 def validate_plan(
@@ -61,9 +57,7 @@ def validate_plan(
 ) -> PlanValidationResult:
     errors: list[str] = []
 
-    for field in ALL_REQUIRED_FIELDS:
-        if field not in plan:
-            errors.append(f"Missing required field '{field}'.")
+    require_fields(plan, ALL_REQUIRED_FIELDS, errors)
 
     for field in REQUIRED_SCALAR_FIELDS:
         value = plan.get(field)
@@ -104,7 +98,7 @@ def validate_plan(
                     f"Field '{field}' must match active implementation marker value '{marker_value}', got '{plan_value}'."
                 )
 
-    return PlanValidationResult(plan=plan, errors=tuple(errors))
+    return PlanValidationResult(plan, tuple(errors))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -139,9 +133,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    plan_path = Path(args.plan)
-    if not plan_path.is_absolute():
-        plan_path = Path.cwd() / plan_path
+    plan_path = path_from_cwd(args.plan)
     if not plan_path.is_file():
         print(f"Implementation plan not found: {plan_path}", file=sys.stderr)
         return 1
@@ -154,9 +146,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     marker = None
     if not args.no_marker:
-        marker_path = Path(args.marker)
-        if not marker_path.is_absolute():
-            marker_path = Path.cwd() / marker_path
+        marker_path = path_from_cwd(args.marker)
         if not marker_path.is_file():
             print(f"Active implementation marker not found: {marker_path}", file=sys.stderr)
             return 1

--- a/tools/codex-harness/validate_workflow_attestations.py
+++ b/tools/codex-harness/validate_workflow_attestations.py
@@ -5,16 +5,25 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 TOOLS_LIB = Path(__file__).resolve().parents[2] / "tools" / "lib"
 if str(TOOLS_LIB) not in sys.path:
     sys.path.insert(0, str(TOOLS_LIB))
 
 from homelab_tools.git import discover_git_branch, discover_git_head, discover_git_root
-from homelab_tools.yamlish import parse_scalar_yaml_file
+from validation_common import (
+    ValidationResult,
+    load_scalar_yaml,
+    path_from_cwd,
+    require_fields,
+    resolve_repo_relative_path,
+)
 from validate_active_implementation import GENERIC_OWNER_AGENTS, parse_marker
 from validate_implementation_plan import parse_plan
 
@@ -42,19 +51,12 @@ GENERIC_IDENTITIES = GENERIC_OWNER_AGENTS
 DELEGATION_TOKEN_ROOT = Path(".codex/tmp/delegation-tokens")
 
 
-@dataclass(frozen=True)
-class AttestationValidationResult:
-    attestation: Mapping[str, str]
-    errors: tuple[str, ...]
-
-    @property
-    def ok(self) -> bool:
-        return not self.errors
+AttestationValidationResult = ValidationResult
 
 
 def parse_attestation(attestation_path: Path) -> dict[str, str]:
     """Parse the scalar-only YAML subset used by workflow attestations."""
-    return parse_scalar_yaml_file(attestation_path)
+    return load_scalar_yaml(attestation_path)
 
 
 def validate_owner_attestation(
@@ -68,7 +70,7 @@ def validate_owner_attestation(
 ) -> AttestationValidationResult:
     errors: list[str] = []
 
-    _require_fields(attestation, OWNER_REQUIRED_FIELDS, errors)
+    require_fields(attestation, OWNER_REQUIRED_FIELDS, errors)
     _validate_common_identity(attestation, expected_role="implementation-agent", errors=errors)
     _validate_common_matches(
         attestation,
@@ -111,7 +113,7 @@ def validate_owner_attestation(
         expected_role="implementation-agent",
         errors=errors,
     )
-    return AttestationValidationResult(attestation=attestation, errors=tuple(errors))
+    return AttestationValidationResult(attestation, tuple(errors))
 
 
 def validate_verifier_attestation(
@@ -136,7 +138,7 @@ def validate_verifier_attestation(
     )
     errors.extend(f"Owner attestation: {error}" for error in owner_result.errors)
 
-    _require_fields(attestation, VERIFIER_REQUIRED_FIELDS, errors)
+    require_fields(attestation, VERIFIER_REQUIRED_FIELDS, errors)
     _validate_common_identity(attestation, expected_role="verifier-agent", errors=errors)
     _validate_common_matches(
         attestation,
@@ -172,7 +174,7 @@ def validate_verifier_attestation(
     if owner_token_path and verifier_token_path and owner_token_path == verifier_token_path:
         errors.append("Field 'delegation_token_path' must differ from implementation owner delegation_token_path.")
 
-    return AttestationValidationResult(attestation=attestation, errors=tuple(errors))
+    return AttestationValidationResult(attestation, tuple(errors))
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -279,12 +281,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 1
 
 
-def _require_fields(attestation: Mapping[str, str], fields: Sequence[str], errors: list[str]) -> None:
-    for field in fields:
-        if field not in attestation:
-            errors.append(f"Missing required field '{field}'.")
-
-
 def _validate_common_identity(
     attestation: Mapping[str, str], *, expected_role: str, errors: list[str]
 ) -> None:
@@ -381,10 +377,7 @@ def _validate_delegation_token(
 
 
 def _path(value: str) -> Path:
-    path = Path(value)
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path
+    return path_from_cwd(value)
 
 
 def _load_delegation_token(
@@ -396,16 +389,13 @@ def _load_delegation_token(
     if not token_path_value:
         return None
 
-    token_path = Path(token_path_value)
-    if token_path.is_absolute():
-        return None
-
     root = Path(current_root) if current_root is not None else Path.cwd()
-    token_root = (root / DELEGATION_TOKEN_ROOT).resolve(strict=False)
-    full_path = (root / token_path).resolve(strict=False)
-    try:
-        full_path.relative_to(token_root)
-    except ValueError:
+    full_path = resolve_repo_relative_path(
+        root,
+        token_path_value,
+        required_parent=DELEGATION_TOKEN_ROOT,
+    )
+    if full_path is None:
         return None
 
     if not full_path.is_file():

--- a/tools/codex-harness/validation_common.py
+++ b/tools/codex-harness/validation_common.py
@@ -1,0 +1,100 @@
+"""Shared helpers for Codex workflow validation CLIs."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+TOOLS_LIB = Path(__file__).resolve().parents[2] / "tools" / "lib"
+if str(TOOLS_LIB) not in sys.path:
+    sys.path.insert(0, str(TOOLS_LIB))
+
+from homelab_tools.yamlish import (
+    parse_key_value_file,
+    parse_scalar_yaml_file,
+    parse_simple_yaml_file,
+)
+
+
+class ValidationResult:
+    def __init__(
+        self,
+        values: Mapping[str, object] | None = None,
+        errors: Sequence[str] = (),
+        *,
+        marker: Mapping[str, object] | None = None,
+        plan: Mapping[str, object] | None = None,
+        attestation: Mapping[str, object] | None = None,
+    ) -> None:
+        selected = values
+        for candidate in (marker, plan, attestation):
+            if selected is None and candidate is not None:
+                selected = candidate
+        self.values = selected or {}
+        self.errors = tuple(errors)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    @property
+    def marker(self) -> Mapping[str, object]:
+        return self.values
+
+    @property
+    def plan(self) -> Mapping[str, object]:
+        return self.values
+
+    @property
+    def attestation(self) -> Mapping[str, object]:
+        return self.values
+
+
+def require_fields(values: Mapping[str, object], fields: Sequence[str], errors: list[str]) -> None:
+    for field in fields:
+        if field not in values:
+            errors.append(f"Missing required field '{field}'.")
+
+
+def path_from_cwd(value: str, *, cwd: Path | None = None) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return (cwd or Path.cwd()) / path
+
+
+def resolve_repo_relative_path(
+    root: Path | str,
+    value: str,
+    *,
+    required_parent: Path | str | None = None,
+) -> Path | None:
+    path = Path(value)
+    if path.is_absolute():
+        return None
+
+    repo_root = Path(root)
+    resolved = (repo_root / path).resolve(strict=False)
+    if required_parent is None:
+        return resolved
+
+    parent = (repo_root / required_parent).resolve(strict=False)
+    try:
+        resolved.relative_to(parent)
+    except ValueError:
+        return None
+    return resolved
+
+
+def load_marker(path: Path) -> dict[str, str]:
+    return parse_key_value_file(path, quote_chars='"')
+
+
+def load_plan(path: Path) -> dict[str, object]:
+    return parse_simple_yaml_file(path)
+
+
+def load_scalar_yaml(path: Path) -> dict[str, str]:
+    return parse_scalar_yaml_file(path)

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
 import json
 import subprocess
 import sys
@@ -12,13 +11,12 @@ from types import SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-MODULE_PATH = REPO_ROOT / "tools" / "development" / "verify_branch_deploy.py"
+TOOLS_DEVELOPMENT = REPO_ROOT / "tools" / "development"
+SHIM_PATH = TOOLS_DEVELOPMENT / "verify_branch_deploy.py"
+if str(TOOLS_DEVELOPMENT) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DEVELOPMENT))
 
-spec = importlib.util.spec_from_file_location("verify_branch_deploy", MODULE_PATH)
-verify = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-sys.modules["verify_branch_deploy"] = verify
-spec.loader.exec_module(verify)
+import devverify as verify
 
 
 READY_HTTPROUTE = """{
@@ -176,6 +174,17 @@ class FakeRunner:
 
 
 class VerifyBranchDeployTest(unittest.TestCase):
+    def test_cli_shim_remains_executable(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SHIM_PATH), "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Verify an app branch environment", result.stdout)
+
     def test_profile_loading_discovers_whoami_and_jellyfin(self) -> None:
         profiles = verify.load_smoke_profiles()
 

--- a/tools/development/verify_branch_deploy.py
+++ b/tools/development/verify_branch_deploy.py
@@ -11,7 +11,6 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
-from devverify import *  # noqa: F401,F403
 from devverify.cli import main
 
 

--- a/tools/foundry_bluegreen.py
+++ b/tools/foundry_bluegreen.py
@@ -11,7 +11,6 @@ TOOLS_DIR = str(Path(__file__).resolve().parent)
 if TOOLS_DIR not in sys.path:
     sys.path.insert(0, TOOLS_DIR)
 
-from foundry_bluegreen_pkg import *  # noqa: F401,F403
 from foundry_bluegreen_pkg import main
 
 

--- a/tools/foundry_bluegreen_pkg/process.py
+++ b/tools/foundry_bluegreen_pkg/process.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
-import subprocess
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Sequence
 
 from .errors import FoundryBlueGreenError
+
+TOOLS_LIB = Path(__file__).resolve().parents[1] / "lib"
+if str(TOOLS_LIB) not in sys.path:
+    sys.path.insert(0, str(TOOLS_LIB))
+
+from homelab_tools.process import run as run_process
 
 
 @dataclass
@@ -19,15 +26,14 @@ class CommandResult:
 
 class CommandRunner:
     def run(self, args: Sequence[str], *, input_text: str | None = None) -> CommandResult:
-        completed = subprocess.run(
-            list(args),
-            input=input_text,
-            text=True,
-            capture_output=True,
-            check=False,
-        )
-        if completed.returncode != 0:
+        completed = run_process(args, input_text=input_text)
+        if not completed.ok():
             rendered = " ".join(args)
             detail = completed.stderr.strip() or completed.stdout.strip()
             raise FoundryBlueGreenError(f"command failed: {rendered}\n{detail}")
-        return CommandResult(args=args, stdout=completed.stdout, stderr=completed.stderr, returncode=0)
+        return CommandResult(
+            args=args,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            returncode=completed.returncode,
+        )

--- a/tools/lib/homelab_tools/yamlish.py
+++ b/tools/lib/homelab_tools/yamlish.py
@@ -100,23 +100,26 @@ def parse_simple_yaml_file(path: Path) -> dict[str, object]:
 
 
 def parse_frontmatter_text(
-    text: str, *, strip_values: bool = False
+    text: str,
+    *,
+    strip_values: bool = False,
+    metadata_line_start: int = 2,
 ) -> tuple[dict[str, Any], str, list[str]]:
     """Parse simple Markdown frontmatter and return metadata, body, and errors."""
     lines = text.splitlines()
-    if not lines or lines[0] != "---":
+    if not lines or lines[0].strip() != "---":
         return {}, text, ["missing opening frontmatter marker"]
 
     try:
-        end = lines[1:].index("---") + 1
-    except ValueError:
+        end = next(index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---")
+    except StopIteration:
         return {}, text, ["missing closing frontmatter marker"]
 
     metadata: dict[str, Any] = {}
     errors: list[str] = []
     current_list: str | None = None
 
-    for lineno, line in enumerate(lines[1:end], start=2):
+    for lineno, line in enumerate(lines[1:end], start=metadata_line_start):
         if not line.strip():
             continue
         if line.startswith("  - "):

--- a/tools/lib/homelab_tools/yamlish.py
+++ b/tools/lib/homelab_tools/yamlish.py
@@ -120,7 +120,7 @@ def parse_frontmatter_text(
     current_list: str | None = None
 
     for lineno, line in enumerate(lines[1:end], start=metadata_line_start):
-        if not line.strip():
+        if not line.strip() or line.lstrip().startswith("#"):
             continue
         if line.startswith("  - "):
             if current_list is None:
@@ -140,6 +140,9 @@ def parse_frontmatter_text(
             continue
         key, raw_value = line.split(":", 1)
         key = key.strip()
+        if not key:
+            errors.append(f"line {lineno}: key must not be empty")
+            continue
         value = raw_value.strip()
         if strip_values:
             value = strip_quotes(value)

--- a/tools/tests/test_foundry_bluegreen.py
+++ b/tools/tests/test_foundry_bluegreen.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import importlib.util
+import importlib
 import io
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -10,13 +11,13 @@ from contextlib import redirect_stdout
 from pathlib import Path
 
 
-MODULE_PATH = Path(__file__).resolve().parents[1] / "foundry_bluegreen.py"
-REPO_ROOT = MODULE_PATH.parents[1]
-SPEC = importlib.util.spec_from_file_location("foundry_bluegreen", MODULE_PATH)
-foundry_bluegreen = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
-sys.modules["foundry_bluegreen"] = foundry_bluegreen
-SPEC.loader.exec_module(foundry_bluegreen)
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = TOOLS_DIR.parent
+SHIM_PATH = TOOLS_DIR / "foundry_bluegreen.py"
+if str(TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOLS_DIR))
+
+import foundry_bluegreen_pkg as foundry_bluegreen
 
 
 class FakeRunner:
@@ -98,6 +99,17 @@ resources:
         self.assertIs(package.FoundryBlueGreenError, foundry_bluegreen.FoundryBlueGreenError)
         self.assertTrue(callable(package.build_parser))
         self.assertTrue(callable(package.command_prepare))
+
+    def test_cli_shim_remains_executable(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SHIM_PATH), "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Safe, dev-gated blue/green workflow", result.stdout)
 
     def test_status_accepts_root_after_subcommand(self) -> None:
         parsed = foundry_bluegreen.build_parser().parse_args(["status", "--root", str(self.root)])

--- a/tools/tests/test_homelab_tools.py
+++ b/tools/tests/test_homelab_tools.py
@@ -73,6 +73,16 @@ class HomelabToolsTest(unittest.TestCase):
         self.assertEqual(metadata, {"status": "current", "scope": ["tools"]})
         self.assertEqual(body, "# Body")
 
+    def test_parse_frontmatter_text_ignores_comments_and_rejects_empty_keys(self) -> None:
+        metadata, body, errors = parse_frontmatter_text(
+            "---\n# comment\n: bad\nstatus: current\n---\n\n# Body\n",
+            metadata_line_start=1,
+        )
+
+        self.assertEqual(metadata, {"status": "current"})
+        self.assertEqual(body, "# Body")
+        self.assertEqual(errors, ["line 2: key must not be empty"])
+
     def test_parse_retrieval_manifest_file_preserves_index_lists(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "retrieval.yaml"


### PR DESCRIPTION
# Python Tooling Structure Cleanup

## Summary
- Cleaned up local Python tooling structure while preserving required public CLI entrypoints.
- Fixed verifier-blocked frontmatter behavior regression from blocked HEAD `1e4c6dfc2806ede2efc56eaeb2daad9946c437d0`.
- Risk tier: low.
- Development-cluster validation: not applicable because this implementation only changes local Python tooling, import structure, validators, and tests; no Kubernetes, Flux, Terraform, Gateway, storage, secrets, or app behavior changes were made.

## Important Changes
- Narrowed `tools/foundry_bluegreen.py` and `tools/development/verify_branch_deploy.py` into import-bootstrapping CLI shims that call package `main` without wildcard re-export behavior.
- Updated Foundry and development verifier tests to import package modules directly and added shim `--help` checks for CLI compatibility.
- Reused `homelab_tools.yamlish.parse_frontmatter_text` in `agent_memory.lint`, removing duplicate frontmatter parsing and quote-stripping helpers while preserving existing missing-frontmatter lint messages.
- Added `tools/codex-harness/validation_common.py` for shared validation result shape, required-field checks, repo-relative path resolution, and common marker/plan/scalar YAML loading.
- Updated active marker, implementation plan, and workflow attestation validators to use the shared helper while preserving CLI arguments, exit codes, and tested error wording.
- Routed `foundry_bluegreen_pkg.process.CommandRunner` through `homelab_tools.process.run` while preserving Foundry domain exceptions.
- Verifier-block fix: extended `parse_frontmatter_text` to ignore blank/comment frontmatter lines and reject empty keys with `key must not be empty`, restoring previous agent-memory lint semantics.
- Added targeted parser and agent-memory lint regression tests for frontmatter comments and empty keys.

## Documentation Impact
- No documentation changes were needed. Public CLI commands and user-facing behavior remain compatible; this is an internal local Python tooling structure cleanup covered by unit and policy checks.

## Tests And Results
- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` - passed.
- `python3 -m unittest discover -s tools/tests -p 'test*.py'` - passed, 20 tests.
- `python3 -m unittest discover -s tools/development/tests -p 'test*.py'` - passed, 26 tests.
- `python3 -m unittest discover -s tools/codex-harness/tests -p 'test*.py'` - passed, 58 tests.
- `python3 -m unittest discover -s tools/context-pack/tests -p 'test*.py'` - passed, 2 tests.
- `PYTHONPATH=tools/agent-memory/src python3 -m unittest discover -s tools/agent-memory/tests -p 'test*.py'` - passed, 16 tests.
- `python3 tools/architecture/render.py --check` - passed.
- `python3 tools/policy/check_decision_metadata.py` - passed.
- `python3 tools/policy/check_retrieval_manifest.py` - passed.
- `python3 tools/policy/check_mcp_config_consistency.py` - passed.

## Verification Notes
- Branch: `codex/python-tooling-cleanup`.
- Current HEAD: `931702cda38c106213979d03b55e0385a808310d`.
- Implementation owner: `implementation-agent-python-tooling-cleanup`.
- Clone path: `/workspaces/homelab-ideas/python-tooling-cleanup`.
- Verifier approval and verifier attestation were intentionally not created; those belong to a separate verifier.
