### PR TITLE
Implementation: development-dev-domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ All shared manifests use `${variable}` placeholders instead of hardcoded values.
 | `gateway_external_passthrough_ip` | `192.168.40.242` | L2 IP for the external WireGuard-reachable TLS passthrough Gateway |
 | `cilium_operator_replicas` | `3` | Cilium operator replica count for the environment |
 | `nfs_server` | `192.168.30.99` | NFS server IP for storage |
-| `letsencrypt_server` | `https://acme-v02...` | ACME server URL (use staging for test envs) |
+| `letsencrypt_server` | `https://acme-v02...` | ACME server URL for trusted Let's Encrypt issuance |
 | `wildcard_cert_name` | `wildcard-lab-petebeegle-com` | Name of the wildcard TLS Secret |
 
 **To add a new environment:**
@@ -172,7 +172,7 @@ All shared manifests use `${variable}` placeholders instead of hardcoded values.
 5. Run `flux bootstrap` pointing at `./kubernetes/clusters/<env>` or use the matching Terraform root
 6. Apply a per-environment SOPS age key as the `sops-age` Secret in `flux-system`
 
-The development environment starts at `kubernetes/clusters/development`, uses `development.lab.petebeegle.com`, ACME staging, reduced Cilium operator replicas, and only the resource-conscious base plus whoami. Heavy production services stay out of the base until a test explicitly needs them.
+The development environment starts at `kubernetes/clusters/development`, uses `dev.lab.petebeegle.com`, trusted Let's Encrypt production issuance through the shared Cloudflare issuer, reduced Cilium operator replicas, and only the resource-conscious base plus whoami. Heavy production services stay out of the base until a test explicitly needs them.
 
 Production Terraform writes operator config to `~/.kube/homelab-production.config` and `~/.talos/homelab-production.config` by default instead of overwriting `~/.kube/config` or `~/.talos/config`. Export `KUBECONFIG` and `TALOSCONFIG` to those cluster-specific files for local production workflows, or override the Terraform output path variables if you intentionally want the old global locations.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `nfs_server` | `192.168.30.99` |
 | `production` | `wildcard_cert_name` | `wildcard-lab-petebeegle-com` |
 | `development` | `cilium_operator_replicas` | `1` |
-| `development` | `cluster_domain` | `development.lab.petebeegle.com` |
+| `development` | `cluster_domain` | `dev.lab.petebeegle.com` |
 | `development` | `cluster_env` | `development` |
 | `development` | `gateway_external_ip` | `192.168.40.225` |
 | `development` | `gateway_external_passthrough_ip` | `192.168.40.226` |
@@ -47,9 +47,9 @@ This document is generated for agentic repo navigation. It records relationships
 | `development` | `gateway_internal_ip` | `192.168.30.225` |
 | `development` | `gateway_internal_pool` | `192.168.30.224/28` |
 | `development` | `gateway_passthrough_ip` | `192.168.30.226` |
-| `development` | `letsencrypt_server` | `https://acme-staging-v02.api.letsencrypt.org/directory` |
+| `development` | `letsencrypt_server` | `https://acme-v02.api.letsencrypt.org/directory` |
 | `development` | `nfs_server` | `192.168.30.99` |
-| `development` | `wildcard_cert_name` | `wildcard-development-lab-petebeegle-com` |
+| `development` | `wildcard_cert_name` | `wildcard-dev-lab-petebeegle-com` |
 
 ## Flux Dependencies
 
@@ -145,7 +145,7 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- | --- | --- | --- |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
-| `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.development.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |
+| `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.dev.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt-public` | `foundry.petebeegle.com` | `gateway/public/http-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `foundryvtt/foundryvtt` | `foundry.${cluster_domain}` | `gateway/internal/https-gateway` | `foundryvtt:80` |
 | `HTTPRoute` | `gateway/https-redirect` | `*.${cluster_domain}, ${cluster_domain}` | `gateway/internal/http-gateway, gateway/external/http-gateway` | `(none)` |

--- a/docs/runbooks/add-app.md
+++ b/docs/runbooks/add-app.md
@@ -322,7 +322,7 @@ Add `- name: nfs-csi` under `dependsOn` when the app uses NFS-backed PVCs.
 
 ## Branch-Aware App Overlay
 
-Use `branch_slug`, not slot terminology. Branch app hostnames must follow `<app>-${branch_slug}.development.lab.petebeegle.com`, and branch resources must be unique enough to coexist with the development base and other branch apps.
+Use `branch_slug`, not slot terminology. Branch app hostnames must follow `<app>-${branch_slug}.dev.lab.petebeegle.com`, and branch resources must be unique enough to coexist with the development base and other branch apps.
 
 For raw manifests, create an overlay such as `kubernetes/apps/<app-name>/branch/` with:
 

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -20,10 +20,10 @@ Use this runbook to create, bootstrap, test, and clean up the dedicated developm
 - Cluster name: `homelab-development`
 - Endpoint: `https://192.168.30.170:6443`
 - Default node: VM `170` on `pve04`, IP `192.168.30.170`, single schedulable control-plane node, 4 CPU, 24576 MB memory, 180 GB disk
-- Domain: `development.lab.petebeegle.com`
+- Domain: `dev.lab.petebeegle.com`
 - LoadBalancer pools: internal `192.168.30.224/28`, external `192.168.40.224/28`
 - Gateway IPs: internal `192.168.30.225`, passthrough `192.168.30.226`, external `192.168.40.225`, external passthrough `192.168.40.226`
-- ACME: Let's Encrypt staging through the shared Cloudflare issuer
+- ACME: trusted Let's Encrypt production issuance through the shared Cloudflare issuer
 
 The development base intentionally includes CRDs, Cilium, cert-manager/certs, Gateway API, NFS CSI, and whoami. Authentik, games/media apps, Cloudflare tunnels, Renovate, VPN, and the full monitoring stack are omitted to keep the single-node cluster resource-conscious and to avoid production-only secrets or traffic paths unless a test explicitly needs them.
 
@@ -125,7 +125,7 @@ kd get httproute -A
 Branch environments are for app-scoped validation on the development cluster. Use `branch_slug` for all uniqueness and route hostnames:
 
 ```text
-<app>-${branch_slug}.development.lab.petebeegle.com
+<app>-${branch_slug}.dev.lab.petebeegle.com
 ```
 
 Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. The tool loads JSON smoke profiles from `tools/development/smoke-profiles/`, renders the matching activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, runs profile resource checks, and then removes the temporary branch Flux resources unless `--keep` is set. Automated profiles currently cover `whoami` and `jellyfin`.
@@ -239,7 +239,7 @@ Local manifest verification does not require pushing a branch:
 
 ```sh
 export branch_slug=example
-export cluster_domain=development.lab.petebeegle.com
+export cluster_domain=dev.lab.petebeegle.com
 kubectl kustomize kubernetes/apps/whoami/branch | flux envsubst --strict
 kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict
 

--- a/docs/runbooks/foundry-bluegreen.md
+++ b/docs/runbooks/foundry-bluegreen.md
@@ -22,7 +22,7 @@ Use this runbook for Foundry VTT image upgrades. Production changes stay GitOps-
 - `Service/foundryvtt` remains the stable production backend for the existing public and internal routes.
 - The original blue `Deployment/foundryvtt` selector intentionally stays app-only for Kubernetes selector immutability and compatibility with the existing live Deployment. Color labels live on pod templates and Services so switching can move traffic without mutating the blue Deployment selector.
 - Green preview traffic uses the internal Gateway only at `foundry-green.${cluster_domain}`.
-- The development fixture preview is LAN-only at `foundry-green-preview.development.lab.petebeegle.com`.
+- The development fixture preview is LAN-only at `foundry-green-preview.dev.lab.petebeegle.com`.
 - After `promote`, inactive blue remains scaled to zero until an explicit `retire`.
 
 ## Development Rehearsal

--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -22,6 +22,7 @@ It exposes DNS on TCP and UDP port 53 and is selected into that pool with the `h
 
 CoreDNS provides split-DNS behavior for VPN clients:
 
+- `dev.lab.petebeegle.com` and `*.dev.lab.petebeegle.com` A queries return the development external Gateway IP `192.168.40.225`.
 - `*.lab.petebeegle.com` A queries return `192.168.40.241`.
 - All other queries forward to UniFi DNS at `192.168.1.1`.
 

--- a/kubernetes/apps/foundry-bluegreen-fixture/httproute-green-preview.yaml
+++ b/kubernetes/apps/foundry-bluegreen-fixture/httproute-green-preview.yaml
@@ -10,7 +10,7 @@ spec:
       namespace: gateway
       sectionName: https-gateway
   hostnames:
-    - foundry-green-preview.development.lab.petebeegle.com
+    - foundry-green-preview.dev.lab.petebeegle.com
   rules:
     - matches:
         - path:

--- a/kubernetes/clusters/development/branches/README.md
+++ b/kubernetes/clusters/development/branches/README.md
@@ -4,7 +4,7 @@ This directory is a template library, not part of the live development cluster e
 
 The manifests here are cluster-layer activation templates: they create a branch-specific Flux `GitRepository` and `Kustomization` that point the development cluster at a Git branch. The app payload they activate lives under app directories such as `kubernetes/apps/whoami/branch/`, where resource names, namespaces, and hostnames are parameterized with `${branch_slug}`.
 
-To test an app branch, copy the relevant template into `kubernetes/clusters/development/apps/branches/` or another reviewed cluster-layer path, replace `branch_name` and `branch_slug`, set `spec.suspend: false`, and commit the activation. Branch app hostnames should follow `<app>-${branch_slug}.development.lab.petebeegle.com`.
+To test an app branch, copy the relevant template into `kubernetes/clusters/development/apps/branches/` or another reviewed cluster-layer path, replace `branch_name` and `branch_slug`, set `spec.suspend: false`, and commit the activation. Branch app hostnames should follow `<app>-${branch_slug}.dev.lab.petebeegle.com`.
 
 ## Local Verification
 
@@ -12,7 +12,7 @@ Local verification without pushing is supported for manifest shape checks:
 
 ```sh
 export branch_slug=example
-export cluster_domain=development.lab.petebeegle.com
+export cluster_domain=dev.lab.petebeegle.com
 kubectl kustomize kubernetes/apps/whoami/branch | flux envsubst --strict
 kubectl kustomize kubernetes/clusters/development
 

--- a/kubernetes/clusters/development/cluster-vars.yaml
+++ b/kubernetes/clusters/development/cluster-vars.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-vars
   namespace: flux-system
 data:
-  cluster_domain: "development.lab.petebeegle.com"
+  cluster_domain: "dev.lab.petebeegle.com"
   cluster_env: "development"
   gateway_internal_pool: "192.168.30.224/28"
   gateway_external_pool: "192.168.40.224/28"
@@ -15,5 +15,5 @@ data:
   gateway_external_passthrough_ip: "192.168.40.226"
   cilium_operator_replicas: "1"
   nfs_server: "192.168.30.99"
-  letsencrypt_server: "https://acme-staging-v02.api.letsencrypt.org/directory"
-  wildcard_cert_name: "wildcard-development-lab-petebeegle-com"
+  letsencrypt_server: "https://acme-v02.api.letsencrypt.org/directory"
+  wildcard_cert_name: "wildcard-dev-lab-petebeegle-com"

--- a/kubernetes/infra/network/gateway/certificate.yaml
+++ b/kubernetes/infra/network/gateway/certificate.yaml
@@ -8,6 +8,7 @@ spec:
   secretName: ${wildcard_cert_name}
   dnsNames:
     - "*.${cluster_domain}"
+    - ${cluster_domain}
   issuerRef:
     name: cloudflare
     kind: ClusterIssuer

--- a/kubernetes/infra/network/vpn/vpn-dns.yaml
+++ b/kubernetes/infra/network/vpn/vpn-dns.yaml
@@ -12,6 +12,11 @@ data:
             lameduck 5s
         }
         ready
+        template IN A dev.lab.petebeegle.com {
+            match ^(.+\.)?dev\.lab\.petebeegle\.com\.$
+            answer "{{ .Name }} 60 IN A 192.168.40.225"
+            fallthrough
+        }
         template IN A lab.petebeegle.com {
             match ^(.+\.)lab\.petebeegle\.com\.$
             answer "{{ .Name }} 60 IN A 192.168.40.241"


### PR DESCRIPTION
## Summary
## Summary

- Moved the development cluster URL namespace from `*.development.lab.petebeegle.com` to `*.dev.lab.petebeegle.com`.
- Switched development `letsencrypt_server` from Let's Encrypt staging to the trusted production ACME directory and renamed the development wildcard certificate Secret to `wildcard-dev-lab-petebeegle-com`.
- Added the apex `${cluster_domain}` DNS name to the shared Gateway wildcard Certificate so wildcard and apex Gateway listeners are covered by the same cert.
- Updated the development foundry blue/green fixture hostname, branch-environment docs, development runbook, README environment description, WireGuard split-DNS runbook, and generated architecture docs.
- Added a more-specific WireGuard CoreDNS template for `dev.lab.petebeegle.com` before the broad `lab.petebeegle.com` template, returning development external Gateway IP `192.168.40.225` without changing the production catch-all answer of `192.168.40.241`.

## Tests

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `rg -n "development\.lab\.petebeegle\.com|wildcard-development-lab-petebeegle-com"` returned no matches.
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `kubectl kustomize kubernetes/clusters/development > /tmp/development-dev-domain-kustomize-postcommit.yaml`
- PASS: `env ... sh -c 'kubectl kustomize kubernetes/infra/network/gateway | flux envsubst --strict > /tmp/development-dev-domain-gateway-postcommit.yaml'`
- PASS: `env ... sh -c 'kubectl kustomize kubernetes/infra/network/certs | flux envsubst --strict > /tmp/development-dev-domain-certs-postcommit.yaml'`
- PASS: `env ... sh -c 'kubectl kustomize kubernetes/infra/network/vpn | flux envsubst --strict > /tmp/development-dev-domain-vpn-postcommit.yaml'`
- PASS: `kubectl kustomize kubernetes/apps/foundry-bluegreen-fixture > /tmp/development-dev-domain-foundry-fixture-postcommit.yaml`
- PASS: substituted focused render inspection confirmed Gateway Certificate `dnsNames` include `*.dev.lab.petebeegle.com` and `dev.lab.petebeegle.com`, the trusted ACME directory is rendered for the primary Cloudflare ClusterIssuer, WireGuard DNS returns `192.168.40.225` for `dev.lab.petebeegle.com`, and the fixture route renders `foundry-green-preview.dev.lab.petebeegle.com`.
- PASS: `uv run --with pytest pytest tools/tests/test_foundry_bluegreen.py` passed 10 tests.

## Development Validation

- PASS: `python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/development-dev-domain --slug development-dev-domain --include-cluster-base --kubeconfig ~/.kube/homelab-development.config`
- Evidence: Flux fetched `codex/development-dev-domain@sha1:dde45dedc17abb1e410f7fd937359591d4e1d43f`, reconciled the development cluster base path with `--include-cluster-base`, reconciled branch Kustomization `branch-whoami-development-dev-domain`, confirmed namespace `whoami-development-dev-domain`, confirmed a Ready whoami branch pod, confirmed Service `whoami-development-dev-domain`, confirmed HTTPRoute `whoami-development-dev-domain`, and deleted the branch Kustomization/GitRepository after namespace cleanup.
- Note: the verifier preflight Terraform plan completed with exit code 2 and showed development resources would be created from this clone's local Terraform state. The branch verifier continued because exit code 2 is Terraform's detailed-exitcode for non-empty plans; no Terraform apply was requested or run.

## Documentation Impact

- Updated `README.md`, `docs/runbooks/development-cluster.md`, `docs/runbooks/foundry-bluegreen.md`, `docs/runbooks/add-app.md`, `docs/runbooks/wireguard.md`, and `kubernetes/clusters/development/branches/README.md`.
- Regenerated `docs/architecture.md` with `python3 tools/architecture/render.py --write`.

## Blockers

- Push and PR creation were not performed because verifier approval for exact HEAD `dde45dedc17abb1e410f7fd937359591d4e1d43f` is required first and no separate verifier-agent approval/tooling was available in this turn.


## Changes
- README.md
- docs/architecture.md
- docs/runbooks/add-app.md
- docs/runbooks/development-cluster.md
- docs/runbooks/foundry-bluegreen.md
- docs/runbooks/wireguard.md
- kubernetes/apps/foundry-bluegreen-fixture/httproute-green-preview.yaml
- kubernetes/clusters/development/branches/README.md
- kubernetes/clusters/development/cluster-vars.yaml
- kubernetes/infra/network/gateway/certificate.yaml
- kubernetes/infra/network/vpn/vpn-dns.yaml

## Commits
- dde45de fix(development): move cluster domain to dev lab

## Verification
- Verified HEAD: `dde45dedc17abb1e410f7fd937359591d4e1d43f`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
