### PR TITLE
fix(talos): include i915 system extension

### DIFF
--- a/docs/runbooks/jellyfin-gpu-nodes.md
+++ b/docs/runbooks/jellyfin-gpu-nodes.md
@@ -10,7 +10,7 @@ last_verified: 2026-05-24
 
 # Jellyfin GPU Nodes
 
-Jellyfin hardware transcoding nodes are prepared by Terraform before any Jellyfin workload scheduling change. The Proxmox VM layer attaches a cluster-specific PCI hardware mapping, and the Talos bootstrap layer applies stable Kubernetes node labels through `machine.nodeLabels`.
+Jellyfin hardware transcoding nodes are prepared by Terraform before any Jellyfin workload scheduling change. The Proxmox VM layer attaches a cluster-specific PCI hardware mapping, the Talos image includes the `siderolabs/i915` system extension required for Intel DRM render devices, and the Talos bootstrap layer applies stable Kubernetes node labels through `machine.nodeLabels`.
 
 Proxmox PCI hardware mappings are cluster-scoped, so each Terraform root must own a distinct mapping name. Production owns `jellyfin-igpu` with only the pve01 and pve02 entries. Development owns `jellyfin-igpu-dev` with only the pve04 entry.
 
@@ -52,7 +52,7 @@ talosctl --nodes 192.168.30.170 ls /dev/dri
 kubectl get nodes -l homelab.petebeegle.com/jellyfin-igpu=true -o wide
 ```
 
-If `/dev/dri` is missing after the VM has the `hostpci` mapping, verify the Proxmox host has IOMMU enabled, the VM has been fully stopped and started, and the mapping entry matches the VM's current Proxmox host.
+If `/dev/dri` is missing after the VM has the `hostpci` mapping, verify the Terraform-generated Talos image includes `siderolabs/i915`, the Proxmox host has IOMMU enabled, the VM has been fully stopped and started, and the mapping entry matches the VM's current Proxmox host.
 
 ## Rollout Notes
 

--- a/docs/runbooks/upgrade-talos.md
+++ b/docs/runbooks/upgrade-talos.md
@@ -26,6 +26,7 @@ Pre-checks:
 - Review Talos release notes for breaking changes.
 - Confirm the target Talos version supports the current Kubernetes version.
 - Confirm cluster health.
+- For GPU workers on Proxmox, use the Terraform/Image Factory `nocloud-installer` image instead of the generic `installer` image so Talos keeps Proxmox NoCloud networking while adding extensions such as `siderolabs/i915`.
 
 ```bash
 talosctl health --nodes <CP_NODE>
@@ -34,7 +35,7 @@ talosctl health --nodes <CP_NODE>
 Upgrade each node:
 
 ```bash
-talosctl upgrade --nodes <NODE_IP> --image ghcr.io/siderolabs/installer:<version>
+talosctl upgrade --nodes <NODE_IP> --image <IMAGE_FACTORY_NOCLOUD_INSTALLER_IMAGE>
 ```
 
 Verify after each node:

--- a/terraform/modules/talos-provision/main.tf
+++ b/terraform/modules/talos-provision/main.tf
@@ -7,6 +7,7 @@ data "talos_image_factory_extensions_versions" "this" {
   filters = {
     names = [
       "siderolabs/btrfs",
+      "siderolabs/i915",
       "siderolabs/qemu-guest-agent"
     ]
   }


### PR DESCRIPTION
# talos-i915-extension

## Summary

Add the official `siderolabs/i915` Talos system extension to the Terraform Talos image factory extension list so Proxmox-passed Intel iGPUs can expose `/dev/dri` on Talos workers.

## Important Changes

- Added `siderolabs/i915` between `siderolabs/btrfs` and `siderolabs/qemu-guest-agent` in `terraform/modules/talos-provision/main.tf`.
- Documented i915 extension expectations and `/dev/dri` troubleshooting in `docs/runbooks/jellyfin-gpu-nodes.md`.
- Updated `docs/runbooks/upgrade-talos.md` to warn GPU worker upgrades to use the Terraform/Image Factory `nocloud-installer` image instead of the generic `installer` image so Proxmox NoCloud networking is preserved.

## Documentation Impact

Runbooks were updated because the Talos image contents and GPU-worker upgrade image selection changed. `docs/architecture.md` was not regenerated because `python3 tools/architecture/render.py --check` passed with no drift.

## Validation Evidence

- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`: passed.
- `terraform fmt -check -recursive`: passed.
- `python3 tools/architecture/render.py --check`: passed; no regeneration needed.
- `terraform -chdir=terraform/development validate`: initially blocked by uninstalled modules, then passed after `terraform -chdir=terraform/development init -backend=false`; existing Proxmox provider deprecation warnings were reported.
- `terraform -chdir=terraform/production validate`: initially blocked by uninstalled modules, then passed after `terraform -chdir=terraform/production init -backend=false`; existing Proxmox provider deprecation warnings were reported.
- `git diff --check --cached`: passed before commit.

## Development Validation

Risk tier: high, because the Terraform Talos image change affects node boot artifacts and live worker upgrades. Live development-cluster apply, Talos upgrade, VM restart, and `/dev/dri` smoke were not run in this implementation because the user requested a focused hotfix with local checks and explicitly said not to create the PR yet. Substitute evidence is the focused Terraform validation in both roots, architecture check, and runbook instructions for one-node-at-a-time rollout and `/dev/dri` validation.

## Workflow Notes

Implementation owner identity is `implementation-agent-talos-i915-extension`, as requested by the user. The task was performed in `/workspaces/homelab-ideas/talos-i915-extension` on branch `codex/talos-i915-extension`.

The commit intentionally excludes an unrelated pre-existing unstaged hunk in `docs/runbooks/jellyfin-gpu-nodes.md` that changes a `talosctl health` command, and excludes the untracked `terraform/modules/talos-provision/.terraform.lock.hcl` generated/local file.
