### PR TITLE
feat(storage): add media NFS storage class

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/controllers/cert-manager` | `app.yaml`, `secret.yaml` |
 | `kubernetes/infra/controllers/grafana-operator` | `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/controllers` | `./nfs-csi`, `./cert-manager`, `./grafana-operator` |
-| `kubernetes/infra/controllers/nfs-csi` | `app.yaml`, `storageclass.yaml`, `volumesnapshotclass.yaml` |
+| `kubernetes/infra/controllers/nfs-csi` | `app.yaml`, `media-storageclass.yaml`, `storageclass.yaml`, `volumesnapshotclass.yaml` |
 | `kubernetes/infra/crds/grafana` | `app.yaml` |
 | `kubernetes/infra/crds` | `https://github.com/kubernetes-csi/external-snapshotter//client/config/crd?ref=v8.5.0`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`, `prometheus`, `grafana` |
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |

--- a/docs/decisions/synology-nfs-storage.md
+++ b/docs/decisions/synology-nfs-storage.md
@@ -7,7 +7,7 @@ scope:
   - nfs
 authority: binding
 created: 2026-05-09
-last_verified: 2026-05-10
+last_verified: 2026-05-17
 supersedes: []
 superseded_by:
 ---
@@ -16,7 +16,10 @@ superseded_by:
 
 ## Decision
 
-Use Synology-backed NFS through StorageClass `nfs-csi-storage` for persistent Kubernetes app storage.
+Use Synology-backed NFS through dedicated NFS CSI StorageClasses for persistent Kubernetes app storage:
+
+- `nfs-csi-storage` is the default StorageClass for general Homelab app storage on `/volume2/Homelab`.
+- `nfs-csi-media-storage` is the opt-in StorageClass for media and download payloads on `/volume1/Media`.
 
 ## Rationale
 
@@ -27,13 +30,15 @@ Use Synology-backed NFS through StorageClass `nfs-csi-storage` for persistent Ku
 ## Consequences
 
 - NFS-dependent apps must depend on the `nfs-csi` Flux Kustomization.
+- PVCs should use `nfs-csi-storage` unless they intentionally store media or download payloads on `nfs-csi-media-storage`.
 - PVC workloads are blocked if Synology CSI is unhealthy.
 - NAS NFS exports must allow the node subnet and any local development subnet that needs access.
 - UID/GID mismatches must be handled with workload security context or NAS permissions.
 
 ## Operational Notes
 
-- StorageClass: `nfs-csi-storage`.
+- Default app StorageClass: `nfs-csi-storage`, backed by `/volume2/Homelab`.
+- Media/download StorageClass: `nfs-csi-media-storage`, backed by `/volume1/Media`.
 - NAS IP in current production variables: `192.168.30.99`.
 - Synology CSI runs in namespace `dataplane`.
 - Use NFS v4.1 for RWX volumes.

--- a/kubernetes/infra/controllers/nfs-csi/kustomization.yaml
+++ b/kubernetes/infra/controllers/nfs-csi/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - app.yaml
+  - media-storageclass.yaml
   - storageclass.yaml
   - volumesnapshotclass.yaml

--- a/kubernetes/infra/controllers/nfs-csi/media-storageclass.yaml
+++ b/kubernetes/infra/controllers/nfs-csi/media-storageclass.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-csi-media-storage
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: ${nfs_server}
+  share: /volume1/Media
+  subDir: nfs-csi-$${pvc.metadata.namespace}-$${pvc.metadata.name}
+mountOptions:
+  - nfsvers=4.1
+  - hard
+  - timeo=600
+  - retrans=2
+  - rsize=1048576
+  - wsize=1048576
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary

Add a dedicated Synology NFS CSI StorageClass, `nfs-csi-media-storage`, for media and download payloads backed by `/volume1/Media`.

## Important Changes

- Added `kubernetes/infra/controllers/nfs-csi/media-storageclass.yaml` with `server: ${nfs_server}`, `share: /volume1/Media`, `subDir: nfs-csi-$${pvc.metadata.namespace}-$${pvc.metadata.name}`, matching NFS mount options, volume expansion enabled, Retain reclaim policy, and Immediate binding.
- Added the media StorageClass manifest to `kubernetes/infra/controllers/nfs-csi/kustomization.yaml`.
- Regenerated `docs/architecture.md` after the architecture check reported the NFS CSI kustomization table was stale.

## Documentation Impact

- Updated `docs/decisions/synology-nfs-storage.md` to document both StorageClasses:
  - `nfs-csi-storage` remains the default for general Homelab app storage on `/volume2/Homelab`.
  - `nfs-csi-media-storage` is opt-in for media and download payloads on `/volume1/Media`.

## Tests

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `PATH="$(pwd)/.codex/tmp/bin:$PATH" kustomize build kubernetes/infra/controllers/nfs-csi`
- PASS: `python3 tools/architecture/render.py --check` after running `python3 tools/architecture/render.py --write`

## Development Validation

Risk tier: high, because this adds shared cluster storage base configuration.

Exception: development-cluster credentials were not staged for this implementation, so live development reconciliation was unavailable. No live evidence was invented. Substitute checks were the local NFS CSI kustomize render and generated architecture freshness check listed above.
