### PR TITLE
Allow Jellyfin Authentik authorization code grant

### DIFF
--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -13,6 +13,8 @@ Jellyfin web SSO is provided by the 9p4 SSO Authentication plugin, pinned in Git
 
 Authentik owns the `jellyfin` OAuth2/OpenID provider and Jellyfin application. The provider name visible to Jellyfin is `authentik`, with client ID `jellyfin`, redirect URL `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`, and launch URL `https://jellyfin.${cluster_domain}/sso/OID/start/authentik`.
 
+The Authentik provider must allow the `authorization_code` grant type, with `refresh_token` enabled alongside it for the normal web authorization-code flow. If Authentik redirects back to Jellyfin with `error=invalid_request&error_description=The request is otherwise malformed` and the Authentik server logs show `Invalid grant_type for provider` with `grant_type=authorization_code`, confirm the Jellyfin provider blueprint includes those grant types.
+
 The GitOps bootstrap writes the plugin configuration at `/config/plugins/configurations/SSO-Auth.xml`. For plugin `v4.0.0.4`, each OIDC provider dictionary value must be rooted as `<PluginConfiguration>` inside the `<value>` element. If it is written as `<OidConfig>`, the plugin rewrites `OidConfigs` empty and `/sso/OID/start/authentik` fails with `Provider does not exist`.
 
 Jellyfin sits behind Gateway API TLS termination, so the upstream hop into the pod is HTTP even though the public route is HTTPS. The Authentik provider strictly allows `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`; keep the plugin `<SchemeOverride>` set to `https` so Jellyfin generates that redirect URI instead of an `http://` callback.

--- a/kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml
+++ b/kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml
@@ -41,6 +41,9 @@ entries:
       authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
       client_type: confidential
+      grant_types:
+        - authorization_code
+        - refresh_token
       client_id: !Context jellyfin_client_id
       client_secret: !Context jellyfin_client_secret
       redirect_uris:

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -12,6 +12,27 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def jellyfin_oauth_provider_attr_lines() -> list[str]:
+    path = REPO_ROOT / "kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml"
+    lines = path.read_text(encoding="utf-8").splitlines()
+    provider_start = next(
+        index
+        for index, line in enumerate(lines)
+        if line == "    model: authentik_providers_oauth2.oauth2provider"
+        and index > 0
+        and lines[index - 2] == "  - identifiers:"
+        and lines[index - 1] == "      name: jellyfin"
+    )
+    attrs_start = next(
+        index for index in range(provider_start, len(lines)) if lines[index] == "    attrs:"
+    )
+    provider_end = next(
+        (index for index in range(attrs_start + 1, len(lines)) if lines[index].startswith("  - identifiers:")),
+        len(lines),
+    )
+    return lines[attrs_start + 1 : provider_end]
+
+
 def embedded_script(path: str) -> str:
     lines = (REPO_ROOT / path).read_text(encoding="utf-8").splitlines()
     try:
@@ -44,6 +65,17 @@ def embedded_script_namespace(path: str) -> dict[str, object]:
 
 
 class JellyfinSsoBootstrapTest(unittest.TestCase):
+    def test_authentik_jellyfin_provider_allows_authorization_code_with_refresh_tokens(self) -> None:
+        attrs = jellyfin_oauth_provider_attr_lines()
+        grant_types_start = attrs.index("      grant_types:")
+        grant_types: list[str] = []
+        for line in attrs[grant_types_start + 1 :]:
+            if not line.startswith("        - "):
+                break
+            grant_types.append(line.removeprefix("        - "))
+
+        self.assertEqual(grant_types, ["authorization_code", "refresh_token"])
+
     def test_production_bootstrap_writes_oid_value_with_plugin_configuration_root(self) -> None:
         script = embedded_script("kubernetes/apps/jellyfin/sso-bootstrap.yaml")
 


### PR DESCRIPTION
# jellyfin-authentik-grant-types

## Summary

Fix the production Jellyfin OAuth flow by explicitly enabling the Authentik provider grant types needed for the web authorization-code flow.

## Important Changes

- Added `grant_types` to the Jellyfin Authentik OAuth2 provider blueprint with only:
  - `authorization_code`
  - `refresh_token`
- Added a focused unittest that parses the Jellyfin provider block and asserts those grant types.
- Updated the Jellyfin Authentik SSO runbook with the grant type requirement and the observed failure symptom.

## Documentation Impact

Updated `docs/runbooks/jellyfin-authentik-sso.md` because operator troubleshooting now needs to cover Authentik 2026.5 provider `grant_types`.

## Production Symptom

Production Jellyfin `/sso/OID/start/authentik` redirects to Authentik with an HTTPS callback, but Authentik redirects back with `error=invalid_request&error_description=The request is otherwise malformed`. Authentik logs show `Invalid grant_type for provider` with `grant_type=authorization_code` and redirect URI `https://jellyfin.lab.petebeegle.com/sso/OID/redirect/authentik`.

## Checks

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap`
- PASS: `python3 -m unittest discover tools/tests`
- PASS: `env cluster_domain=lab.example.test bash -c 'kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict > /tmp/jellyfin-authentik-grant-types-rendered.yaml'`
- PASS: rendered Authentik output contains Jellyfin provider `grant_types: [authorization_code, refresh_token]`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`

Note: An initial render attempt failed because the dummy `cluster_domain` variable was scoped only to the `kubectl` side of the pipe; it passed after rerunning with the environment visible to `flux envsubst`.

## Development Validation

Exception recorded: no current Kubernetes context is configured in this environment, so I could not run a development-cluster smoke. The development cluster architecture also does not activate the production Authentik infra path, so the production Authentik blueprint cannot be fully exercised by the existing branch app profiles.

Substitute checks were the focused unit regression, strict local Authentik kustomize rendering with dummy substitution, rendered blueprint inspection, architecture freshness check, and whitespace validation.

## Branch State

- Branch: `codex/jellyfin-authentik-grant-types`
- HEAD: `49fb208f9a58bbc2ce3ab56377b915853f68f07a`
- Commit: `fix(authentik): allow jellyfin authorization code grant`
