### PR TITLE
fix(flux): prepare transfer activation handoff

### DIFF
--- a/kubernetes/clusters/production/apps/private/transfer.yaml
+++ b/kubernetes/clusters/production/apps/private/transfer.yaml
@@ -9,6 +9,7 @@ spec:
   retryInterval: 2m
   path: ./kubernetes/apps/transfer
   prune: true
+  deletionPolicy: Orphan
   wait: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Private PR Dependency

- Depends on private PR: https://github.com/petebeegle/homelab-private/pull/4
- Merge order: merge the private PR first, wait for private `app-transfer-private` to reconcile Ready and confirm transfer remains healthy, then do the later public-only cleanup PR.
- Verifier approval: verifier-agent-transfer-private-handoff approved exact public HEAD `360b8e348853b47ba464aee8820cbef5aef05e51`.
- Development smoke exception and no-docs rationale are recorded below.

# transfer-private-handoff

Implementation owner: implementation-agent-transfer-private-handoff

## Summary

Handoff-prep step for moving transfer activation into the private aggregator without pruning the live transfer workload. Final cleanup is intentionally deferred to a later public-only PR after private `app-transfer-private` has reconciled Ready and the transfer workload remains healthy.

## Heads

- Public repo `/workspaces/homelab-ideas/transfer-private-handoff`: `360b8e348853b47ba464aee8820cbef5aef05e51`
- Private repo `/workspaces/homelab-ideas/transfer-private-handoff-private`: `b4ce059cc5b1e2a2139f96e7ad23ba8c4a0fa372`

## Changes

- Public: added `spec.deletionPolicy: Orphan` to `kubernetes/clusters/production/apps/private/transfer.yaml` on the existing `app-transfer` Flux Kustomization.
- Public: kept `transfer.yaml` listed in `kubernetes/clusters/production/apps/private/kustomization.yaml` for this handoff-prep PR.
- Private: added `kubernetes/clusters/production/apps/transfer.yaml` with distinct Flux Kustomization name `app-transfer-private`.
- Private: added `transfer.yaml` to `kubernetes/clusters/production/apps/kustomization.yaml`.
- Private: did not change `kubernetes/apps/transfer` workload, storage, route, service, namespace, or secret manifests.

## Documentation Impact

No documentation files changed. This is a narrow Flux handoff safety preparation and `python3 tools/architecture/render.py --check` reported `docs/architecture.md` is fresh.

## Evidence

- PASS private: `kubectl kustomize kubernetes/clusters/production/apps`
- PASS private: `kubectl kustomize kubernetes/apps/transfer`
- PASS private: `git diff --exit-code origin/main -- kubernetes/apps/transfer`
- PASS private: rendered transfer storage still shows `storageClassName: nfs-csi-storage`, `storageClassName: nfs-csi-media-storage`, and qBittorrent `mountPath: /downloads`.
- PASS private: rendered apps aggregator includes `app-transfer-private`, `GitRepository/homelab-private`, dependencies on `private-source`, `gateway`, and `nfs-csi`, SOPS decryption, and `cluster-vars` substitution.
- PASS public: `kubectl kustomize kubernetes/clusters/production/apps`
- PASS public: `python3 tools/architecture/render.py --check`
- PASS public: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS public: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS public: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS public: `git diff --check HEAD^ HEAD`
- PASS private: `git diff --check HEAD^ HEAD`
- PASS public: source check confirms `kubernetes/clusters/production/apps/private/kustomization.yaml` still lists `transfer.yaml`.
- PASS public: rendered apps output confirms existing `app-transfer` now includes `deletionPolicy: Orphan`.

## Development And Production Smoke

No production live changes were made.

Development live smoke was not run because this handoff specifically depends on reconciling the private transfer source and cannot be safely modeled here without applying private-source Flux ownership and branch-source behavior to a live development cluster. Substitute checks were the committed-head public/private production renders, exact transfer storage/workload no-diff check against private `origin/main`, and rendered Flux wiring checks for both old and new Kustomizations.

## Follow-Up

After private `app-transfer-private` reconciles Ready and the transfer workload remains healthy, perform the later public-only cleanup PR that removes the old public `app-transfer` activation.
