### PR TITLE
test(agent-memory): stabilize CLI JSON lint fixture

### DIFF
--- a/tools/agent-memory/tests/test_lint.py
+++ b/tools/agent-memory/tests/test_lint.py
@@ -196,7 +196,7 @@ class MemoryLintTests(unittest.TestCase):
     def test_cli_json_output_contains_issue_shape(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            write_approved_memory(root, source="unknown")
+            write_approved_memory(root, source="unknown", review_after="2999-01-01")
             stdout = io.StringIO()
 
             with contextlib.redirect_stdout(stdout):


### PR DESCRIPTION
# agent-memory-cli-json-warning

## Summary

Stabilized `MemoryLintTests.test_cli_json_output_contains_issue_shape` by making its approved-memory fixture avoid date-based review warnings. The test remains focused on the JSON issue shape for the intended `frontmatter-vague` warning, and linter behavior is unchanged.

Implementation owner evidence: delegated to `implementation-agent-agent-memory-cli-json-warning` with token `implementation-delegation-agent-memory-cli-json-warning`.

## Important Changes

- Updated `tools/agent-memory/tests/test_lint.py` so the CLI JSON output test passes `review_after="2999-01-01"` when creating the `source="unknown"` fixture.
- Preserved existing warning semantics; only the test fixture changed.

## Documentation Impact

No documentation changed. This is a local-only Python test fixture stabilization and does not change user-facing behavior, operational procedures, Kubernetes manifests, Terraform, Flux, storage, Gateway routes, or secret handling.

## Validation

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `uv run --project tools/agent-memory pytest tools/agent-memory/tests/test_lint.py::MemoryLintTests::test_cli_json_output_contains_issue_shape` (`1 passed`)
- PASS: `uv run --project tools/agent-memory pytest tools/agent-memory/tests` (`16 passed`)

## Development Validation

Exception recorded: `smoke_profile: none`. This change is not cluster-affecting; it only adjusts a local Python test fixture under `tools/agent-memory/tests`. Substitute checks were the focused regression test, the full `tools/agent-memory` test suite, and workflow harness validation.

## PR Status

Branch: `codex/agent-memory-cli-json-warning`

Commit: `b3b486085d85a782c9f3f24e497d92581b36485c`

Verifier approval files were intentionally not created.
