### PR TITLE
Fix Jellyfin OAuth secret drift

### DIFF
--- a/kubernetes/apps/jellyfin/secret.yaml
+++ b/kubernetes/apps/jellyfin/secret.yaml
@@ -18,6 +18,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-17T00:51:25Z"
-    mac: ENC[AES256_GCM,data:t5Zml82LbJTk79pxlunHWjwZrSwkOQfNzN9AYyqy9ReieG+thZ4M0bH9xILhzZ7m6zuhVtSPPLZfrvv6L4XW1E4UVQM/XALNGvi9wEU3SuvVGx30L8mQUB0AKF8O4i4vp2GwNvW67KG4kSX5MyxCdSuJqc05wWtVogvGREBt3xI=,iv:lc/dRREKBlUxLdLY2+YheVAOuucuOFa22PLFpG775vs=,tag:Yx3svXkVwH7ul5WMfAJccQ==,type:str]
+    lastmodified: "2026-05-23T21:54:25Z"
+    mac: ENC[AES256_GCM,data:ijQXTuyOoKp3YpwN2adG+hN8H9FKOHPmFvgPKBiUuPrXA2925YaGQdLyetfVeXACEADaKIHjp81Sq5tSG1+V2yYw2JOCLplVaLpPTLfsjax0zrp81N9DxzwU0AWXsv4Aen3lhkIvgLiAu7SNvsNfR22+/VHRoNL7vY5EsKlYFVY=,iv:DwbN2OVkCwOIw3c4+kJgNDyTcntEg4AGXf9KJ/MC1kg=,tag:9vd3hmCJLIVU+cniFjji+Q==,type:str]
     version: 3.13.0


### PR DESCRIPTION
## Summary

- Align Jellyfin's encrypted `JELLYFIN_OAUTH_CLIENT_SECRET` with the Authentik encrypted provider secret in repo desired state.
- Keep plaintext secret material out of logs and local non-SOPS files.
- No-plaintext comparison showed the pre-edit repo Jellyfin value already matched Authentik; this SOPS re-save creates a GitOps revision to reconcile the drifted live production Secret back to repo desired state.

## Workflow

- Implementation fallback: the user explicitly assigned this session as implementation owner for `jellyfin-oauth-secret-align`; no separate implementation subagent tool is available in this runtime.
- Verification status: pending separate verifier review for exact HEAD; this implementation owner will not self-verify or open a PR.
- Branch: `codex/jellyfin-oauth-secret-align`
- Exact HEAD: `bbc96c4fe5f726d137d08549b0a53d401f678baf`
- Commit: `fix(jellyfin): realign oauth client secret`

## Documentation Impact

- No docs changed. This is an encrypted data correction only and does not alter architecture, runbooks, app wiring, or operator procedures.

## Validation

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `sops --decrypt kubernetes/infra/authentik/secret.yaml >/dev/null`
- PASS: `sops --decrypt kubernetes/apps/jellyfin/secret.yaml >/dev/null`
- PASS: no-plaintext SHA comparison of `stringData.JELLYFIN_OAUTH_CLIENT_SECRET` between `kubernetes/infra/authentik/secret.yaml` and `kubernetes/apps/jellyfin/secret.yaml`
- PASS: no-plaintext SHA comparison showed `HEAD:kubernetes/apps/jellyfin/secret.yaml` already matched the Authentik value before this SOPS re-save
- PASS: `kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict >/dev/null` after exporting production `cluster-vars`
- PASS: `kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict >/dev/null` after exporting production `cluster-vars`
- NOTE: the same two envsubst commands without exported cluster vars failed with `variable not set (strict mode): "cluster_domain"`, which is expected for shared manifests rendered outside Flux postBuild substitution.
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`
- PASS: `sops filestatus kubernetes/apps/jellyfin/secret.yaml`
- PASS after commit: repeated SOPS decrypt/equality checks, Jellyfin/Authentik kustomize/envsubst checks with production cluster vars, architecture check, and `git diff --check` at `bbc96c4fe5f726d137d08549b0a53d401f678baf`.

## Development Validation

- Exception recorded: no development kube context or staged development kubeconfig/credentials were available in this implementation clone, and the correction targets a production live Secret drift from the repository's encrypted desired state. Substitute checks were SOPS decryptability, no-plaintext equality comparisons, production cluster-var renders for Jellyfin and Authentik, architecture check, and diff hygiene.

## Verifier

- Approved exact HEAD: bbc96c4fe5f726d137d08549b0a53d401f678baf
- Verifier found no blockers; diff is scoped to encrypted Jellyfin SOPS secret metadata and plaintext was not exposed.
