### PR TITLE
[codex] fix Home Assistant init shell variables

### DIFF
--- a/kubernetes/apps/home-assistant/deployment.yaml
+++ b/kubernetes/apps/home-assistant/deployment.yaml
@@ -30,10 +30,10 @@ spec:
               apk add --no-cache unzip
               archive=/tmp/hass-oidc-auth-v1.1.1.zip
               expected_sha=0226716e299eace3204ea3e6fcdf54a96cc9ded42dadaa34c37c54ffff9b8b68
-              wget -q -O "${archive}" https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/v1.1.1.zip
-              echo "${expected_sha}  ${archive}" | sha256sum -c -
+              wget -q -O "$archive" https://github.com/christiaangoossens/hass-oidc-auth/archive/refs/tags/v1.1.1.zip
+              echo "$expected_sha  $archive" | sha256sum -c -
               rm -rf /tmp/hass-oidc-auth-1.1.1 /config/custom_components/auth_oidc
-              unzip -q "${archive}" "hass-oidc-auth-1.1.1/custom_components/auth_oidc/*" -d /tmp
+              unzip -q "$archive" "hass-oidc-auth-1.1.1/custom_components/auth_oidc/*" -d /tmp
               mkdir -p /config/custom_components
               mv /tmp/hass-oidc-auth-1.1.1/custom_components/auth_oidc /config/custom_components/auth_oidc
           volumeMounts:


### PR DESCRIPTION
## Summary

Fixes the production Home Assistant startup failure found during verification. The `install-auth-oidc` init-container script used shell variables in `${...}` form, and Flux postBuild substitution rendered them empty before Kubernetes applied the manifest.

## Root Cause

Production rendered the init command as:

```text
wget -q -O ""
echo "  "
```

because Flux treated `${archive}` and `${expected_sha}` as substitution variables. The pod stayed in `Init:CrashLoopBackOff`/`Init:Error`, so `app-home-assistant` could not become Ready.

## Change

`kubernetes/apps/home-assistant/deployment.yaml` now uses POSIX shell `$archive` and `$expected_sha` references:

```text
wget -q -O "$archive"
echo "$expected_sha  $archive" | sha256sum -c -
unzip -q "$archive"
```

This preserves runtime shell expansion while avoiding Flux postBuild substitution.

## Validation

- PASS: owner workflow marker/plan/attestation validators
- PASS: verifier approval for exact HEAD `361e8cbfbe4483d867b4c243f1aa817834ea9493`
- PASS: verifier attestation validation
- PASS: `kubectl kustomize kubernetes/apps/home-assistant`
- PASS: `kubectl kustomize kubernetes/clusters/production/apps`
- PASS: focused regression render with `kubectl kustomize kubernetes/apps/home-assistant | flux envsubst --strict`, confirming the rendered command keeps `$archive` / `$expected_sha` and does not contain `wget -q -O ""` or `echo "  "`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `git diff --check HEAD~1..HEAD`

Development branch smoke was not rerun because the development Home Assistant overlay intentionally omits the Authentik/OIDC init container, so it would not exercise this production-only failure path. The focused Flux render regression covers the actual bug.