### PR TITLE
feat(auth): mount private blueprint secret

### DIFF
--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -39,6 +39,8 @@ spec:
         - grafana-oauth-blueprint
         - jellyfin-oauth-blueprint
         - synology-oauth-blueprint
+      secrets:
+        - private-authentik-blueprints
   valuesFrom:
     - kind: ConfigMap
       name: authentik-values

--- a/tools/agent-memory/tests/test_lint.py
+++ b/tools/agent-memory/tests/test_lint.py
@@ -200,7 +200,9 @@ class MemoryLintTests(unittest.TestCase):
             stdout = io.StringIO()
 
             with contextlib.redirect_stdout(stdout):
-                exit_code = main(["lint", "--root", str(root), "--format", "json"])
+                exit_code = main(
+                    ["lint", "--root", str(root), "--format", "json", "--review-window-days", "999999"]
+                )
 
             payload = json.loads(stdout.getvalue())
             self.assertEqual(exit_code, 0)


### PR DESCRIPTION
## Summary

Mount the generic Authentik blueprint Secret `private-authentik-blueprints` through the public Authentik HelmRelease values, and stabilize a time-sensitive agent-memory lint JSON test that failed in CI on this branch.

## Important Changes

- Added `private-authentik-blueprints` to `spec.values.blueprints.secrets` for the Authentik HelmRelease.
- Updated the agent-memory JSON issue-shape test to pass a large `--review-window-days` value, keeping it focused on the intended vague-frontmatter warning instead of date-dependent freshness warnings.

## Documentation Impact

No documentation changed. The Authentik change only wires a generic chart value, and the test change does not alter user-facing or operational behavior.

## Validation

- PASS: `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
- PASS: `PATH=/tmp/kustomize-bin:$PATH kustomize build kubernetes/infra/authentik`
- PASS: `PATH=/tmp/kustomize-bin:$PATH kustomize build kubernetes/infra/authentik | rg -n "blueprints:|configMaps:|secrets:|private-authentik-blueprints"`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `uv run --project tools/agent-memory --with pytest pytest tools/agent-memory/tests/test_lint.py::MemoryLintTests::test_cli_json_output_contains_issue_shape`
- PASS: `uv run --project tools/agent-memory --with pytest pytest tools/agent-memory/tests` with 16 passed
- PASS: exact-HEAD verifier-agent review and verifier attestation validation.

## Development Validation

Not run. Authentik is not present in the development activation path in this public repo, and no kube context, reconciled development route, or browser-login credentials are available in this implementation context. Substitute evidence is the local Authentik kustomize render plus generated architecture check above.
