### PR TITLE
Make Jellyfin SSO bootstrap restart-safe

### DIFF
--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -15,6 +15,8 @@ Authentik owns the `jellyfin` OAuth2/OpenID provider and Jellyfin application. T
 
 The GitOps bootstrap writes the plugin configuration at `/config/plugins/configurations/SSO-Auth.xml`. For plugin `v4.0.0.4`, each OIDC provider dictionary value must be rooted as `<PluginConfiguration>` inside the `<value>` element. If it is written as `<OidConfig>`, the plugin rewrites `OidConfigs` empty and `/sso/OID/start/authentik` fails with `Provider does not exist`.
 
+The bootstrap runs from an init container, so ConfigMap or init script changes require a Jellyfin pod restart before they take effect. The plugin install step is intentionally idempotent for rolling restarts: when the existing `SSO Authentication_4.0.0.4` directory already contains the expected plugin files, the bootstrap reuses it instead of deleting it from the shared config PVC while an older pod may still be serving traffic.
+
 Group membership is exposed through the `groups` OIDC scope and claim. Users must be in `Jellyfin Users` or `Jellyfin Admins` to pass plugin authorization. Members of `Jellyfin Admins` are mapped to Jellyfin administrators.
 
 Native Jellyfin login is intentionally preserved. Keep at least one local administrator or QuickConnect-capable fallback available for native clients and for recovery if Authentik, group claims, or the SSO plugin fail. The plugin does not provide an SSO logout callback; logging out of Jellyfin only ends the Jellyfin session.

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -54,23 +54,61 @@ data:
     plugin_dir = config_root / "plugins" / f"SSO Authentication_{plugin_version}"
     plugin_config = config_root / "plugins" / "configurations" / "SSO-Auth.xml"
     branding_config = config_root / "config" / "branding.xml"
+    expected_plugin_files = (
+        "SSO-Auth.dll",
+        "Duende.IdentityModel.dll",
+        "Duende.IdentityModel.OidcClient.dll",
+        "meta.json",
+    )
     public_url = os.environ["JELLYFIN_PUBLIC_URL"].rstrip("/")
     oid_endpoint = os.environ["JELLYFIN_OIDC_ENDPOINT"]
     client_secret = os.environ["JELLYFIN_OAUTH_CLIENT_SECRET"]
 
+    def plugin_install_complete(path=None):
+        plugin_path = plugin_dir if path is None else path
+        return plugin_path.is_dir() and all((plugin_path / name).is_file() for name in expected_plugin_files)
+
     try:
         plugin_dir.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            archive = Path(temp_dir) / "sso-authentication.zip"
-            with urllib.request.urlopen(plugin_url, timeout=60) as response:
-                archive.write_bytes(response.read())
-            if hashlib.sha256(archive.read_bytes()).hexdigest() != plugin_sha256:
-                raise RuntimeError("SSO Authentication plugin checksum mismatch")
-            if plugin_dir.exists():
-                shutil.rmtree(plugin_dir)
-            plugin_dir.mkdir(parents=True)
-            with zipfile.ZipFile(archive) as plugin_zip:
-                plugin_zip.extractall(plugin_dir)
+        if plugin_install_complete():
+            print(f"SSO Authentication plugin {plugin_version} already installed; skipping install")
+        else:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                archive = Path(temp_dir) / "sso-authentication.zip"
+                with urllib.request.urlopen(plugin_url, timeout=60) as response:
+                    archive.write_bytes(response.read())
+                if hashlib.sha256(archive.read_bytes()).hexdigest() != plugin_sha256:
+                    raise RuntimeError("SSO Authentication plugin checksum mismatch")
+
+                install_parent = plugin_dir.parent
+                with tempfile.TemporaryDirectory(
+                    prefix=f".{plugin_dir.name}.install-",
+                    dir=install_parent,
+                ) as staged_dir:
+                    staged_plugin_dir = Path(staged_dir) / plugin_dir.name
+                    staged_plugin_dir.mkdir()
+                    with zipfile.ZipFile(archive) as plugin_zip:
+                        plugin_zip.extractall(staged_plugin_dir)
+
+                    if not plugin_install_complete(staged_plugin_dir):
+                        missing = [
+                            name for name in expected_plugin_files
+                            if not (staged_plugin_dir / name).is_file()
+                        ]
+                        raise RuntimeError(
+                            "SSO Authentication plugin archive is incomplete; "
+                            f"missing expected files: {', '.join(missing)}"
+                        )
+
+                    if plugin_dir.exists():
+                        try:
+                            shutil.rmtree(plugin_dir)
+                        except OSError as exc:
+                            raise RuntimeError(
+                                "Existing SSO Authentication plugin directory is incomplete "
+                                "and could not be replaced safely; stop Jellyfin and retry"
+                            ) from exc
+                    staged_plugin_dir.rename(plugin_dir)
 
         plugin_config.parent.mkdir(parents=True, exist_ok=True)
         plugin_config.write_text(f"""<?xml version='1.0' encoding='utf-8'?>

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -29,6 +29,12 @@ data:
     PLUGIN_DIR = CONFIG_ROOT / "plugins" / f"SSO Authentication_{PLUGIN_VERSION}"
     PLUGIN_CONFIG = CONFIG_ROOT / "plugins" / "configurations" / "SSO-Auth.xml"
     BRANDING_CONFIG = CONFIG_ROOT / "config" / "branding.xml"
+    EXPECTED_PLUGIN_FILES = (
+        "SSO-Auth.dll",
+        "Duende.IdentityModel.dll",
+        "Duende.IdentityModel.OidcClient.dll",
+        "meta.json",
+    )
 
     def indent(element, level=0):
         spacing = "\n" + level * "  "
@@ -70,8 +76,16 @@ data:
         string = key.find("string")
         return string.text if string is not None else None
 
+    def plugin_install_complete(path=None):
+        plugin_path = PLUGIN_DIR if path is None else path
+        return plugin_path.is_dir() and all((plugin_path / name).is_file() for name in EXPECTED_PLUGIN_FILES)
+
     def install_plugin():
         PLUGIN_DIR.parent.mkdir(parents=True, exist_ok=True)
+        if plugin_install_complete():
+            print(f"SSO Authentication plugin {PLUGIN_VERSION} already installed; skipping install")
+            return
+
         with tempfile.TemporaryDirectory() as temp_dir:
             archive = Path(temp_dir) / "sso-authentication.zip"
             with urllib.request.urlopen(PLUGIN_URL, timeout=60) as response:
@@ -79,11 +93,36 @@ data:
             digest = hashlib.sha256(archive.read_bytes()).hexdigest()
             if digest != PLUGIN_SHA256:
                 raise RuntimeError("SSO Authentication plugin checksum mismatch")
-            if PLUGIN_DIR.exists():
-                shutil.rmtree(PLUGIN_DIR)
-            PLUGIN_DIR.mkdir(parents=True)
-            with zipfile.ZipFile(archive) as plugin_zip:
-                plugin_zip.extractall(PLUGIN_DIR)
+
+            install_parent = PLUGIN_DIR.parent
+            with tempfile.TemporaryDirectory(
+                prefix=f".{PLUGIN_DIR.name}.install-",
+                dir=install_parent,
+            ) as staged_dir:
+                staged_plugin_dir = Path(staged_dir) / PLUGIN_DIR.name
+                staged_plugin_dir.mkdir()
+                with zipfile.ZipFile(archive) as plugin_zip:
+                    plugin_zip.extractall(staged_plugin_dir)
+
+                if not plugin_install_complete(staged_plugin_dir):
+                    missing = [
+                        name for name in EXPECTED_PLUGIN_FILES
+                        if not (staged_plugin_dir / name).is_file()
+                    ]
+                    raise RuntimeError(
+                        "SSO Authentication plugin archive is incomplete; "
+                        f"missing expected files: {', '.join(missing)}"
+                    )
+
+                if PLUGIN_DIR.exists():
+                    try:
+                        shutil.rmtree(PLUGIN_DIR)
+                    except OSError as exc:
+                        raise RuntimeError(
+                            "Existing SSO Authentication plugin directory is incomplete "
+                            "and could not be replaced safely; stop Jellyfin and retry"
+                        ) from exc
+                staged_plugin_dir.rename(PLUGIN_DIR)
 
     def build_oid_config(canonical_links):
         oid_config = ET.Element("PluginConfiguration")

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import unittest
+import io
+import os
+import tempfile
+import zipfile
+from unittest import mock
 from pathlib import Path
 
 
@@ -22,6 +27,22 @@ def embedded_script(path: str) -> str:
     return "\n".join(body)
 
 
+def embedded_script_namespace(path: str) -> dict[str, object]:
+    script = embedded_script(path)
+    definitions = script.split("\ntry:\n", 1)[0]
+    namespace: dict[str, object] = {}
+    with mock.patch.dict(
+        os.environ,
+        {
+            "JELLYFIN_OIDC_ENDPOINT": "https://authentik.example.test/application/o/jellyfin/.well-known/openid-configuration",
+            "JELLYFIN_PUBLIC_URL": "https://jellyfin.example.test",
+            "JELLYFIN_OAUTH_CLIENT_SECRET": "test-secret",
+        },
+    ):
+        exec(compile(definitions, path, "exec"), namespace)
+    return namespace
+
+
 class JellyfinSsoBootstrapTest(unittest.TestCase):
     def test_production_bootstrap_writes_oid_value_with_plugin_configuration_root(self) -> None:
         script = embedded_script("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
@@ -39,6 +60,76 @@ class JellyfinSsoBootstrapTest(unittest.TestCase):
         self.assertIn("</PluginConfiguration>\n      </value>", script)
         self.assertNotIn("<OidConfig>", script)
         self.assertNotIn("</OidConfig>", script)
+
+    def test_production_bootstrap_skips_complete_plugin_without_removing_it(self) -> None:
+        namespace = embedded_script_namespace("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_dir = Path(temp_dir) / "plugins" / "SSO Authentication_4.0.0.4"
+            plugin_dir.mkdir(parents=True)
+            for filename in namespace["EXPECTED_PLUGIN_FILES"]:
+                (plugin_dir / filename).write_text("present", encoding="utf-8")
+
+            namespace["PLUGIN_DIR"] = plugin_dir
+            with (
+                mock.patch("builtins.print"),
+                mock.patch.object(namespace["shutil"], "rmtree", side_effect=AssertionError("rmtree called")),
+                mock.patch.object(namespace["urllib"].request, "urlopen", side_effect=AssertionError("download called")),
+            ):
+                namespace["install_plugin"]()
+
+            self.assertTrue(plugin_dir.is_dir())
+
+    def test_production_bootstrap_reports_incomplete_plugin_replacement_failure(self) -> None:
+        namespace = embedded_script_namespace("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
+
+        archive_buffer = io.BytesIO()
+        with zipfile.ZipFile(archive_buffer, "w") as plugin_zip:
+            for filename in namespace["EXPECTED_PLUGIN_FILES"]:
+                plugin_zip.writestr(filename, "present")
+        archive_bytes = archive_buffer.getvalue()
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+            def read(self):
+                return archive_bytes
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            plugin_dir = Path(temp_dir) / "plugins" / "SSO Authentication_4.0.0.4"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "SSO-Auth.dll").write_text("partial", encoding="utf-8")
+
+            namespace["PLUGIN_DIR"] = plugin_dir
+            namespace["PLUGIN_SHA256"] = namespace["hashlib"].sha256(archive_bytes).hexdigest()
+            with (
+                mock.patch.object(namespace["urllib"].request, "urlopen", return_value=Response()),
+                mock.patch.object(namespace["shutil"], "rmtree", side_effect=OSError("busy")),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "could not be replaced safely; stop Jellyfin and retry"):
+                    namespace["install_plugin"]()
+
+    def test_bootstrap_scripts_check_expected_plugin_files_before_reinstalling(self) -> None:
+        production = embedded_script("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
+        branch = embedded_script("kubernetes/apps/jellyfin/branch/jellyfin.yaml")
+
+        for script in (production, branch):
+            self.assertIn("SSO-Auth.dll", script)
+            self.assertIn("Duende.IdentityModel.dll", script)
+            self.assertIn("Duende.IdentityModel.OidcClient.dll", script)
+            self.assertIn("meta.json", script)
+            self.assertIn("plugin_install_complete()", script)
+            self.assertIn("already installed; skipping install", script)
+            self.assertIn(".is_file() for name in", script)
+            self.assertIn(".install-", script)
+            self.assertIn("could not be replaced safely", script)
+
+        self.assertNotIn("if PLUGIN_DIR.exists():\n                shutil.rmtree(PLUGIN_DIR)", production)
+        self.assertNotIn("if plugin_dir.exists():\n                shutil.rmtree(plugin_dir)", branch)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make the Jellyfin SSO plugin bootstrap idempotent so a corrected ConfigMap/init script restart can safely run while the old pod is still using the shared config PVC.

## Production Symptom

After PR #289 reached production, a manual rollout restart attempted to run the corrected init container, but the new pod failed with `OSError: [Errno 16] Resource busy` while deleting `/config/plugins/SSO Authentication_4.0.0.4`. Production was stabilized with a rollout undo, leaving the old ready pod serving traffic but SSO startup still blocked until the bootstrap is safe for rolling restarts.

## Changes

- Updated `kubernetes/apps/jellyfin/sso-bootstrap.yaml` to treat an existing plugin directory as complete when `SSO-Auth.dll`, `Duende.IdentityModel.dll`, `Duende.IdentityModel.OidcClient.dll`, and `meta.json` are present, skipping deletion and download in that case.
- Updated `kubernetes/apps/jellyfin/branch/jellyfin.yaml` with the same completeness check and staged temporary install behavior for branch environments.
- In incomplete/missing cases, the bootstrap extracts into a temporary sibling directory, validates expected files, then replaces the target only after extraction succeeds. If an incomplete existing target cannot be removed, it fails with a clear stop-and-retry message instead of hiding the busy PVC condition.
- Extended `tools/tests/test_jellyfin_sso_bootstrap.py` to guard the complete-plugin skip path, expected plugin file checks, absence of the unsafe immediate `exists() -> rmtree()` pattern, and the clear incomplete replacement failure.

## Documentation Impact

- Updated `docs/runbooks/jellyfin-authentik-sso.md` to note that init ConfigMap/script changes require a pod restart and that the plugin install step is intentionally idempotent for rolling restarts.
- `docs/architecture.md` was not regenerated because `python3 tools/architecture/render.py --check` passed.

## Checks

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap` passed.
- Embedded production and branch bootstrap scripts were extracted to temp files and `py_compile` passed.
- `cluster_domain=example.test kubectl kustomize kubernetes/apps/jellyfin | envsubst >/tmp/jellyfin-production-render.yaml` passed.
- `branch_slug=codex-jellyfin cluster_domain=example.test kubectl kustomize kubernetes/apps/jellyfin/branch | envsubst >/tmp/jellyfin-branch-render.yaml` passed.
- `python3 tools/architecture/render.py --check` passed.
- `git diff --check` passed.

## Development Validation

- Risk tier: high, because this affects authentication bootstrap and the production rollout recovery path.
- Development live validation exception: this implementation environment does not have development cluster access configured. `kubectl config current-context` failed with current-context unset, and `KUBECONFIG` is not set.
- Substitute checks: production and branch local renders, embedded script compilation, focused executable bootstrap tests for complete and incomplete plugin states, architecture freshness check, and whitespace diff check.

## Branch

- Branch: `codex/jellyfin-sso-idempotent-install`
- HEAD: `0d04dfef869369a08f927b9afa9280e7cf10ec2e`
