### PR TITLE
Fix Jellyfin SSO provider config XML

### DIFF
--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -4,7 +4,7 @@ scope:
   - jellyfin
   - authentik
   - sso
-last_verified: 2026-05-17
+last_verified: 2026-05-23
 ---
 
 # Jellyfin Authentik SSO
@@ -12,6 +12,8 @@ last_verified: 2026-05-17
 Jellyfin web SSO is provided by the 9p4 SSO Authentication plugin, pinned in GitOps to release `v4.0.0.4`. The Authentik setup follows the community integration guide at <https://integrations.goauthentik.io/media/jellyfin/>.
 
 Authentik owns the `jellyfin` OAuth2/OpenID provider and Jellyfin application. The provider name visible to Jellyfin is `authentik`, with client ID `jellyfin`, redirect URL `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`, and launch URL `https://jellyfin.${cluster_domain}/sso/OID/start/authentik`.
+
+The GitOps bootstrap writes the plugin configuration at `/config/plugins/configurations/SSO-Auth.xml`. For plugin `v4.0.0.4`, each OIDC provider dictionary value must be rooted as `<PluginConfiguration>` inside the `<value>` element. If it is written as `<OidConfig>`, the plugin rewrites `OidConfigs` empty and `/sso/OID/start/authentik` fails with `Provider does not exist`.
 
 Group membership is exposed through the `groups` OIDC scope and claim. Users must be in `Jellyfin Users` or `Jellyfin Admins` to pass plugin authorization. Members of `Jellyfin Admins` are mapped to Jellyfin administrators.
 

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -80,7 +80,7 @@ data:
         <item>
           <key><string>authentik</string></key>
           <value>
-            <OidConfig>
+            <PluginConfiguration>
               <OidEndpoint>{escape(oid_endpoint)}</OidEndpoint>
               <OidClientId>jellyfin</OidClientId>
               <OidSecret>{escape(client_secret)}</OidSecret>
@@ -110,7 +110,7 @@ data:
               <DoNotValidateEndpoints>false</DoNotValidateEndpoints>
               <DoNotValidateIssuerName>false</DoNotValidateIssuerName>
               <DoNotLoadProfile>false</DoNotLoadProfile>
-            </OidConfig>
+            </PluginConfiguration>
           </value>
         </item>
       </OidConfigs>

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -86,7 +86,7 @@ data:
                 plugin_zip.extractall(PLUGIN_DIR)
 
     def build_oid_config(canonical_links):
-        oid_config = ET.Element("OidConfig")
+        oid_config = ET.Element("PluginConfiguration")
         set_text(oid_config, "OidEndpoint", OID_ENDPOINT)
         set_text(oid_config, "OidClientId", CLIENT_ID)
         set_text(oid_config, "OidSecret", CLIENT_SECRET)
@@ -140,9 +140,11 @@ data:
 
         for item in list(oid_configs.findall("item")):
             if key_text(item) == PROVIDER_NAME:
-                existing = item.find("./value/OidConfig/CanonicalLinks")
-                if existing is not None:
-                    canonical_links = existing
+                for path in ("./value/PluginConfiguration/CanonicalLinks", "./value/OidConfig/CanonicalLinks"):
+                    existing = item.find(path)
+                    if existing is not None:
+                        canonical_links = existing
+                        break
                 oid_configs.remove(item)
 
         item = ET.SubElement(oid_configs, "item")

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def embedded_script(path: str) -> str:
+    lines = (REPO_ROOT / path).read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index("  bootstrap-sso.py: |") + 1
+    except ValueError:
+        raise AssertionError(f"bootstrap-sso.py block not found in {path}")
+
+    body: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith("    "):
+            break
+        body.append(line[4:] if line.startswith("    ") else "")
+    return "\n".join(body)
+
+
+class JellyfinSsoBootstrapTest(unittest.TestCase):
+    def test_production_bootstrap_writes_oid_value_with_plugin_configuration_root(self) -> None:
+        script = embedded_script("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
+
+        self.assertIn('PROVIDER_NAME = "authentik"', script)
+        self.assertIn('oid_config = ET.Element("PluginConfiguration")', script)
+        self.assertNotIn('oid_config = ET.Element("OidConfig")', script)
+        self.assertIn("./value/PluginConfiguration/CanonicalLinks", script)
+
+    def test_branch_bootstrap_static_xml_uses_plugin_configuration_value_root(self) -> None:
+        script = embedded_script("kubernetes/apps/jellyfin/branch/jellyfin.yaml")
+
+        self.assertIn("<key><string>authentik</string></key>", script)
+        self.assertIn("<value>\n        <PluginConfiguration>", script)
+        self.assertIn("</PluginConfiguration>\n      </value>", script)
+        self.assertNotIn("<OidConfig>", script)
+        self.assertNotIn("</OidConfig>", script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix Jellyfin SSO bootstrap configuration so the 9p4 SSO Authentication plugin `v4.0.0.4` can deserialize the `authentik` OIDC provider instead of rewriting `OidConfigs` empty.

## Important Changes

- Updated `kubernetes/apps/jellyfin/sso-bootstrap.yaml` so the generated `SerializableDictionary<string, OidConfig>` value uses `<PluginConfiguration>` under `<value>`, matching the plugin's `OidConfig` XML root.
- Preserved existing `CanonicalLinks` when rewriting the production provider, including links from either the corrected `<PluginConfiguration>` shape or the previous unreadable `<OidConfig>` shape.
- Updated `kubernetes/apps/jellyfin/branch/jellyfin.yaml` to use the same `<PluginConfiguration>` provider value root.
- Added `tools/tests/test_jellyfin_sso_bootstrap.py` to guard the production and branch bootstrap XML root shape.

## Documentation Impact

- Updated `docs/runbooks/jellyfin-authentik-sso.md` with the plugin configuration root requirement and the observed failure mode.
- `docs/architecture.md` was not regenerated because `python3 tools/architecture/render.py --check` passed.

## Checks

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `env cluster_domain=example.test nfs_server=192.0.2.10 bash -c 'kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict' >/tmp/jellyfin-render.yaml`
- PASS: `env cluster_domain=example.test nfs_server=192.0.2.10 branch_slug=sso-test bash -c 'kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict' >/tmp/jellyfin-branch-render.yaml`
- PASS: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap`
- PASS: transient Python validation extracted both embedded bootstrap scripts, ran `py_compile`, generated production and branch provider XML with dummy values, verified provider key `authentik`, verified `<value><PluginConfiguration>...</PluginConfiguration></value>`, and verified production `CanonicalLinks` preservation.
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`

## Development Validation

- Exception: development cluster validation was not run because `kubectl config current-context` returned `error: current-context is not set` in this environment.
- Substitute checks were the production and branch kustomize/envsubst renders, embedded script compilation, focused XML shape validation, unit test guard, architecture check, and diff whitespace check.
- Recommended follow-up before merge when credentials are available: run `python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-sso-config-xml --slug jellyfin-sso-config-xml --push`.

## Production Symptom And Fix Notes

- Symptom: production `/sso/OID/start/authentik` returned HTTP 400 with Jellyfin log `System.ArgumentException: Provider does not exist`.
- Root cause: the bootstrap wrote the dictionary value as `<OidConfig>`, but plugin `v4.0.0.4` deserializes each value with `XmlSerializer(typeof(OidConfig))`; because `OidConfig` has XML root `PluginConfiguration`, the unreadable provider was discarded and `OidConfigs` was rewritten empty.
- Fix: write the provider value with `<PluginConfiguration>` root while retaining provider key `authentik`.

## Branch

- Branch: `codex/jellyfin-sso-config-xml`
- HEAD: `74ee182f433541a3f904b43ec73a9fa1054229c9`
