### PR TITLE
Align Jellyfin OAuth provider secret source

### DIFF
--- a/kubernetes/apps/jellyfin/secret.yaml
+++ b/kubernetes/apps/jellyfin/secret.yaml
@@ -18,6 +18,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-23T21:54:25Z"
-    mac: ENC[AES256_GCM,data:ijQXTuyOoKp3YpwN2adG+hN8H9FKOHPmFvgPKBiUuPrXA2925YaGQdLyetfVeXACEADaKIHjp81Sq5tSG1+V2yYw2JOCLplVaLpPTLfsjax0zrp81N9DxzwU0AWXsv4Aen3lhkIvgLiAu7SNvsNfR22+/VHRoNL7vY5EsKlYFVY=,iv:DwbN2OVkCwOIw3c4+kJgNDyTcntEg4AGXf9KJ/MC1kg=,tag:9vd3hmCJLIVU+cniFjji+Q==,type:str]
+    lastmodified: "2026-05-24T00:42:05Z"
+    mac: ENC[AES256_GCM,data:HOh7MnljtPrDcZ9fRx7fXjf/HVbdDg41fm6jeILz1aq3liIRah4kNNLViIvQIBnd+dfVDctI9eogNOSqOC7xwUWyuuxVknJl9eCgKCtjwtQU34LloF4A5e8I6PYuEVmSs0OvY2Zw5Ho7Svt0EKbLaPrX6Y7ET6M+4LWNBCtgg+8=,iv:GbZPW9xJy9CyBzj5MG/ng7G9rHdsO94z/DgVvukdhhw=,tag:47ChUwzO5NOnaxdw8trQ3g==,type:str]
     version: 3.13.0

--- a/kubernetes/infra/authentik/secret.yaml
+++ b/kubernetes/infra/authentik/secret.yaml
@@ -26,6 +26,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-17T00:53:08Z"
-    mac: ENC[AES256_GCM,data:Ze0KESK6urn3Zpsz/i83edcon+Y/XUFN+4xS3Sz3yLqz3UAipn3Thf4tmOFa8M/rZtRqrSEtz0WsOm/BY0/Wj8m1GdLkf5P9WbYJ496WTxMVDiD4AXYGQrnSfUdfN+Nuq951OqSVI3prayN43KcDVIjqWj88A7654j7zuaCj9mk=,iv:sDQyhiag+tfeW7QzvC9ODMYg5nytwScNp/XPRqe8w/U=,tag:bwB8lfrzHXItoZzNH7L0cA==,type:str]
+    lastmodified: "2026-05-24T00:42:05Z"
+    mac: ENC[AES256_GCM,data:Bzsj0Kap31MX4M6LQNnZ9vMJWL+rlvtQBAv/MVvEc0Wcuxkt5YYWDzY9/Pg3DTrsnaGuRequbr2tKbqY9I8Lazi6ZJlrST1FxGhrY1DPB8tFTGDrViys0ZonXYawIOFcELhObHtFkQ+NmzwsCrsFCi99XUGL3U3NdaflUG5wWlI=,iv:/e2SXYhKpso3gsXbpF+zLz2qfI+sHybP6meJS/RsRpw=,tag:q5DkxSWC0pv3ZGsmECvZIw==,type:str]
     version: 3.11.0


### PR DESCRIPTION
## Summary

Align the repository Authentik and Jellyfin OAuth client secret manifests with the current production Authentik OAuth2 provider secret for provider `jellyfin`.

## Important Changes

- Updated `kubernetes/infra/authentik/secret.yaml` through `sops set --value-stdin` for `stringData.JELLYFIN_OAUTH_CLIENT_SECRET`.
- Updated `kubernetes/apps/jellyfin/secret.yaml` through `sops set --value-stdin` for `stringData.JELLYFIN_OAUTH_CLIENT_SECRET`.
- No plaintext secret value was printed or persisted outside SOPS-managed files.

## Implementation Notes

- The implementation owner identity is `implementation-agent-jellyfin-oauth-provider-secret-source`.
- The requested provider secret was retrieved from production Authentik with `ak shell`, captured only inside command pipelines, and passed to SOPS via stdin.
- A comparison against `origin/main` found that the decrypted `JELLYFIN_OAUTH_CLIENT_SECRET` values already matched the production Authentik provider secret before the local SOPS refresh; the committed diff is therefore SOPS metadata only, while decrypted desired state remains provider-matching in both manifests.

## Validation Evidence

- Workflow marker validator: passed.
- Implementation plan validator: passed.
- Owner attestation validator: passed.
- SOPS/decrypted equality check: passed.
  - `provider_secret_present=True`
  - `authentik_repo_matches_provider=True`
  - `jellyfin_repo_matches_provider=True`
  - `repo_secrets_match_each_other=True`
  - `provider_secret_length=64`
- `origin/main` comparison: both repo SOPS manifests already decrypted equal to the current provider secret, and current worktree values still equal it.
- SOPS guard: passed.
- Git diff plaintext check: passed; no changed `JELLYFIN_OAUTH_CLIENT_SECRET` plaintext line was present in the diff.
- `kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict` with production `cluster-vars`: passed.
- `kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict` with production `cluster-vars`: passed.
- `python3 tools/architecture/render.py --check`: passed.
- `git diff --check`: passed.

## Development Validation

Development validation exception: `smoke_profile: none`. The development cluster is reachable as `admin@homelab-development`, but it does not run the production Authentik or Jellyfin namespaces/apps, and the authoritative value for this task is the production Authentik OAuth2 provider database secret. Substitute checks were production provider equality, no-plaintext checks, local render/envsubst checks, architecture check, and git whitespace check.

Additional production live evidence supplied by the requester after the temporary live patch and Jellyfin restart:

- `provider_secret_matches_live_jellyfin=yes`
- `jellyfin_oid_secret_matches_live_secret=yes`
- `external SSO start_status=302`
- `authorize_status=302`
- `redirect_uri_https_public=yes`
- Recent Authentik logs have no `invalid_client` or token errors.

## Documentation Impact

No documentation files were changed. This implementation only refreshes encrypted secret manifest content/metadata and does not alter operating procedures, manifest shape, app wiring, or documented behavior.

## Push / PR Status

Branch: `codex/jellyfin-oauth-provider-secret-source`

Committed HEAD: `1e127a407af9f8b351e8fb85df97d45cf67df6a8`

Not pushed and no PR opened yet. Workflow requires separate verifier approval for the exact committed HEAD before push or PR creation.

## Verifier

- Approved exact HEAD: 1e127a407af9f8b351e8fb85df97d45cf67df6a8
- Verifier found no blockers; both repo secrets match the live Authentik provider secret without plaintext exposure.
