### PR TITLE
feat(terraform): add Jellyfin GPU node passthrough

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,10 +204,12 @@ This lists secret manifest presence only. Secret values are not rendered.
 | `development` | Module | `kubernetes_nodes` | `../modules/vm` | `(none)` |
 | `development` | Module | `talos_bootstrap` | `../modules/talos-bootstrap` | `kubernetes_nodes, talos_provision` |
 | `development` | Module | `talos_provision` | `../modules/talos-provision` | `(none)` |
+| `development` | Root resource | `proxmox_hardware_mapping_pci.jellyfin_igpu` | `(root)` | `(none)` |
 | `development` | Root resource | `proxmox_virtual_environment_file.talos_iso` | `(root)` | `talos_provision` |
 | `development` | Root resource | `terraform_data.bootstrap_script` | `(root)` | `talos_bootstrap` |
 | `production` | Module | `kubernetes_nodes` | `../modules/vm` | `(none)` |
 | `production` | Module | `talos_bootstrap` | `../modules/talos-bootstrap` | `kubernetes_nodes, talos_provision` |
 | `production` | Module | `talos_provision` | `../modules/talos-provision` | `(none)` |
+| `production` | Root resource | `proxmox_hardware_mapping_pci.jellyfin_igpu` | `(root)` | `(none)` |
 | `production` | Root resource | `proxmox_virtual_environment_file.talos_iso` | `(root)` | `talos_provision` |
 | `production` | Root resource | `terraform_data.bootstrap_script` | `(root)` | `talos_bootstrap` |

--- a/docs/runbooks/jellyfin-gpu-nodes.md
+++ b/docs/runbooks/jellyfin-gpu-nodes.md
@@ -1,0 +1,75 @@
+---
+status: current
+scope:
+  - jellyfin
+  - gpu
+  - talos
+  - terraform
+last_verified: 2026-05-24
+---
+
+# Jellyfin GPU Nodes
+
+Jellyfin hardware transcoding nodes are prepared by Terraform before any Jellyfin workload scheduling change. The Proxmox VM layer attaches a cluster-specific PCI hardware mapping, and the Talos bootstrap layer applies stable Kubernetes node labels through `machine.nodeLabels`.
+
+Proxmox PCI hardware mappings are cluster-scoped, so each Terraform root must own a distinct mapping name. Production owns `jellyfin-igpu` with only the pve01 and pve02 entries. Development owns `jellyfin-igpu-dev` with only the pve04 entry.
+
+Expected Jellyfin-capable nodes:
+
+| Cluster | Mapping | Proxmox host | VMID | Address |
+| --- | --- | --- | --- | --- |
+| production | `jellyfin-igpu` | `pve01` | `160` | `192.168.30.160` |
+| production | `jellyfin-igpu` | `pve02` | `161` | `192.168.30.161` |
+| development | `jellyfin-igpu-dev` | `pve04` | `170` | `192.168.30.170` |
+
+Each Talos node should have these stable labels:
+
+- `homelab.petebeegle.com/proxmox-host`
+- `homelab.petebeegle.com/vm-id`
+- `homelab.petebeegle.com/machine-type`
+- `homelab.petebeegle.com/jellyfin-igpu=true` on the Jellyfin-capable nodes only
+
+## Readiness Checks
+
+Confirm the labels without depending on generated Kubernetes node names:
+
+```sh
+kubectl get nodes --show-labels | grep 'homelab.petebeegle.com/jellyfin-igpu=true'
+kubectl get nodes -l homelab.petebeegle.com/jellyfin-igpu=true -o wide
+```
+
+Confirm Talos can see the passed-through render devices before scheduling Jellyfin onto GPU nodes:
+
+```sh
+talosctl --nodes 192.168.30.160 ls /dev/dri
+talosctl --nodes 192.168.30.161 ls /dev/dri
+```
+
+For development validation, check the single development VM:
+
+```sh
+talosctl --nodes 192.168.30.170 ls /dev/dri
+kubectl get nodes -l homelab.petebeegle.com/jellyfin-igpu=true -o wide
+```
+
+If `/dev/dri` is missing after the VM has the `hostpci` mapping, verify the Proxmox host has IOMMU enabled, the VM has been fully stopped and started, and the mapping entry matches the VM's current Proxmox host.
+
+## Rollout Notes
+
+Production rollout should be one worker at a time. Do not rely on generated Talos/Kubernetes node names; select nodes by the stable VMID label:
+
+```sh
+NODE=$(kubectl get node -l homelab.petebeegle.com/vm-id=160 -o jsonpath='{.items[0].metadata.name}')
+kubectl drain "$NODE" --ignore-daemonsets --delete-emptydir-data
+```
+
+Apply the Terraform change, then fully stop and start the VM through Proxmox if the PCI device was added while the VM was running. A guest-only reboot may not be enough for new PCI passthrough hardware. After the node returns:
+
+```sh
+talosctl health --nodes 192.168.30.160
+talosctl --nodes 192.168.30.160 ls /dev/dri
+kubectl wait node "$NODE" --for=condition=Ready --timeout=10m
+kubectl uncordon "$NODE"
+```
+
+Repeat the same sequence for VMID `161` and address `192.168.30.161`. Run the development VMID `170` sequence first when validating this path in the development cluster; if development credentials or an approved VM restart window are unavailable, record that exception with `terraform validate`, `terraform plan`, and local render evidence instead of making production live changes.

--- a/terraform/development/README.md
+++ b/terraform/development/README.md
@@ -32,6 +32,7 @@ Keep local shared credentials in ignored `terraform/development/terraform.tfvars
 
 | Name | Type |
 | ---- | ---- |
+| [proxmox_hardware_mapping_pci.jellyfin_igpu](https://registry.terraform.io/providers/bpg/proxmox/0.106.0/docs/resources/hardware_mapping_pci) | resource |
 | [proxmox_virtual_environment_file.talos_iso](https://registry.terraform.io/providers/bpg/proxmox/0.106.0/docs/resources/virtual_environment_file) | resource |
 | [terraform_data.bootstrap_script](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -1,3 +1,40 @@
+locals {
+  jellyfin_igpu_vm_ids = toset([
+    for node in var.nodes : node.vm_id
+    if node.node == "pve04"
+  ])
+
+  jellyfin_igpu_pci_maps = [
+    {
+      comment      = "pve04 Intel iGPU for development VMID 170"
+      id           = "8086:1912"
+      iommu_group  = 0
+      node         = "pve04"
+      path         = "0000:00:02.0"
+      subsystem_id = "1028:07a1"
+    }
+  ]
+
+  jellyfin_igpu_pci_passthrough_devices = [
+    {
+      mapping = proxmox_hardware_mapping_pci.jellyfin_igpu.name
+    }
+  ]
+
+  node_labels = {
+    for node in var.nodes : node.address => merge(
+      {
+        "homelab.petebeegle.com/proxmox-host" = node.node
+        "homelab.petebeegle.com/vm-id"        = tostring(node.vm_id)
+        "homelab.petebeegle.com/machine-type" = node.machine_type
+      },
+      contains(tolist(local.jellyfin_igpu_vm_ids), node.vm_id) ? {
+        "homelab.petebeegle.com/jellyfin-igpu" = "true"
+      } : {}
+    )
+  }
+}
+
 module "talos_provision" {
   source = "../modules/talos-provision"
 
@@ -12,6 +49,13 @@ resource "proxmox_virtual_environment_file" "talos_iso" {
     path      = module.talos_provision.iso_url
     file_name = module.talos_provision.image_name
   }
+}
+
+resource "proxmox_hardware_mapping_pci" "jellyfin_igpu" {
+  name             = "jellyfin-igpu-dev"
+  comment          = "Development Intel iGPU mapping for Jellyfin hardware transcoding validation."
+  mediated_devices = false
+  map              = local.jellyfin_igpu_pci_maps
 }
 
 module "kubernetes_nodes" {
@@ -41,6 +85,8 @@ module "kubernetes_nodes" {
   memory    = each.value.memory
   disk_size = each.value.disk_size
 
+  pci_passthrough_devices = contains(tolist(local.jellyfin_igpu_vm_ids), each.value.vm_id) ? local.jellyfin_igpu_pci_passthrough_devices : []
+
   additional_tags = [each.value.machine_type, "development"]
 }
 
@@ -59,6 +105,7 @@ module "talos_bootstrap" {
 
   control_nodes = [for node in var.nodes : node.address if node.machine_type == "controlplane"]
   worker_nodes  = [for node in var.nodes : node.address if node.machine_type == "worker"]
+  node_labels   = local.node_labels
 
   allow_scheduling_on_control_planes = true
   cilium_operator_replicas           = 1

--- a/terraform/modules/talos-bootstrap/README.md
+++ b/terraform/modules/talos-bootstrap/README.md
@@ -48,6 +48,7 @@ No modules.
 | <a name="input_installer"></a> [installer](#input\_installer) | Installer url to load | `string` | n/a | yes |
 | <a name="input_kubeconfig_output_path"></a> [kubeconfig\_output\_path](#input\_kubeconfig\_output\_path) | Optional path where the generated kubeconfig should be written | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for Talos-generated component images and bootstrap Cilium template compatibility | `string` | n/a | yes |
+| <a name="input_node_labels"></a> [node\_labels](#input\_node\_labels) | Kubernetes node labels to apply through Talos machine.nodeLabels, keyed by node address. | `map(map(string))` | `{}` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | The version of Talos to use for the cluster | `string` | n/a | yes |
 | <a name="input_talosconfig_output_path"></a> [talosconfig\_output\_path](#input\_talosconfig\_output\_path) | Optional path where the generated talosconfig should be written | `string` | `null` | no |
 | <a name="input_worker_nodes"></a> [worker\_nodes](#input\_worker\_nodes) | List of nodes to compose the cluster worker plane | `set(string)` | n/a | yes |

--- a/terraform/modules/talos-bootstrap/control_plane.tf
+++ b/terraform/modules/talos-bootstrap/control_plane.tf
@@ -18,6 +18,7 @@ resource "talos_machine_configuration_apply" "control_plane_apply" {
   config_patches = [
     templatefile("${path.module}/templates/control_plane.yaml.tftpl", {
       install_image                      = var.installer
+      node_labels                        = lookup(var.node_labels, each.key, {})
       cilium_install                     = data.helm_template.cilium.manifest
       allow_scheduling_on_control_planes = var.allow_scheduling_on_control_planes
     }),

--- a/terraform/modules/talos-bootstrap/templates/control_plane.yaml.tftpl
+++ b/terraform/modules/talos-bootstrap/templates/control_plane.yaml.tftpl
@@ -1,6 +1,10 @@
 machine:
   install:
     image: ${install_image}
+%{ if length(node_labels) > 0 ~}
+  nodeLabels:
+    ${indent(4, chomp(yamlencode(node_labels)))}
+%{ endif ~}
 cluster:
   allowSchedulingOnControlPlanes: ${allow_scheduling_on_control_planes}
   network:

--- a/terraform/modules/talos-bootstrap/templates/worker.yaml.tftpl
+++ b/terraform/modules/talos-bootstrap/templates/worker.yaml.tftpl
@@ -1,3 +1,7 @@
 machine:
   install:
     image: ${install_image}
+%{ if length(node_labels) > 0 ~}
+  nodeLabels:
+    ${indent(4, chomp(yamlencode(node_labels)))}
+%{ endif ~}

--- a/terraform/modules/talos-bootstrap/variables.tf
+++ b/terraform/modules/talos-bootstrap/variables.tf
@@ -78,6 +78,12 @@ variable "worker_nodes" {
   type        = set(string)
 }
 
+variable "node_labels" {
+  description = "Kubernetes node labels to apply through Talos machine.nodeLabels, keyed by node address."
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "cluster" {
   description = "Information about the cluster to join"
   type = object({

--- a/terraform/modules/talos-bootstrap/worker_plane.tf
+++ b/terraform/modules/talos-bootstrap/worker_plane.tf
@@ -18,6 +18,7 @@ resource "talos_machine_configuration_apply" "worker_apply" {
   config_patches = [
     templatefile("${path.module}/templates/worker.yaml.tftpl", {
       install_image  = var.installer
+      node_labels    = lookup(var.node_labels, each.key, {})
       cilium_install = data.helm_template.cilium.manifest
     }),
     templatefile("${path.module}/templates/docker_proxy.yaml.tftpl", {

--- a/terraform/modules/vm/README.md
+++ b/terraform/modules/vm/README.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of the boot disk in gigabytes | `number` | `40` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | Amount of dedicated memory (megabytes) to assign to the VM | `number` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Network configuration for the VM | <pre>object({<br/>    address = string<br/>    gateway = string<br/>  })</pre> | n/a | yes |
+| <a name="input_pci_passthrough_devices"></a> [pci\_passthrough\_devices](#input\_pci\_passthrough\_devices) | Optional host PCI devices to attach to the VM. Set exactly one of id or mapping for each device. | <pre>list(object({<br/>    id       = optional(string)<br/>    mapping  = optional(string)<br/>    mdev     = optional(string)<br/>    pcie     = optional(bool)<br/>    rom_file = optional(string)<br/>    rombar   = optional(bool)<br/>    xvga     = optional(bool)<br/>  }))</pre> | `[]` | no |
 | <a name="input_target_node_name"></a> [target\_node\_name](#input\_target\_node\_name) | Name of the node to create the VM on | `string` | n/a | yes |
 | <a name="input_vm_id"></a> [vm\_id](#input\_vm\_id) | Id to assign to the VM | `number` | n/a | yes |
 

--- a/terraform/modules/vm/main.tf
+++ b/terraform/modules/vm/main.tf
@@ -60,6 +60,21 @@ resource "proxmox_virtual_environment_vm" "kubernetes_node" {
     model  = "virtio"
   }
 
+  dynamic "hostpci" {
+    for_each = var.pci_passthrough_devices
+
+    content {
+      device   = "hostpci${hostpci.key}"
+      id       = hostpci.value.id
+      mapping  = hostpci.value.mapping
+      mdev     = hostpci.value.mdev
+      pcie     = hostpci.value.pcie
+      rom_file = hostpci.value.rom_file
+      rombar   = hostpci.value.rombar
+      xvga     = hostpci.value.xvga
+    }
+  }
+
   initialization {
     datastore_id = local.datastore.id
 

--- a/terraform/modules/vm/variables.tf
+++ b/terraform/modules/vm/variables.tf
@@ -26,6 +26,36 @@ variable "additional_tags" {
   default = []
 }
 
+variable "pci_passthrough_devices" {
+  description = "Optional host PCI devices to attach to the VM. Set exactly one of id or mapping for each device."
+  type = list(object({
+    id       = optional(string)
+    mapping  = optional(string)
+    mdev     = optional(string)
+    pcie     = optional(bool)
+    rom_file = optional(string)
+    rombar   = optional(bool)
+    xvga     = optional(bool)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for device in var.pci_passthrough_devices :
+      length([
+        for value in [device.id, device.mapping] : value
+        if value != null && value != ""
+      ]) == 1
+    ])
+    error_message = "Each PCI passthrough device must set exactly one non-empty value for either id or mapping."
+  }
+
+  validation {
+    condition     = length(var.pci_passthrough_devices) <= 16
+    error_message = "Proxmox supports at most 16 host PCI devices per VM."
+  }
+}
+
 variable "network" {
   description = "Network configuration for the VM"
   type = object({

--- a/terraform/production/README.md
+++ b/terraform/production/README.md
@@ -32,6 +32,7 @@ The generated kubeconfig and talosconfig are written to cluster-specific paths b
 
 | Name | Type |
 | ---- | ---- |
+| [proxmox_hardware_mapping_pci.jellyfin_igpu](https://registry.terraform.io/providers/bpg/proxmox/0.106.0/docs/resources/hardware_mapping_pci) | resource |
 | [proxmox_virtual_environment_file.talos_iso](https://registry.terraform.io/providers/bpg/proxmox/0.106.0/docs/resources/virtual_environment_file) | resource |
 | [terraform_data.bootstrap_script](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -1,3 +1,45 @@
+locals {
+  jellyfin_igpu_vm_ids = toset([160, 161])
+
+  jellyfin_igpu_pci_maps = [
+    {
+      comment      = "pve01 Intel iGPU for production worker VMID 160"
+      id           = "8086:a780"
+      iommu_group  = 0
+      node         = "pve01"
+      path         = "0000:00:02.0"
+      subsystem_id = "1028:0c79"
+    },
+    {
+      comment      = "pve02 Intel iGPU for production worker VMID 161"
+      id           = "8086:4680"
+      iommu_group  = 0
+      node         = "pve02"
+      path         = "0000:00:02.0"
+      subsystem_id = "1028:0c7b"
+    }
+  ]
+
+  jellyfin_igpu_pci_passthrough_devices = [
+    {
+      mapping = proxmox_hardware_mapping_pci.jellyfin_igpu.name
+    }
+  ]
+
+  node_labels = {
+    for node in var.nodes : node.address => merge(
+      {
+        "homelab.petebeegle.com/proxmox-host" = node.node
+        "homelab.petebeegle.com/vm-id"        = tostring(node.vm_id)
+        "homelab.petebeegle.com/machine-type" = node.machine_type
+      },
+      contains(tolist(local.jellyfin_igpu_vm_ids), node.vm_id) ? {
+        "homelab.petebeegle.com/jellyfin-igpu" = "true"
+      } : {}
+    )
+  }
+}
+
 module "talos_provision" {
   source = "../modules/talos-provision"
 
@@ -12,6 +54,13 @@ resource "proxmox_virtual_environment_file" "talos_iso" {
     path      = module.talos_provision.iso_url
     file_name = module.talos_provision.image_name
   }
+}
+
+resource "proxmox_hardware_mapping_pci" "jellyfin_igpu" {
+  name             = "jellyfin-igpu"
+  comment          = "Production Intel iGPU mapping for Jellyfin hardware transcoding nodes."
+  mediated_devices = false
+  map              = local.jellyfin_igpu_pci_maps
 }
 
 module "kubernetes_nodes" {
@@ -41,6 +90,8 @@ module "kubernetes_nodes" {
   memory    = each.value.memory
   disk_size = each.value.disk_size
 
+  pci_passthrough_devices = contains(tolist(local.jellyfin_igpu_vm_ids), each.value.vm_id) ? local.jellyfin_igpu_pci_passthrough_devices : []
+
   additional_tags = [each.value.machine_type]
 }
 
@@ -59,6 +110,7 @@ module "talos_bootstrap" {
 
   control_nodes = [for node in var.nodes : node.address if node.machine_type == "controlplane"]
   worker_nodes  = [for node in var.nodes : node.address if node.machine_type == "worker"]
+  node_labels   = local.node_labels
 
   allow_scheduling_on_control_planes = false
   cilium_operator_replicas           = 3


### PR DESCRIPTION
# PR Summary: jellyfin-gpu-nodes

Implementation owner: `implementation-agent-jellyfin-gpu-nodes`
Branch: `codex/jellyfin-gpu-nodes`
Commit: `d6a0bc9373edd7f23704bad505758fa97a646ea9`

## Summary

Add optional Proxmox VM PCI passthrough support and stable Talos node labels so Jellyfin-capable nodes can be selected by durable metadata instead of generated Kubernetes node names.

## Important Changes

- Added `pci_passthrough_devices` to `terraform/modules/vm`, rendering `hostpci` blocks from either direct PCI IDs or Proxmox hardware mapping names. The default is empty, so non-GPU VMs do not change.
- Added `node_labels` to `terraform/modules/talos-bootstrap`, rendering `machine.nodeLabels` for control-plane and worker Talos patches from maps keyed by node address.
- Production now owns the cluster-scoped Proxmox PCI hardware mapping `jellyfin-igpu` with only `pve01` and `pve02` map entries, and attaches it only to production VMIDs `160` and `161`.
- Development now owns the separate cluster-scoped Proxmox PCI hardware mapping `jellyfin-igpu-dev` with only the `pve04` map entry, and attaches it to VMID `170`.
- Added stable labels for Proxmox host, VM ID, machine type, and `homelab.petebeegle.com/jellyfin-igpu=true` on the Jellyfin GPU nodes.

## Documentation Impact

- Added `docs/runbooks/jellyfin-gpu-nodes.md` with GPU node readiness checks, `/dev/dri` validation, rollout notes, reboot or stop/start guidance, and the separate production/development mapping ownership model.
- Regenerated Terraform README tables for changed roots/modules.
- Regenerated `docs/architecture.md` because the new root PCI mapping resources changed the generated Terraform substrate table.

## Checks

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` passed.
- `terraform fmt -check -recursive` passed.
- `terraform -chdir=terraform/development init -input=false -no-color` passed with restored local state present.
- `terraform -chdir=terraform/production init -input=false -no-color` passed with restored local state present.
- `terraform -chdir=terraform/development validate -no-color` passed with pre-existing deprecation warnings for `proxmox_virtual_environment_datastores`.
- `terraform -chdir=terraform/production validate -no-color` passed with the same pre-existing deprecation warnings.
- `python3 tools/architecture/render.py --check` passed.
- `git diff --check` passed.

## Restored-State Plan Evidence

- Development targeted plan command:
  `terraform -chdir=terraform/development plan -input=false -no-color -detailed-exitcode -target=proxmox_hardware_mapping_pci.jellyfin_igpu -target='module.kubernetes_nodes["192.168.30.170"].proxmox_virtual_environment_vm.kubernetes_node' -target='module.talos_bootstrap.talos_machine_configuration_apply.control_plane_apply["192.168.30.170"]' -out=../../.codex/tmp/terraform/development-restored-targeted.tfplan`
- Development targeted plan exited `2` with restored local state. Plan JSON summary: `proxmox_hardware_mapping_pci.jellyfin_igpu` creates mapping `jellyfin-igpu-dev` with one map entry, `pve04` `0000:00:02.0` `8086:1912` `1028:07a1` group `0`; VMID `170` updates with `hostpci` mapping `jellyfin-igpu-dev`; Talos config apply for `192.168.30.170` updates.
- Production targeted plan command:
  `terraform -chdir=terraform/production plan -input=false -no-color -detailed-exitcode -target=proxmox_hardware_mapping_pci.jellyfin_igpu -target='module.kubernetes_nodes["192.168.30.160"].proxmox_virtual_environment_vm.kubernetes_node' -target='module.kubernetes_nodes["192.168.30.161"].proxmox_virtual_environment_vm.kubernetes_node' -target='module.talos_bootstrap.talos_machine_configuration_apply.control_plane_apply["192.168.30.150"]' -target='module.talos_bootstrap.talos_machine_configuration_apply.control_plane_apply["192.168.30.151"]' -target='module.talos_bootstrap.talos_machine_configuration_apply.worker_apply["192.168.30.160"]' -target='module.talos_bootstrap.talos_machine_configuration_apply.worker_apply["192.168.30.161"]' -target='module.talos_bootstrap.talos_machine_configuration_apply.worker_apply["192.168.30.162"]' -target=module.talos_bootstrap.local_file.kube_config -target=module.talos_bootstrap.local_file.talos_config -out=../../.codex/tmp/terraform/production-restored-targeted.tfplan`
- Production targeted plan exited `2` with restored local state. Plan JSON summary: `proxmox_hardware_mapping_pci.jellyfin_igpu` creates mapping `jellyfin-igpu` with two map entries, `pve01` `0000:00:02.0` `8086:a780` `1028:0c79` group `0` and `pve02` `0000:00:02.0` `8086:4680` `1028:0c7b` group `0`; VMIDs `160` and `161` update with `hostpci` mapping `jellyfin-igpu`; Talos config apply resources update for production nodes. Terraform requested the two local-file targets because restored state contains moved kubeconfig/talosconfig resource addresses.
- Terraform console evidence showed development node labels add `homelab.petebeegle.com/jellyfin-igpu=true` for `192.168.30.170`; production node labels add it only for `192.168.30.160` and `192.168.30.161`.
- Terraform console evidence rendered Talos `machine.nodeLabels` with quoted string label values.

## Development Validation

Smoke profile: `none`.

Live development apply was not run because PCI passthrough validation requires an approved VM stop/start or reboot window to prove `/dev/dri`, and no such live-change window was requested. Substitute evidence is the successful development init, validate, restored-state targeted plan, plan JSON checks for VMID `170`, and local Talos label render evidence.

## Production Notes

No production live changes were made. Production rollout should follow `docs/runbooks/jellyfin-gpu-nodes.md`, draining and validating one worker at a time and fully stop/starting VMs after adding PCI passthrough when required.
