### PR TITLE
fix: label intel device plugin namespace for pod security

### DIFF
--- a/kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml
+++ b/kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml
@@ -3,3 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: intel-device-plugins-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest


### PR DESCRIPTION
## Summary

Make the Intel device plugins namespace durable for Pod Security Admission by labeling `intel-device-plugins-system` as privileged for enforce, audit, and warn modes.

## Important Changes

- Added Pod Security Admission labels to `kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml`:
  - `pod-security.kubernetes.io/enforce: privileged`
  - `pod-security.kubernetes.io/audit: privileged`
  - `pod-security.kubernetes.io/warn: privileged`
  - matching `*-version: latest` labels, consistent with existing repository namespace patterns.

## Documentation Impact

No docs changed. This is a narrow namespace policy durability update for an existing controller namespace and does not change operator usage, app behavior, runbooks, or architecture relationships.

## Validation

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `kubectl kustomize kubernetes/infra/controllers/intel-device-plugins/operator > /tmp/intel-device-plugin-operator-render.yaml`
- PASS: `kubectl kustomize kubernetes/infra/controllers/intel-device-plugins > /tmp/intel-device-plugins-render.yaml`
- PASS: `kubectl kustomize kubernetes/clusters/development > /tmp/homelab-development-render.yaml`
- PASS: `kubectl kustomize kubernetes/clusters/production > /tmp/homelab-production-render.yaml`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `pre-commit run yamllint --files kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml`
- PASS: `pre-commit run k8svalidate --files kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml`
- PASS: `flux build kustomization intel-device-plugins-operator --path=./kubernetes/infra/controllers/intel-device-plugins/operator --kustomization-file=./kubernetes/clusters/development/infra/intel-device-plugins-operator.yaml --dry-run > /tmp/flux-build-intel-device-plugins-operator.yaml`
- PASS: `kubectl --kubeconfig ~/.kube/homelab-development.config apply --server-side --dry-run=server -f kubernetes/infra/controllers/intel-device-plugins/operator/namespace.yaml -o yaml`
- PASS: `kubectl --kubeconfig ~/.kube/homelab-development.config apply --server-side --dry-run=server -k kubernetes/infra/controllers/intel-device-plugins/operator -o name`
- PASS: `kubectl --kubeconfig ~/.kube/homelab-development.config apply --server-side --dry-run=server -k kubernetes/infra/controllers/intel-device-plugins -o name`

## Development Validation

- Risk tier: medium Kubernetes manifest change.
- Smoke profile: none.
- Development cluster status: reachable via `~/.kube/homelab-development.config`.
- Branch verifier exception: the canonical `verify_branch_deploy.py --app whoami --include-cluster-base --push` path requires development Terraform variables in the sibling clone, but no workflow-staged development config was provided under `.codex/tmp/implementation-secrets/intel-device-plugin-pod-security/` for installation into this clone. To avoid copying ignored config outside the prescribed staging path or logging secret/config contents, live validation was limited to server-side dry-runs against the development API plus Flux and kustomize renders.
- Substitute evidence: the development API accepted the touched namespace manifest, the operator kustomization, and the parent Intel device plugins kustomization using `--server-side --dry-run=server`; the Flux build from the development `intel-device-plugins-operator` Kustomization rendered the namespace with the new PSA labels.

## Commit

- `c6420fa1c614d9e969fbfa551c3875456632e4eb` `fix: label intel device plugin namespace for pod security`
