### PR TITLE
feat(jellyfin): enable Intel iGPU transcoding

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,14 +10,14 @@ This document is generated for agentic repo navigation. It records relationships
 
 - Root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
-- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
+- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `grafana-operator.yaml`, `intel-device-plugins-operator.yaml`, `intel-gpu-device-plugin.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
 - App activation list: `external.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`, `private`.
 
 ### Development
 
 - Root Kustomization: `kubernetes/clusters/development/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
-- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`.
+- Infra activation list: `crds.yaml`, `cert-manager.yaml`, `intel-device-plugins-operator.yaml`, `intel-gpu-device-plugin.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `certs.yaml`, `gateway.yaml`.
 - App activation list: `whoami.yaml`, `foundry-bluegreen-fixture.yaml`.
 
 - Branch environment templates: `whoami-template.yaml`, `jellyfin-template.yaml`.
@@ -66,6 +66,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `gateway` | `./kubernetes/clusters/production/overlays/gateway` | `crds`, `cilium`, `certs` | `cluster-vars` | `no` |
 | `production` | `grafana-operator` | `./kubernetes/infra/controllers/grafana-operator` | `crds` | `cluster-vars` | `no` |
 | `production` | `grafana` | `./kubernetes/infra/monitoring/grafana` | `gateway`, `grafana-operator`, `loki`, `mimir` | `cluster-vars` | `sops` |
+| `production` | `intel-device-plugins-operator` | `./kubernetes/infra/controllers/intel-device-plugins/operator` | `cert-manager` | `cluster-vars` | `no` |
+| `production` | `intel-gpu-device-plugin` | `./kubernetes/infra/controllers/intel-device-plugins/gpu` | `intel-device-plugins-operator` | `cluster-vars` | `no` |
 | `production` | `loki` | `./kubernetes/infra/monitoring/loki` | `crds` | `cluster-vars` | `no` |
 | `production` | `mimir` | `./kubernetes/infra/monitoring/mimir` | `crds`, `nfs-csi` | `cluster-vars` | `no` |
 | `production` | `monitoring` | `./kubernetes/infra/monitoring` | (none) | `cluster-vars` | `sops` |
@@ -77,6 +79,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `development` | `cilium` | `./kubernetes/infra/network/cilium` | `crds` | `cluster-vars` | `no` |
 | `development` | `crds` | `./kubernetes/infra/crds` | (none) | `cluster-vars` | `no` |
 | `development` | `gateway` | `./kubernetes/infra/network/gateway` | `crds`, `cilium`, `certs` | `cluster-vars` | `no` |
+| `development` | `intel-device-plugins-operator` | `./kubernetes/infra/controllers/intel-device-plugins/operator` | `cert-manager` | `cluster-vars` | `no` |
+| `development` | `intel-gpu-device-plugin` | `./kubernetes/infra/controllers/intel-device-plugins/gpu` | `intel-device-plugins-operator` | `cluster-vars` | `no` |
 | `development` | `nfs-csi` | `./kubernetes/infra/controllers/nfs-csi` | (none) | `cluster-vars` | `no` |
 
 ### Applications
@@ -86,7 +90,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-cloudflare-tunnels` | `./kubernetes/apps/cloudflare-tunnels` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-external` | `./kubernetes/apps/external` | `gateway` | `cluster-vars` | `no` |
 | `production` | `app-foundryvtt` | `./kubernetes/apps/foundryvtt` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
-| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
+| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `intel-gpu-device-plugin` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
 | `production` | `private-source` | `./kubernetes/clusters/production/apps/private/source` | (none) | `(none)` | `sops` |
@@ -104,7 +108,10 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/authentik` | `namespace.yaml`, `app.yaml`, `secret.yaml`, `httproute.yaml`, `blueprints` |
 | `kubernetes/infra/controllers/cert-manager` | `app.yaml`, `secret.yaml` |
 | `kubernetes/infra/controllers/grafana-operator` | `namespace.yaml`, `app.yaml` |
-| `kubernetes/infra/controllers` | `./nfs-csi`, `./cert-manager`, `./grafana-operator` |
+| `kubernetes/infra/controllers/intel-device-plugins/gpu` | `app.yaml` |
+| `kubernetes/infra/controllers/intel-device-plugins` | `./operator`, `./gpu` |
+| `kubernetes/infra/controllers/intel-device-plugins/operator` | `namespace.yaml`, `app.yaml` |
+| `kubernetes/infra/controllers` | `./nfs-csi`, `./cert-manager`, `./grafana-operator`, `./intel-device-plugins` |
 | `kubernetes/infra/controllers/nfs-csi` | `app.yaml`, `media-storageclass.yaml`, `storageclass.yaml`, `volumesnapshotclass.yaml` |
 | `kubernetes/infra/crds/grafana` | `app.yaml` |
 | `kubernetes/infra/crds` | `https://github.com/kubernetes-csi/external-snapshotter//client/config/crd?ref=v8.5.0`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_gateways.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_httproutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_referencegrants.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/standard/gateway.networking.k8s.io_grpcroutes.yaml`, `https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml`, `prometheus`, `grafana` |

--- a/docs/runbooks/jellyfin-hardware-transcoding.md
+++ b/docs/runbooks/jellyfin-hardware-transcoding.md
@@ -1,0 +1,35 @@
+---
+status: current
+scope:
+  - jellyfin
+  - hardware-transcoding
+  - intel-gpu
+last_verified: 2026-05-24
+---
+
+# Jellyfin Hardware Transcoding
+
+Jellyfin uses Intel Quick Sync Video through the Intel GPU Device Plugin. The base dependency is the Intel Device Plugins Operator, and the GPU plugin is reconciled only after the operator is ready. Both Helm releases are pinned to chart `0.35.0` from `https://intel.github.io/helm-charts`.
+
+The GPU plugin intentionally does not use Node Feature Discovery. It sets `nodeFeatureRule=false` and targets only nodes labeled `homelab.petebeegle.com/jellyfin-igpu=true`. The matching node label and iGPU passthrough are provided by the separate `jellyfin-gpu-nodes` implementation; without that prerequisite, Jellyfin pods should remain unscheduled instead of falling back to CPU-only placement.
+
+Jellyfin scheduling hard-requires the same node label and requests `gpu.intel.com/i915: 1` with matching limits. Do not add privileged mode, supplemental host groups, or `/dev/dri` hostPath mounts for Jellyfin. Device access should come from the Intel GPU Device Plugin allocation.
+
+The Jellyfin init bootstrap enforces `/config/config/encoding.xml` on each pod start:
+
+- `<HardwareAccelerationType>qsv</HardwareAccelerationType>`
+- `<VaapiDevice>/dev/dri/renderD128</VaapiDevice>` and `<QsvDevice>/dev/dri/renderD128</QsvDevice>`
+- `<EnableHardwareEncoding>true</EnableHardwareEncoding>`
+- hardware decoding codecs `h264`, `hevc`, `mpeg2video`, `vc1`, `vp8`, and `vp9`
+- HEVC and VP9 10-bit decode toggles enabled, with native VA-API decoder preference enabled for QSV pipelines
+
+After reconcile, acceptance should confirm:
+
+1. The node intended for Jellyfin has label `homelab.petebeegle.com/jellyfin-igpu=true`.
+2. `kubectl describe node <node>` advertises allocatable `gpu.intel.com/i915`.
+3. `flux -n flux-system get kustomization intel-device-plugins-operator intel-gpu-device-plugin app-jellyfin` reports Ready.
+4. The Jellyfin pod is scheduled on the labeled node and has `gpu.intel.com/i915: 1` in requests and limits.
+5. `kubectl -n jellyfin exec deploy/jellyfin -- /usr/lib/jellyfin-ffmpeg/vainfo` reports the Intel media driver and render device.
+6. A 4K HEVC or HEVC Main10 playback test shows QSV decode/encode in the Jellyfin transcode log.
+
+For branch validation, use the Jellyfin development verifier with `--include-cluster-base` once the `jellyfin-gpu-nodes` prerequisite is present. If the development cluster does not yet expose the label and `gpu.intel.com/i915` resource, record the smoke as blocked by that prerequisite and substitute local render checks plus bootstrap tests.

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -44,6 +44,7 @@ data:
     import tempfile
     import urllib.request
     import zipfile
+    import xml.etree.ElementTree as ET
     from pathlib import Path
     from xml.sax.saxutils import escape
 
@@ -54,6 +55,9 @@ data:
     plugin_dir = config_root / "plugins" / f"SSO Authentication_{plugin_version}"
     plugin_config = config_root / "plugins" / "configurations" / "SSO-Auth.xml"
     branding_config = config_root / "config" / "branding.xml"
+    ENCODING_CONFIG = config_root / "config" / "encoding.xml"
+    QSV_RENDER_DEVICE = "/dev/dri/renderD128"
+    HARDWARE_DECODING_CODECS = ("h264", "hevc", "mpeg2video", "vc1", "vp8", "vp9")
     expected_plugin_files = (
         "SSO-Auth.dll",
         "Duende.IdentityModel.dll",
@@ -67,6 +71,58 @@ data:
     def plugin_install_complete(path=None):
         plugin_path = plugin_dir if path is None else path
         return plugin_path.is_dir() and all((plugin_path / name).is_file() for name in expected_plugin_files)
+
+    def indent(element, level=0):
+        spacing = "\n" + level * "  "
+        child_spacing = "\n" + (level + 1) * "  "
+        if len(element):
+            if not element.text or not element.text.strip():
+                element.text = child_spacing
+            for child in element:
+                indent(child, level + 1)
+            if not child.tail or not child.tail.strip():
+                child.tail = spacing
+        if level and (not element.tail or not element.tail.strip()):
+            element.tail = spacing
+
+    def set_text(parent, name, value):
+        child = parent.find(name)
+        if child is None:
+            child = ET.SubElement(parent, name)
+        child.text = value
+        return child
+
+    def set_bool(parent, name, value):
+        set_text(parent, name, "true" if value else "false")
+
+    def set_string_array(parent, name, values):
+        existing = parent.find(name)
+        if existing is not None:
+            parent.remove(existing)
+        array = ET.SubElement(parent, name)
+        for value in values:
+            item = ET.SubElement(array, "string")
+            item.text = value
+        return array
+
+    def configure_encoding():
+        ENCODING_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        if ENCODING_CONFIG.exists():
+            root = ET.parse(ENCODING_CONFIG).getroot()
+        else:
+            root = ET.Element("EncodingOptions")
+
+        set_text(root, "HardwareAccelerationType", "qsv")
+        set_text(root, "VaapiDevice", QSV_RENDER_DEVICE)
+        set_text(root, "QsvDevice", QSV_RENDER_DEVICE)
+        set_bool(root, "EnableHardwareEncoding", True)
+        set_bool(root, "EnableDecodingColorDepth10Hevc", True)
+        set_bool(root, "EnableDecodingColorDepth10Vp9", True)
+        set_bool(root, "PreferSystemNativeHwDecoder", True)
+        set_string_array(root, "HardwareDecodingCodecs", HARDWARE_DECODING_CODECS)
+
+        indent(root)
+        ET.ElementTree(root).write(ENCODING_CONFIG, encoding="utf-8", xml_declaration=True)
 
     try:
         plugin_dir.parent.mkdir(parents=True, exist_ok=True)
@@ -173,6 +229,8 @@ data:
       <SplashscreenEnabled>false</SplashscreenEnabled>
     </BrandingOptions>
     """, encoding="utf-8")
+
+        configure_encoding()
     except Exception as exc:
         print(f"Jellyfin branch SSO bootstrap failed: {exc}", file=sys.stderr)
         raise
@@ -226,6 +284,13 @@ spec:
         storageClass: nfs-csi-storage
       media:
         enabled: false
+    nodeSelector:
+      homelab.petebeegle.com/jellyfin-igpu: "true"
+    resources:
+      requests:
+        gpu.intel.com/i915: 1
+      limits:
+        gpu.intel.com/i915: 1
     service:
       annotations:
         prometheus.io/scrape: "true"

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -29,6 +29,9 @@ data:
     PLUGIN_DIR = CONFIG_ROOT / "plugins" / f"SSO Authentication_{PLUGIN_VERSION}"
     PLUGIN_CONFIG = CONFIG_ROOT / "plugins" / "configurations" / "SSO-Auth.xml"
     BRANDING_CONFIG = CONFIG_ROOT / "config" / "branding.xml"
+    ENCODING_CONFIG = CONFIG_ROOT / "config" / "encoding.xml"
+    QSV_RENDER_DEVICE = "/dev/dri/renderD128"
+    HARDWARE_DECODING_CODECS = ("h264", "hevc", "mpeg2video", "vc1", "vp8", "vp9")
     EXPECTED_PLUGIN_FILES = (
         "SSO-Auth.dll",
         "Duende.IdentityModel.dll",
@@ -239,10 +242,30 @@ data:
         indent(root)
         ET.ElementTree(root).write(BRANDING_CONFIG, encoding="utf-8", xml_declaration=True)
 
+    def configure_encoding():
+        ENCODING_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+        if ENCODING_CONFIG.exists():
+            root = ET.parse(ENCODING_CONFIG).getroot()
+        else:
+            root = ET.Element("EncodingOptions")
+
+        set_text(root, "HardwareAccelerationType", "qsv")
+        set_text(root, "VaapiDevice", QSV_RENDER_DEVICE)
+        set_text(root, "QsvDevice", QSV_RENDER_DEVICE)
+        set_bool(root, "EnableHardwareEncoding", True)
+        set_bool(root, "EnableDecodingColorDepth10Hevc", True)
+        set_bool(root, "EnableDecodingColorDepth10Vp9", True)
+        set_bool(root, "PreferSystemNativeHwDecoder", True)
+        set_string_array(root, "HardwareDecodingCodecs", HARDWARE_DECODING_CODECS)
+
+        indent(root)
+        ET.ElementTree(root).write(ENCODING_CONFIG, encoding="utf-8", xml_declaration=True)
+
     try:
         install_plugin()
         configure_sso()
         configure_branding()
+        configure_encoding()
     except Exception as exc:
         print(f"Jellyfin SSO bootstrap failed: {exc}", file=sys.stderr)
         raise

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -5,6 +5,13 @@ persistence:
     storageClass: nfs-csi-storage
   media:
     enabled: false
+nodeSelector:
+  homelab.petebeegle.com/jellyfin-igpu: "true"
+resources:
+  requests:
+    gpu.intel.com/i915: 1
+  limits:
+    gpu.intel.com/i915: 1
 service:
   annotations:
     prometheus.io/scrape: "true"

--- a/kubernetes/clusters/development/branches/jellyfin-template.yaml
+++ b/kubernetes/clusters/development/branches/jellyfin-template.yaml
@@ -31,6 +31,7 @@ spec:
   dependsOn:
     - name: gateway
     - name: nfs-csi
+    - name: intel-gpu-device-plugin
   postBuild:
     substitute:
       branch_slug: ${branch_slug}

--- a/kubernetes/clusters/development/infra/intel-device-plugins-operator.yaml
+++ b/kubernetes/clusters/development/infra/intel-device-plugins-operator.yaml
@@ -2,21 +2,19 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: app-jellyfin
+  name: intel-device-plugins-operator
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/apps/jellyfin
+  path: ./kubernetes/infra/controllers/intel-device-plugins/operator
   prune: true
   wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
   dependsOn:
-    - name: gateway
-    - name: nfs-csi
-    - name: intel-gpu-device-plugin
+    - name: cert-manager
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/development/infra/intel-gpu-device-plugin.yaml
+++ b/kubernetes/clusters/development/infra/intel-gpu-device-plugin.yaml
@@ -2,21 +2,19 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: app-jellyfin
+  name: intel-gpu-device-plugin
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/apps/jellyfin
+  path: ./kubernetes/infra/controllers/intel-device-plugins/gpu
   prune: true
   wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
   dependsOn:
-    - name: gateway
-    - name: nfs-csi
-    - name: intel-gpu-device-plugin
+    - name: intel-device-plugins-operator
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/development/infra/kustomization.yaml
+++ b/kubernetes/clusters/development/infra/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - crds.yaml
   - cert-manager.yaml
+  - intel-device-plugins-operator.yaml
+  - intel-gpu-device-plugin.yaml
   - nfs-csi.yaml
   - cilium.yaml
   - certs.yaml

--- a/kubernetes/clusters/production/infra/intel-device-plugins-operator.yaml
+++ b/kubernetes/clusters/production/infra/intel-device-plugins-operator.yaml
@@ -2,21 +2,19 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: app-jellyfin
+  name: intel-device-plugins-operator
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/apps/jellyfin
+  path: ./kubernetes/infra/controllers/intel-device-plugins/operator
   prune: true
   wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
   dependsOn:
-    - name: gateway
-    - name: nfs-csi
-    - name: intel-gpu-device-plugin
+    - name: cert-manager
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/production/infra/intel-gpu-device-plugin.yaml
+++ b/kubernetes/clusters/production/infra/intel-gpu-device-plugin.yaml
@@ -2,21 +2,19 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: app-jellyfin
+  name: intel-gpu-device-plugin
   namespace: flux-system
 spec:
-  interval: 5m
+  interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/apps/jellyfin
+  path: ./kubernetes/infra/controllers/intel-device-plugins/gpu
   prune: true
   wait: true
   sourceRef:
     kind: GitRepository
     name: flux-system
   dependsOn:
-    - name: gateway
-    - name: nfs-csi
-    - name: intel-gpu-device-plugin
+    - name: intel-device-plugins-operator
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/kubernetes/clusters/production/infra/kustomization.yaml
+++ b/kubernetes/clusters/production/infra/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - crds.yaml
   - cert-manager.yaml
   - grafana-operator.yaml
+  - intel-device-plugins-operator.yaml
+  - intel-gpu-device-plugin.yaml
   - nfs-csi.yaml
   - cilium.yaml
   - certs.yaml

--- a/kubernetes/infra/controllers/intel-device-plugins/gpu/app.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/gpu/app.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-gpu-device-plugin
+  namespace: intel-device-plugins-system
+spec:
+  interval: 5m0s
+  releaseName: intel-gpu-device-plugin
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: intel-device-plugins-gpu
+      sourceRef:
+        kind: HelmRepository
+        name: intel
+        namespace: flux-system
+      version: "0.35.0"
+  values:
+    nodeFeatureRule: false
+    nodeSelector:
+      intel.feature.node.kubernetes.io/gpu: null
+      homelab.petebeegle.com/jellyfin-igpu: "true"

--- a/kubernetes/infra/controllers/intel-device-plugins/gpu/kustomization.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/gpu/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app.yaml

--- a/kubernetes/infra/controllers/intel-device-plugins/kustomization.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./operator
+  - ./gpu

--- a/kubernetes/infra/controllers/intel-device-plugins/operator/app.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/operator/app.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: intel
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://intel.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-device-plugins-operator
+  namespace: intel-device-plugins-system
+spec:
+  interval: 5m0s
+  releaseName: intel-device-plugins-operator
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: intel-device-plugins-operator
+      sourceRef:
+        kind: HelmRepository
+        name: intel
+        namespace: flux-system
+      version: "0.35.0"
+  values:
+    manager:
+      devices:
+        gpu: true

--- a/kubernetes/infra/controllers/intel-device-plugins/operator/kustomization.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/operator/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - app.yaml

--- a/kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-device-plugins-system

--- a/kubernetes/infra/controllers/kustomization.yaml
+++ b/kubernetes/infra/controllers/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./nfs-csi
   - ./cert-manager
   - ./grafana-operator
+  - ./intel-device-plugins

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -5,6 +5,7 @@ import io
 import os
 import tempfile
 import zipfile
+import xml.etree.ElementTree as ET
 from unittest import mock
 from pathlib import Path
 
@@ -172,6 +173,49 @@ class JellyfinSsoBootstrapTest(unittest.TestCase):
 
         self.assertNotIn("if PLUGIN_DIR.exists():\n                shutil.rmtree(PLUGIN_DIR)", production)
         self.assertNotIn("if plugin_dir.exists():\n                shutil.rmtree(plugin_dir)", branch)
+
+    def test_bootstrap_scripts_force_qsv_encoding_settings(self) -> None:
+        for path in (
+            "kubernetes/apps/jellyfin/sso-bootstrap.yaml",
+            "kubernetes/apps/jellyfin/branch/jellyfin.yaml",
+        ):
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as temp_dir:
+                namespace = embedded_script_namespace(path)
+                encoding_config = Path(temp_dir) / "config" / "encoding.xml"
+                encoding_config.parent.mkdir(parents=True)
+                encoding_config.write_text(
+                    """<?xml version='1.0' encoding='utf-8'?>
+<EncodingOptions>
+  <HardwareAccelerationType>none</HardwareAccelerationType>
+  <VaapiDevice>/dev/dri/renderD128</VaapiDevice>
+  <EnableHardwareEncoding>false</EnableHardwareEncoding>
+  <EnableDecodingColorDepth10Hevc>false</EnableDecodingColorDepth10Hevc>
+  <EnableDecodingColorDepth10Vp9>false</EnableDecodingColorDepth10Vp9>
+  <PreferSystemNativeHwDecoder>false</PreferSystemNativeHwDecoder>
+  <HardwareDecodingCodecs>
+    <string>h264</string>
+    <string>vc1</string>
+  </HardwareDecodingCodecs>
+</EncodingOptions>
+""",
+                    encoding="utf-8",
+                )
+
+                namespace["ENCODING_CONFIG"] = encoding_config
+                namespace["configure_encoding"]()
+
+                root = ET.parse(encoding_config).getroot()
+                self.assertEqual(root.findtext("HardwareAccelerationType"), "qsv")
+                self.assertEqual(root.findtext("VaapiDevice"), "/dev/dri/renderD128")
+                self.assertEqual(root.findtext("QsvDevice"), "/dev/dri/renderD128")
+                self.assertEqual(root.findtext("EnableHardwareEncoding"), "true")
+                self.assertEqual(root.findtext("EnableDecodingColorDepth10Hevc"), "true")
+                self.assertEqual(root.findtext("EnableDecodingColorDepth10Vp9"), "true")
+                self.assertEqual(root.findtext("PreferSystemNativeHwDecoder"), "true")
+                self.assertEqual(
+                    [item.text for item in root.findall("./HardwareDecodingCodecs/string")],
+                    ["h264", "hevc", "mpeg2video", "vc1", "vp8", "vp9"],
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on PR 1: `codex/jellyfin-gpu-nodes` must merge and be rolled out before this change is applied to production.

## Summary

Add Intel Device Plugins Operator and Intel GPU Device Plugin reconciliation, and make Jellyfin hard-require the Intel iGPU resource for QSV hardware transcoding.

## Important Changes

- Added Intel Helm repository usage under `kubernetes/infra/controllers/intel-device-plugins`.
- Added HelmReleases pinned to chart `0.35.0` for `intel-device-plugins-operator` and `intel-device-plugins-gpu`.
- Configured the GPU plugin with `nodeFeatureRule=false` and the stable selector `homelab.petebeegle.com/jellyfin-igpu=true`; the default NFD selector is nulled so Node Feature Discovery is not required.
- Wired development and production infra Flux Kustomizations so the GPU plugin depends on the operator.
- Updated production `app-jellyfin` and the development Jellyfin branch template to depend on `intel-gpu-device-plugin`.
- Updated Jellyfin production values and branch overlay to require `homelab.petebeegle.com/jellyfin-igpu=true` and request/limit `gpu.intel.com/i915: 1`.
- Extended both production and branch Jellyfin bootstrap scripts to enforce QSV settings in `/config/config/encoding.xml`.

## Documentation Impact

- Added `docs/runbooks/jellyfin-hardware-transcoding.md` with scheduling, bootstrap, validation, and PR 1 prerequisite notes.
- Regenerated `docs/architecture.md` after the architecture check reported new infra/app relationships.

## Tests And Checks

- Workflow marker validation: passed.
- Implementation plan validation: passed.
- Owner attestation validation: passed.
- Red TDD check before script implementation: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap.JellyfinSsoBootstrapTest.test_bootstrap_scripts_force_qsv_encoding_settings` failed with missing `configure_encoding` in both scripts.
- Green focused check: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap.JellyfinSsoBootstrapTest.test_bootstrap_scripts_force_qsv_encoding_settings` passed.
- Full bootstrap tests: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap` passed.
- Development verifier tests: `python3 -m unittest tools.development.tests.test_verify_branch_deploy` passed.
- Render checks passed:
  - `kubectl kustomize kubernetes/infra/controllers/intel-device-plugins/operator`
  - `kubectl kustomize kubernetes/infra/controllers/intel-device-plugins/gpu`
  - `kubectl kustomize kubernetes/infra/controllers`
  - `kubectl kustomize kubernetes/clusters/development/infra`
  - `kubectl kustomize kubernetes/clusters/production/infra`
  - `kubectl kustomize kubernetes/apps/jellyfin`
  - `env branch_slug=jellyfin-hw-transcode cluster_domain=example.test nfs_server=nas.example.test sh -c 'kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict'`
  - `env branch_name=codex/jellyfin-hw-transcode branch_slug=jellyfin-hw-transcode sh -c 'kubectl kustomize kubernetes/clusters/development/branches | flux envsubst --strict'`
- Helm chart checks passed:
  - `helm template intel-gpu-device-plugin intel-device-plugins-gpu --repo https://intel.github.io/helm-charts --version 0.35.0 --namespace intel-device-plugins-system --values <gpu values>` rendered only `homelab.petebeegle.com/jellyfin-igpu=true` in the plugin node selector.
  - `helm template intel-device-plugins-operator intel-device-plugins-operator --repo https://intel.github.io/helm-charts --version 0.35.0 --namespace intel-device-plugins-system --set manager.devices.gpu=true` rendered `--devices=gpu` plus cert-manager Certificate/Issuer resources.
  - `helm template jellyfin jellyfin --repo https://jellyfin.github.io/jellyfin-helm --version 3.2.0 --namespace jellyfin --values kubernetes/apps/jellyfin/values.yaml` rendered the i915 request/limit and Jellyfin iGPU node selector without privileged or hostPath matches.
- Architecture check: `python3 tools/architecture/render.py --check` failed before regeneration, then passed after `python3 tools/architecture/render.py --write`.
- Whitespace check: `git diff --check` passed.

## Development Validation

Live development validation is blocked in this owner environment. `kubectl config current-context` reported no current context, and a read-only node prerequisite check fell back to localhost:8080 and failed to connect. The PR 1 prerequisite (`jellyfin-gpu-nodes`) is therefore unavailable/unconfirmed here, and the requested `verify_branch_deploy.py --push` path is not safe in this phase because the user explicitly said not to push before verifier approval.

Substitute evidence is the render suite, chart rendering, bootstrap tests, architecture check, and the documented blocked-by-PR1/no-kube-context exception. Once PR 1 is present and verifier approval permits pushing, run:

```bash
python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-hw-transcode --slug jellyfin-hw-transcode --push --include-cluster-base
```

## Commit

`7fa1b96d21331fa824ec394252d896387dc3df11`
