### PR TITLE
Force HTTPS for Jellyfin SSO redirects

### DIFF
--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -15,6 +15,8 @@ Authentik owns the `jellyfin` OAuth2/OpenID provider and Jellyfin application. T
 
 The GitOps bootstrap writes the plugin configuration at `/config/plugins/configurations/SSO-Auth.xml`. For plugin `v4.0.0.4`, each OIDC provider dictionary value must be rooted as `<PluginConfiguration>` inside the `<value>` element. If it is written as `<OidConfig>`, the plugin rewrites `OidConfigs` empty and `/sso/OID/start/authentik` fails with `Provider does not exist`.
 
+Jellyfin sits behind Gateway API TLS termination, so the upstream hop into the pod is HTTP even though the public route is HTTPS. The Authentik provider strictly allows `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`; keep the plugin `<SchemeOverride>` set to `https` so Jellyfin generates that redirect URI instead of an `http://` callback.
+
 The bootstrap runs from an init container, so ConfigMap or init script changes require a Jellyfin pod restart before they take effect. The plugin install step is intentionally idempotent for rolling restarts: when the existing `SSO Authentication_4.0.0.4` directory already contains the expected plugin files, the bootstrap reuses it instead of deleting it from the shared config PVC while an older pod may still be serving traffic.
 
 Group membership is exposed through the `groups` OIDC scope and claim. Users must be in `Jellyfin Users` or `Jellyfin Admins` to pass plugin authorization. Members of `Jellyfin Admins` are mapped to Jellyfin administrators.

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -138,7 +138,7 @@ data:
               <RoleClaim>groups</RoleClaim>
               <OidScopes><string>groups</string></OidScopes>
               <DefaultProvider />
-              <SchemeOverride />
+              <SchemeOverride>https</SchemeOverride>
               <NewPath>true</NewPath>
               <CanonicalLinks />
               <DefaultUsernameClaim>preferred_username</DefaultUsernameClaim>

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -145,7 +145,7 @@ data:
         set_text(oid_config, "RoleClaim", "groups")
         set_string_array(oid_config, "OidScopes", ["groups"])
         set_text(oid_config, "DefaultProvider", "")
-        set_text(oid_config, "SchemeOverride", "")
+        set_text(oid_config, "SchemeOverride", "https")
         set_bool(oid_config, "NewPath", True)
         if canonical_links is not None:
             oid_config.append(canonical_links)

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -61,6 +61,16 @@ class JellyfinSsoBootstrapTest(unittest.TestCase):
         self.assertNotIn("<OidConfig>", script)
         self.assertNotIn("</OidConfig>", script)
 
+    def test_bootstrap_scripts_force_https_scheme_for_gateway_tls_termination(self) -> None:
+        production = embedded_script_namespace("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
+        oid_config = production["build_oid_config"](None)
+
+        self.assertEqual(oid_config.findtext("SchemeOverride"), "https")
+
+        branch = embedded_script("kubernetes/apps/jellyfin/branch/jellyfin.yaml")
+        self.assertIn("<SchemeOverride>https</SchemeOverride>", branch)
+        self.assertNotIn("<SchemeOverride />", branch)
+
     def test_production_bootstrap_skips_complete_plugin_without_removing_it(self) -> None:
         namespace = embedded_script_namespace("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
 


### PR DESCRIPTION
# Jellyfin SSO Scheme Override

## Summary

Fixes the production Jellyfin OAuth redirect scheme by configuring the SSO Authentication plugin Authentik provider with `<SchemeOverride>https</SchemeOverride>`.

Production symptom: after rollout, `/sso/OID/start/authentik` redirected to Authentik with `redirect_uri=http%3A%2F%2Fjellyfin.lab.petebeegle.com%2Fsso%2FOID%2Fredirect%2Fauthentik`; Authentik rejected it with HTTP 400 Redirect URI Error because the provider strictly allows the HTTPS callback.

## Important Changes

- Updated `kubernetes/apps/jellyfin/sso-bootstrap.yaml` to write `SchemeOverride=https` for the production Authentik OIDC provider.
- Updated `kubernetes/apps/jellyfin/branch/jellyfin.yaml` to set the same scheme override in branch environments.
- Extended `tools/tests/test_jellyfin_sso_bootstrap.py` to guard both bootstraps while preserving the previous XML value root and idempotent plugin install checks.

## Documentation Impact

- Updated `docs/runbooks/jellyfin-authentik-sso.md` to document that Gateway API TLS termination requires the Jellyfin SSO plugin HTTPS scheme override so strict Authentik redirect URI validation receives `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`.

## Checks

- Passed: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- Passed: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- Passed: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- Red/green evidence: updated `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap` first failed with `AssertionError: '' != 'https'` before the manifest fix, then passed after the fix.
- Passed: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap`
- Passed: `export cluster_domain=lab.petebeegle.com nfs_server=192.168.30.99; kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict > .codex/tmp/rendered/jellyfin-production.yaml`
- Passed: `export cluster_domain=lab.petebeegle.com branch_slug=scheme-test; kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict > .codex/tmp/rendered/jellyfin-branch.yaml`
- Passed: extracted embedded production and branch `bootstrap-sso.py` scripts to `.codex/tmp/extracted-scripts/` and ran `python3 -m py_compile` on both.
- Passed: `python3 tools/architecture/render.py --check`
- Passed: `git diff --check`

## Development Validation

Risk tier: high, because this changes authentication behavior on a production OAuth traffic path.

Development smoke profile: `none`. The repository has a Jellyfin development branch profile, but this environment has no available kubeconfig context (`kubectl config current-context` and `kubectl config get-contexts -o name` returned no context names), so live development reconciliation could not be run.

Substitute checks used: focused red/green unit coverage for both bootstraps, production and branch kustomize plus Flux envsubst renders, embedded script `py_compile`, architecture freshness check, and whitespace diff check.

## Branch

- Branch: `codex/jellyfin-sso-scheme-override`
- HEAD: `b876d3f13234c6cc8845ffb46552fd5d6a5ab80d`
- Commit: `fix(jellyfin): force https sso redirect scheme`
