### PR TITLE
Implementation: jellyfin-cache-cleanup-local

### DIFF
--- a/docs/runbooks/jellyfin-hardware-transcoding.md
+++ b/docs/runbooks/jellyfin-hardware-transcoding.md
@@ -22,6 +22,9 @@ The Jellyfin init bootstrap enforces `/config/config/encoding.xml` on each pod s
 - `<EnableHardwareEncoding>true</EnableHardwareEncoding>`
 - hardware decoding codecs `h264`, `hevc`, `mpeg2video`, `vc1`, `vp8`, and `vp9`
 - HEVC and VP9 10-bit decode toggles enabled, with native VA-API decoder preference enabled for QSV pipelines
+- segment deletion and throttling enabled, with `<ThrottleDelaySeconds>180</ThrottleDelaySeconds>` and `<SegmentKeepSeconds>720</SegmentKeepSeconds>`
+
+The Jellyfin `/cache` volume is intentionally node-local `emptyDir` storage for transcode performance. The Helm post-renderer bounds it at `40Gi`, and the encoding bootstrap keeps transcode segments self-cleaning so cache growth does not rely only on pod eviction. Do not move `/cache` to an NFS-backed PVC for this iteration; NFS remains appropriate for persistent config and media access, but transcode cache I/O should stay local unless a later decision record changes that tradeoff.
 
 After reconcile, acceptance should confirm:
 
@@ -30,6 +33,8 @@ After reconcile, acceptance should confirm:
 3. `flux -n flux-system get kustomization intel-device-plugins-operator intel-gpu-device-plugin app-jellyfin` reports Ready.
 4. The Jellyfin pod is scheduled on the labeled node and has `gpu.intel.com/i915: 1` in requests and limits.
 5. `kubectl -n jellyfin exec deploy/jellyfin -- /usr/lib/jellyfin-ffmpeg/vainfo` reports the Intel media driver and render device.
-6. A 4K HEVC or HEVC Main10 playback test shows QSV decode/encode in the Jellyfin transcode log.
+6. `kubectl -n jellyfin get deploy jellyfin -o jsonpath='{.spec.template.spec.volumes[?(@.name=="cache")].emptyDir.sizeLimit}'` reports `40Gi`.
+7. `/config/config/encoding.xml` contains segment deletion and throttling settings.
+8. A 4K HEVC or HEVC Main10 playback test shows QSV decode/encode in the Jellyfin transcode log.
 
 For branch validation, use the Jellyfin development verifier with `--include-cluster-base` once the `jellyfin-gpu-nodes` prerequisite is present. If the development cluster does not yet expose the label and `gpu.intel.com/i915` resource, record the smoke as blocked by that prerequisite and substitute local render checks plus bootstrap tests.

--- a/kubernetes/apps/jellyfin/app.yaml
+++ b/kubernetes/apps/jellyfin/app.yaml
@@ -60,4 +60,4 @@ spec:
                     volumes:
                       - name: cache
                         emptyDir:
-                          sizeLimit: 20Gi
+                          sizeLimit: 40Gi

--- a/kubernetes/apps/jellyfin/branch/jellyfin.yaml
+++ b/kubernetes/apps/jellyfin/branch/jellyfin.yaml
@@ -119,6 +119,10 @@ data:
         set_bool(root, "EnableDecodingColorDepth10Hevc", True)
         set_bool(root, "EnableDecodingColorDepth10Vp9", True)
         set_bool(root, "PreferSystemNativeHwDecoder", True)
+        set_bool(root, "EnableSegmentDeletion", True)
+        set_bool(root, "EnableThrottling", True)
+        set_text(root, "ThrottleDelaySeconds", "180")
+        set_text(root, "SegmentKeepSeconds", "720")
         set_string_array(root, "HardwareDecodingCodecs", HARDWARE_DECODING_CODECS)
 
         indent(root)
@@ -344,6 +348,26 @@ spec:
       - name: jellyfin-sso-bootstrap
         configMap:
           name: jellyfin-${branch_slug}-sso-bootstrap
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: jellyfin-${branch_slug}
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: jellyfin-${branch_slug}
+              spec:
+                template:
+                  spec:
+                    volumes:
+                      - name: cache
+                        emptyDir:
+                          sizeLimit: 40Gi
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant

--- a/kubernetes/apps/jellyfin/sso-bootstrap.yaml
+++ b/kubernetes/apps/jellyfin/sso-bootstrap.yaml
@@ -256,6 +256,10 @@ data:
         set_bool(root, "EnableDecodingColorDepth10Hevc", True)
         set_bool(root, "EnableDecodingColorDepth10Vp9", True)
         set_bool(root, "PreferSystemNativeHwDecoder", True)
+        set_bool(root, "EnableSegmentDeletion", True)
+        set_bool(root, "EnableThrottling", True)
+        set_text(root, "ThrottleDelaySeconds", "180")
+        set_text(root, "SegmentKeepSeconds", "720")
         set_string_array(root, "HardwareDecodingCodecs", HARDWARE_DECODING_CODECS)
 
         indent(root)

--- a/tools/tests/test_jellyfin_sso_bootstrap.py
+++ b/tools/tests/test_jellyfin_sso_bootstrap.py
@@ -192,6 +192,10 @@ class JellyfinSsoBootstrapTest(unittest.TestCase):
   <EnableDecodingColorDepth10Hevc>false</EnableDecodingColorDepth10Hevc>
   <EnableDecodingColorDepth10Vp9>false</EnableDecodingColorDepth10Vp9>
   <PreferSystemNativeHwDecoder>false</PreferSystemNativeHwDecoder>
+  <EnableSegmentDeletion>false</EnableSegmentDeletion>
+  <EnableThrottling>false</EnableThrottling>
+  <ThrottleDelaySeconds>0</ThrottleDelaySeconds>
+  <SegmentKeepSeconds>0</SegmentKeepSeconds>
   <HardwareDecodingCodecs>
     <string>h264</string>
     <string>vc1</string>
@@ -212,6 +216,10 @@ class JellyfinSsoBootstrapTest(unittest.TestCase):
                 self.assertEqual(root.findtext("EnableDecodingColorDepth10Hevc"), "true")
                 self.assertEqual(root.findtext("EnableDecodingColorDepth10Vp9"), "true")
                 self.assertEqual(root.findtext("PreferSystemNativeHwDecoder"), "true")
+                self.assertEqual(root.findtext("EnableSegmentDeletion"), "true")
+                self.assertEqual(root.findtext("EnableThrottling"), "true")
+                self.assertEqual(root.findtext("ThrottleDelaySeconds"), "180")
+                self.assertEqual(root.findtext("SegmentKeepSeconds"), "720")
                 self.assertEqual(
                     [item.text for item in root.findall("./HardwareDecodingCodecs/string")],
                     ["h264", "hevc", "mpeg2video", "vc1", "vp8", "vp9"],


### PR DESCRIPTION
## Summary
# Jellyfin Local Cache Cleanup Fix

Implementation: `jellyfin-cache-cleanup-local`  
Branch: `codex/jellyfin-cache-cleanup-local`  
Commit: `8ad692fc5b94c8d129ebd74d7fadc976fca34515`  
Owner agent: `implementation-agent-jellyfin-cache-cleanup-local`

## Summary

- Kept Jellyfin `/cache` on node-local `emptyDir` storage and raised the Helm post-renderer guardrail from `20Gi` to `40Gi`.
- Added the same `40Gi` local cache post-renderer to the Jellyfin branch overlay so development validation renders the same cache behavior.
- Updated production and branch bootstrap encoding configuration to enforce transcode segment deletion and throttling on every pod start:
  - `EnableSegmentDeletion=true`
  - `EnableThrottling=true`
  - `ThrottleDelaySeconds=180`
  - `SegmentKeepSeconds=720`
- Updated focused bootstrap tests to prove the encoding XML fields are written.
- Updated the Jellyfin hardware transcoding runbook to document that `/cache` is intentionally local, bounded at `40Gi`, and self-cleaning; NFS cache PVCs are intentionally avoided for this iteration due to transcode performance concerns.

## Documentation Impact

- Updated `docs/runbooks/jellyfin-hardware-transcoding.md` with cache behavior, encoding cleanup settings, and acceptance checks.
- `python3 tools/architecture/render.py --check` passed, so `docs/architecture.md` was not regenerated.

## Workflow Evidence

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- Note: current session was explicitly assigned by the user as `implementation-agent-jellyfin-cache-cleanup-local`; verifier files and PR creation were intentionally not created.

## Test And Render Evidence

- FAIL: `pytest tools/tests/test_jellyfin_sso_bootstrap.py`
  - Blocker: `/bin/bash: pytest: command not found`.
- FAIL: `python3 -m pytest tools/tests/test_jellyfin_sso_bootstrap.py`
  - Blocker: `/usr/bin/python3: No module named pytest`.
- PASS: `python3 -m unittest tools.tests.test_jellyfin_sso_bootstrap`
  - Result: `Ran 8 tests in 0.022s`, `OK`.
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check`
- PASS: `export cluster_domain=example.test nfs_server=192.0.2.10; kubectl kustomize kubernetes/apps/jellyfin | flux envsubst --strict > .codex/tmp/jellyfin-render.yaml`
  - Inspection: `.codex/tmp/jellyfin-render.yaml` contains the Jellyfin HelmRelease post-renderer patch with `cache` as `emptyDir` and `sizeLimit: 40Gi`.
  - Inspection: render contains the bootstrap encoding fields for segment deletion and throttling.
- PASS: `export branch_slug=jellyfin-cache-cleanup-local cluster_domain=example.test; kubectl kustomize kubernetes/apps/jellyfin/branch | flux envsubst --strict > .codex/tmp/jellyfin-branch-render.yaml`
  - Inspection: `.codex/tmp/jellyfin-branch-render.yaml` contains the branch HelmRelease post-renderer patch with `cache` as `emptyDir` and `sizeLimit: 40Gi`.
  - Inspection: render contains the branch bootstrap encoding fields for segment deletion and throttling.
- PASS: `helm template jellyfin jellyfin/jellyfin --version 3.2.0 --namespace jellyfin -f .codex/tmp/jellyfin-values-rendered.yaml > .codex/tmp/jellyfin-helm-template.yaml`
- PASS: `kubectl kustomize .codex/tmp/prod-postrender > .codex/tmp/jellyfin-helm-postrendered.yaml`
  - Inspection: simulated post-rendered Deployment has `/cache` mounted from a `cache` volume with `emptyDir.sizeLimit: 40Gi`.

## Development Validation

- POST-VERIFIER ATTEMPT: Branch was pushed after verifier approval for exact HEAD `8ad692fc5b94c8d129ebd74d7fadc976fca34515`.
- FAILED/BLOCKED: `python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-cache-cleanup-local --slug jellyfin-cache-cleanup-local --kubeconfig ~/.kube/homelab-development.config --include-cluster-base`
- Successful live evidence before blocker:
  - The verifier fetched the branch revision successfully.
  - The scripted development base sequence reconciled against main/branch: `crds`, `cert-manager`, `nfs-csi`, `cilium`, `certs`, `gateway`, and `app-whoami`.
  - Active base pods reached Ready.
  - Terraform plan portion succeeded, but showed the local development Terraform state is not aligned with the existing live development cluster and would create resources if applied; no apply was run.
  - Branch Jellyfin resources were created: namespace `jellyfin-jellyfin-cache-cleanup-local`, PVC bound on `nfs-csi-storage`, HTTPRoute created, and HelmRelease contained the `cache` postRenderer with `emptyDir.sizeLimit: 40Gi`.
- Blocker:
  - The branch Jellyfin pod remained Pending because the single development node lacked `homelab.petebeegle.com/jellyfin-igpu=true` and did not advertise `gpu.intel.com/i915`.
  - Pod events said the node did not match the pod node selector.
  - This matches the Jellyfin runbook's documented development iGPU prerequisite blocker.
- Cleanup:
  - During cleanup, the development API briefly refused connection, causing the verifier script to exit failed and report cleanup failed.
  - The main coordinator manually deleted the temporary branch Kustomization and GitRepository, confirmed namespace deletion, and confirmed the `flux-system` GitRepository is back on `main@sha1:0379d3860fa0b4079c216f8c2e10d4db01a1fb6e`.
- Development validation status: blocked/failed due to missing development iGPU prerequisite, with successful manual cleanup after the scripted cleanup failure.
- Substitute checks:
  - Local production render with strict Flux substitution passed.
  - Local branch overlay render with strict Flux substitution passed.
  - Focused bootstrap tests passed via `unittest`.
  - Simulated Helm chart post-render confirmed the Deployment cache volume remains local `emptyDir` with `sizeLimit: 40Gi`.
  - Live partial resource checks confirmed the branch PVC, HTTPRoute, and HelmRelease postRenderer shape before the GPU scheduling blocker.

## Verifier Notes

- Changed files:
  - `docs/runbooks/jellyfin-hardware-transcoding.md`
  - `kubernetes/apps/jellyfin/app.yaml`
  - `kubernetes/apps/jellyfin/branch/jellyfin.yaml`
  - `kubernetes/apps/jellyfin/sso-bootstrap.yaml`
  - `tools/tests/test_jellyfin_sso_bootstrap.py`
- No SOPS secret files were changed.
- No cache PVC was added.
- No verifier approval files were created.
- Branch was pushed after verifier approval for exact HEAD `8ad692fc5b94c8d129ebd74d7fadc976fca34515`.


## Changes
- docs/runbooks/jellyfin-hardware-transcoding.md
- kubernetes/apps/jellyfin/app.yaml
- kubernetes/apps/jellyfin/branch/jellyfin.yaml
- kubernetes/apps/jellyfin/sso-bootstrap.yaml
- tools/tests/test_jellyfin_sso_bootstrap.py

## Commits
- 8ad692f fix(jellyfin): bound local transcode cache cleanup

## Verification
- Verified HEAD: `8ad692fc5b94c8d129ebd74d7fadc976fca34515`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
