### PR TITLE
Implementation: sdd-workflow-guards

### DIFF
--- a/.codex/hooks/implementation_workflow_guard.sh
+++ b/.codex/hooks/implementation_workflow_guard.sh
@@ -21,6 +21,7 @@ owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
 marker_validator="tools/codex-harness/validate_active_implementation.py"
 plan_validator="tools/codex-harness/validate_implementation_plan.py"
 attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
+sdd_validator="tools/codex-harness/validate_sdd_context.py"
 branch="$(git branch --show-current)"
 
 fail() {
@@ -33,12 +34,13 @@ fail() {
     printf '  3. Record %s with implementation, branch, base, role=implementation, clone_path, owner_role=implementation-agent, and owner_agent.\n' "$marker"
     printf '  4. Record %s with implementation identity, scope, planned changes, docs impact, tests, verification, and risks.\n' "$plan"
     printf '  5. Record %s with role=implementation-agent, agent_id matching owner_agent, clone identity, and created_at.\n' "$owner_attestation"
-    printf '  6. Make tracked-file changes only inside that sibling clone.\n'
+    printf '  6. Create durable specs/<implementation>/spec.md, plan.md, tasks.md, and evidence.md from the Spec Kit templates.\n'
+    printf '  7. Make tracked-file changes only inside that sibling clone.\n'
   } >&2
   exit 1
 }
 
-validate_workflow() {
+validate_workflow_base() {
   if [[ "$branch" == "main" ]]; then
     fail "Current branch is main."
   fi
@@ -70,6 +72,154 @@ validate_workflow() {
   if ! python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch"; then
     fail "Implementation owner attestation validation failed."
   fi
+}
+
+validate_sdd_context() {
+  if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts; then
+    fail "SDD context validation failed."
+  fi
+}
+
+validate_sdd_evidence() {
+  if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"; then
+    fail "SDD evidence validation failed."
+  fi
+}
+
+validate_workflow() {
+  validate_workflow_base
+  validate_sdd_context
+}
+
+payload_mentions_verifier_evidence() {
+  PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+payload = os.environ.get("PAYLOAD", "")
+haystacks = [payload]
+try:
+    data = json.loads(payload) if payload.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+def walk(value):
+    if isinstance(value, str):
+        haystacks.append(value)
+    elif isinstance(value, dict):
+        for nested in value.values():
+            walk(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            walk(nested)
+
+walk(data)
+text = "\n".join(haystacks)
+if re.search(r"(?:/workspaces/homelab-ideas/[^/\s]+/)?\.codex/tmp/(?:verifier-approved|verifier-attestation\.yaml)", text):
+    sys.exit(0)
+sys.exit(1)
+PY
+}
+
+is_sdd_bootstrap_payload() {
+  PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+payload = os.environ.get("PAYLOAD", "")
+haystacks = [payload]
+try:
+    data = json.loads(payload) if payload.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+def walk(value):
+    if isinstance(value, str):
+        haystacks.append(value)
+    elif isinstance(value, dict):
+        for nested in value.values():
+            walk(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            walk(nested)
+
+walk(data)
+text = "\n".join(haystacks)
+paths = set(re.findall(r"(?:/workspaces/homelab-ideas/[^/\s]+/)?specs/([^/\s]+)/((?:spec|plan|tasks|evidence)\.md)", text))
+if paths:
+    implementations = {implementation for implementation, _ in paths}
+    files = {name for _, name in paths}
+    if len(implementations) == 1 and files <= {"spec.md", "plan.md", "tasks.md", "evidence.md"}:
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+tracked_changes_are_sdd_bootstrap() {
+  python3 - "$branch" <<'PY'
+import subprocess
+import sys
+
+branch = sys.argv[1]
+if not branch.startswith("codex/"):
+    sys.exit(1)
+implementation = branch.split("/", 1)[1]
+allowed = {
+    f"specs/{implementation}/spec.md",
+    f"specs/{implementation}/plan.md",
+    f"specs/{implementation}/tasks.md",
+    f"specs/{implementation}/evidence.md",
+}
+result = subprocess.run(
+    ["git", "status", "--porcelain", "--untracked-files=no"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    check=False,
+)
+paths = []
+for line in result.stdout.splitlines():
+    path = line[3:]
+    if " -> " in path:
+        path = path.split(" -> ", 1)[1]
+    paths.append(path)
+
+tracked_at_head = subprocess.run(
+    ["git", "ls-tree", "-r", "--name-only", "HEAD", f"specs/{implementation}"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    check=False,
+)
+
+if paths and set(paths) <= allowed and not tracked_at_head.stdout.strip():
+    sys.exit(0)
+sys.exit(1)
+PY
+}
+
+sdd_artifacts_absent_from_head() {
+  python3 - "$branch" <<'PY'
+import subprocess
+import sys
+
+branch = sys.argv[1]
+if not branch.startswith("codex/"):
+    sys.exit(1)
+implementation = branch.split("/", 1)[1]
+result = subprocess.run(
+    ["git", "ls-tree", "-r", "--name-only", "HEAD", f"specs/{implementation}"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.DEVNULL,
+    text=True,
+    check=False,
+)
+sys.exit(0 if not result.stdout.strip() else 1)
+PY
 }
 
 if [[ "${1:-}" == "--preflight-mutation" ]]; then
@@ -115,6 +265,15 @@ if normalized and normalized <= allowed:
 sys.exit(1)
 PY
   then
+    exit 0
+  fi
+  if is_sdd_bootstrap_payload && sdd_artifacts_absent_from_head; then
+    validate_workflow_base
+    exit 0
+  fi
+  if payload_mentions_verifier_evidence; then
+    validate_workflow_base
+    validate_sdd_evidence
     exit 0
   fi
   validate_workflow
@@ -240,7 +399,12 @@ for value in values:
 sys.exit(1)
 PY
   then
-    validate_workflow
+    if payload_mentions_verifier_evidence; then
+      validate_workflow_base
+      validate_sdd_evidence
+    else
+      validate_workflow
+    fi
   fi
   exit 0
 fi
@@ -253,6 +417,11 @@ if [[ -f "$state_file" ]]; then
 fi
 
 if [[ -z "$tracked_changes" && "$head_before" == "$head_now" ]]; then
+  exit 0
+fi
+
+if tracked_changes_are_sdd_bootstrap; then
+  validate_workflow_base
   exit 0
 fi
 

--- a/.codex/hooks/verifier_push_guard.sh
+++ b/.codex/hooks/verifier_push_guard.sh
@@ -37,9 +37,59 @@ fi
 head_sha="$(git rev-parse HEAD)"
 approval_file=".codex/tmp/verifier-approved"
 attestation_file=".codex/tmp/verifier-attestation.yaml"
+marker=".codex/tmp/active-implementation"
+plan=".codex/tmp/implementation-plan.yaml"
+owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
+marker_validator="tools/codex-harness/validate_active_implementation.py"
+plan_validator="tools/codex-harness/validate_implementation_plan.py"
 attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
+sdd_validator="tools/codex-harness/validate_sdd_context.py"
+push_updates="$(cat || true)"
+
+allow_smoke_push() {
+  local branch
+  branch="$(git branch --show-current)"
+  [[ "$branch" =~ ^codex/.+ ]] || return 1
+  [[ -n "$push_updates" ]] || return 1
+
+  if ! PUSH_UPDATES="$push_updates" BRANCH="$branch" HEAD_SHA="$head_sha" python3 - <<'PY'
+import os
+import sys
+
+branch = os.environ["BRANCH"]
+head = os.environ["HEAD_SHA"]
+updates = [line.split() for line in os.environ.get("PUSH_UPDATES", "").splitlines() if line.strip()]
+if not updates:
+    sys.exit(1)
+
+remote_ref = f"refs/heads/{branch}"
+for fields in updates:
+    if len(fields) != 4:
+        sys.exit(1)
+    local_ref, local_oid, pushed_remote_ref, _remote_oid = fields
+    if pushed_remote_ref != remote_ref:
+        sys.exit(1)
+    if local_oid != head:
+        sys.exit(1)
+    if local_ref not in {"HEAD", remote_ref}:
+        sys.exit(1)
+sys.exit(0)
+PY
+  then
+    return 1
+  fi
+
+  python3 "$marker_validator" --marker "$marker" --root "$root" --branch "$branch" || return 1
+  python3 "$plan_validator" --plan "$plan" --marker "$marker" --root "$root" --branch "$branch" || return 1
+  python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch" || return 1
+  python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts || return 1
+  return 0
+}
 
 if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
+  if allow_smoke_push; then
+    exit 0
+  fi
   {
     printf 'Verifier push guard: refusing to push to origin.\n'
     printf 'Expected %s to contain the exact HEAD SHA:\n' "$approval_file"
@@ -58,7 +108,7 @@ if [[ ! -f "$attestation_file" ]]; then
   exit 1
 fi
 
-if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --head "$head_sha"; then
+if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --marker "$marker" --owner-attestation "$owner_attestation" --head "$head_sha" --root "$root" --branch "$(git branch --show-current)"; then
   printf 'Verifier push guard: verifier attestation validation failed.\n' >&2
   exit 1
 fi

--- a/.codex/scripts/create_implementation_pr.sh
+++ b/.codex/scripts/create_implementation_pr.sh
@@ -22,9 +22,6 @@ head_sha="$(git rev-parse HEAD)"
 approval_file=".codex/tmp/verifier-approved"
 attestation_file=".codex/tmp/verifier-attestation.yaml"
 if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
-  if ((auto)); then
-    exit 0
-  fi
   {
     printf 'Implementation PR: verifier approval is missing for exact HEAD.\n'
     printf 'Expected %s to contain:\n' "$approval_file"
@@ -34,9 +31,6 @@ if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
 fi
 
 if [[ ! -f "$attestation_file" ]]; then
-  if ((auto)); then
-    exit 0
-  fi
   {
     printf 'Implementation PR: verifier attestation is missing for exact HEAD.\n'
     printf 'Expected %s with approved_head:\n' "$attestation_file"
@@ -46,19 +40,48 @@ if [[ ! -f "$attestation_file" ]]; then
 fi
 
 marker=".codex/tmp/active-implementation"
+plan=".codex/tmp/implementation-plan.yaml"
+owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
 if [[ ! -f "$marker" ]]; then
   printf 'Implementation PR: missing %s.\n' "$marker" >&2
   exit 1
 fi
 
 validator="tools/codex-harness/validate_active_implementation.py"
+plan_validator="tools/codex-harness/validate_implementation_plan.py"
+attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
+sdd_validator="tools/codex-harness/validate_sdd_context.py"
 if ! python3 "$validator" --marker "$marker" --root "$root" --branch "$branch"; then
   printf 'Implementation PR: active implementation marker does not match this checkout.\n' >&2
   exit 1
 fi
 
-attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
-if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --head "$head_sha" --root "$root" --branch "$branch"; then
+if [[ ! -f "$plan" ]]; then
+  printf 'Implementation PR: missing %s.\n' "$plan" >&2
+  exit 1
+fi
+
+if ! python3 "$plan_validator" --plan "$plan" --marker "$marker" --root "$root" --branch "$branch"; then
+  printf 'Implementation PR: implementation plan validation failed.\n' >&2
+  exit 1
+fi
+
+if [[ ! -f "$owner_attestation" ]]; then
+  printf 'Implementation PR: missing %s.\n' "$owner_attestation" >&2
+  exit 1
+fi
+
+if ! python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch"; then
+  printf 'Implementation PR: implementation owner attestation validation failed.\n' >&2
+  exit 1
+fi
+
+if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts --require-evidence --head "$head_sha"; then
+  printf 'Implementation PR: SDD evidence validation failed.\n' >&2
+  exit 1
+fi
+
+if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --marker "$marker" --owner-attestation "$owner_attestation" --head "$head_sha" --root "$root" --branch "$branch"; then
   printf 'Implementation PR: verifier attestation validation failed.\n' >&2
   exit 1
 fi

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -22,14 +22,16 @@ Use this runbook for every repository code change. The binding decision is `docs
 6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development validation expectations for the implementation, or explain why they do not apply.
 7. Before tracked edits, create `.codex/tmp/implementation-owner-attestation.yaml` with implementation identity, role, concrete `agent_id`, clone path, `created_at`, and matching delegation token evidence under `.codex/tmp/delegation-tokens/`.
 8. Validate the marker, plan, and owner attestation.
-9. Make tracked-file changes only in the sibling clone.
-10. Update docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no docs change, record why in `.codex/tmp/pr-summary.md`.
-11. Commit with conventional commits.
-12. Run relevant checks, collect TDD evidence, and collect required development-cluster validation evidence for covered cluster-affecting changes before requesting verifier review.
-13. Record verifier approval for the exact `HEAD` SHA in `.codex/tmp/verifier-approved`.
-14. Record `.codex/tmp/verifier-attestation.yaml` with verifier identity, separate delegation token evidence, and `approved_head` equal to the exact `HEAD` SHA. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
-15. Write `.codex/tmp/pr-summary.md` from the plan and final result.
-16. Create the pull request against `main`; delete the sibling clone only after PR creation succeeds.
+9. Create durable SDD artifacts under `specs/<implementation>/`: `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
+10. Make tracked-file changes only in the sibling clone.
+11. Update docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no docs change, record why in `.codex/tmp/pr-summary.md`.
+12. Commit with conventional commits.
+13. Run relevant checks, collect TDD evidence, and collect required development-cluster validation evidence for covered cluster-affecting changes before requesting verifier review.
+14. Record command outcomes, development validation evidence or exceptions, final `HEAD`, and documentation impact in `specs/<implementation>/evidence.md`.
+15. Record verifier approval for the exact `HEAD` SHA in `.codex/tmp/verifier-approved`.
+16. Record `.codex/tmp/verifier-attestation.yaml` with verifier identity, separate delegation token evidence, and `approved_head` equal to the exact `HEAD` SHA. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
+17. Write `.codex/tmp/pr-summary.md` from the plan and final result.
+18. Create the pull request against `main`; delete the sibling clone only after PR creation succeeds.
 
 ## Active Marker
 
@@ -132,6 +134,12 @@ python3 tools/codex-harness/validate_workflow_attestations.py \
   --root "$(pwd)" \
   --branch "$(git branch --show-current)"
 
+python3 tools/codex-harness/validate_sdd_context.py \
+  --marker .codex/tmp/active-implementation \
+  --root "$(pwd)" \
+  --branch "$(git branch --show-current)" \
+  --require-plan-artifacts
+
 python3 tools/codex-harness/validate_workflow_attestations.py \
   --kind verifier \
   --attestation .codex/tmp/verifier-attestation.yaml \
@@ -140,7 +148,40 @@ python3 tools/codex-harness/validate_workflow_attestations.py \
   --head "$(git rev-parse HEAD)" \
   --root "$(pwd)" \
   --branch "$(git branch --show-current)"
+
+python3 tools/codex-harness/validate_sdd_context.py \
+  --marker .codex/tmp/active-implementation \
+  --root "$(pwd)" \
+  --branch "$(git branch --show-current)" \
+  --require-plan-artifacts \
+  --require-evidence \
+  --head "$(git rev-parse HEAD)"
 ```
+
+## SDD Guard Gates
+
+For non-bootstrap tracked edits, the workflow guard requires valid branch,
+clone, marker, implementation plan, owner attestation, delegation token, and
+non-empty `specs/<implementation>/spec.md`, `plan.md`, and `tasks.md`.
+Bootstrap edits that create the initial SDD artifact files are allowed only when
+the branch `HEAD` does not already contain SDD artifacts for the implementation.
+
+Verifier approval, verifier attestation, automatic PR creation, final handoff,
+and non-smoke pushes require `specs/<implementation>/evidence.md` to exist and
+be non-empty. When `evidence.md` records an explicit final, verified, approved,
+branch, or current `HEAD`, that SHA must match the current branch `HEAD`.
+
+`.codex/scripts/create_implementation_pr.sh --auto` performs its own marker,
+plan, owner attestation, SDD evidence, verifier approval, and verifier
+attestation gates before pushing or creating a PR. Do not rely on Stop-hook
+ordering as the PR creation safety boundary.
+
+Development validation may push `origin HEAD:refs/heads/codex/<implementation>`
+before verifier approval only from the active implementation branch, only when
+the implementation clone has valid runtime workflow context and non-empty
+`spec.md`, `plan.md`, and `tasks.md`. PR creation, final handoff, and all other
+origin pushes still require exact-HEAD verifier approval and verifier
+attestation.
 
 ## Ownership
 

--- a/docs/runbooks/spec-driven-development.md
+++ b/docs/runbooks/spec-driven-development.md
@@ -73,6 +73,32 @@ the sibling clone. These files are ignored and are not durable documentation.
 Verifier files under `.codex/tmp/` are owned by a separate verifier and are not
 created by the implementation owner.
 
+## Enforced Guard Behavior
+
+The harness treats `specs/<implementation>/` as durable implementation context.
+After the initial SDD artifact bootstrap, non-bootstrap tracked edits require a
+valid implementation marker, implementation plan, owner attestation, delegation
+token, and non-empty:
+
+- `specs/<implementation>/spec.md`
+- `specs/<implementation>/plan.md`
+- `specs/<implementation>/tasks.md`
+
+`specs/<implementation>/evidence.md` is required before verifier approval,
+automatic PR creation, final handoff, and non-smoke pushes. If evidence records
+an explicit final, verified, approved, branch, or current `HEAD`, the recorded
+SHA must match the current branch `HEAD`.
+
+Automatic PR creation runs these gates itself through
+`.codex/scripts/create_implementation_pr.sh --auto`; Stop-hook ordering is not
+the enforcement boundary.
+
+Development smoke validation may push the active implementation branch to
+`origin codex/<implementation>` before verifier approval only from a valid
+implementation clone with non-empty `spec.md`, `plan.md`, and `tasks.md`.
+Verifier approval for the exact `HEAD` remains mandatory for PR creation, final
+handoff, and non-smoke pushes.
+
 ## Spec Persistence
 
 Keep useful decisions, assumptions, acceptance criteria, test outcomes, smoke

--- a/specs/sdd-workflow-guards/evidence.md
+++ b/specs/sdd-workflow-guards/evidence.md
@@ -1,0 +1,73 @@
+# Evidence: sdd-workflow-guards
+
+**Branch**: `codex/sdd-workflow-guards`
+**Risk Tier**: low
+**Started**: 2026-07-03
+**Owner**: implementation-agent-sdd-workflow-guards
+
+## Spec Kit Initialization
+
+- Command: Not run in this implementation; PR #317 already initialized Spec Kit
+  and this branch starts from `origin/main` containing merge `1846b94`.
+- Outcome: Reused merged Spec Kit templates from `.specify/templates/`.
+- Spec Kit version: Not rechecked; no Spec Kit scaffolding changes are planned.
+- Integration: Existing `codex` integration from PR #317.
+- Fallback: None.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `git clone https://github.com/petebeegle/homelab.git /workspaces/homelab-ideas/sdd-workflow-guards && git -C /workspaces/homelab-ideas/sdd-workflow-guards switch -c codex/sdd-workflow-guards origin/main && git -C /workspaces/homelab-ideas/sdd-workflow-guards merge-base --is-ancestor 1846b942a8c12db3cb4964074c7b85fdbb8e3729 origin/main && git -C /workspaces/homelab-ideas/sdd-workflow-guards log --oneline -5` | PASS | Sibling clone created; `origin/main` contains PR #317 merge `1846b94`; branch starts at `2da21ee`. |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Active marker accepted. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan accepted. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation and matching delegation token accepted. |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | New durable SDD context validator accepted current spec, plan, tasks, and evidence artifacts. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest discover -s tools/codex-harness/tests` | PASS | 75 tests passed. Covers valid/invalid SDD artifacts, verifier approval/evidence gates, PR creation auto blocking, smoke push allowance/rejection, and stale evidence. |
+| `python3 tools/architecture/render.py --check` | PASS | No generated architecture changes required. |
+| `python3 -m unittest discover -s tools/development/tests` | PASS | 28 tests passed. |
+| `python3 -m unittest discover -s tools/context-pack/tests` | PASS | 2 tests passed. |
+| `uv run --project tools/agent-memory pytest tools/agent-memory/tests` | FAIL | Environment/tooling failure before tests: `uv` could not find Python 3.14.6 in managed installations or search path and suggested a newer uv may be required. |
+| `pre-commit run --all-files` | PASS | All configured hooks passed, including generated architecture check. |
+| `npx -y agnix@0.25.0 .` | PASS | Completed with 0 errors, 14 warnings, and 1 info. Warnings were pre-existing Spec Kit skill/AGENTS guidance warnings from PR #317-era content; no changes made because skill cleanup is out of scope. |
+| `npm test` in `tests/smoke` | FAIL | Initial optional smoke attempt failed because `playwright` was not installed in the sibling clone. |
+| `npm ci && npm test` in `tests/smoke` | PASS | Installed 3 npm packages locally, then 6 Playwright smoke tests passed. Generated `node_modules` and `test-results` were removed afterward. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: Deferred; exact final branch HEAD is recorded in `.codex/tmp/pr-summary.md`
+  and the implementation handoff because a committed file cannot stably contain
+  the SHA of the commit that contains it.
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Local-only harness, hook, script, and documentation
+  change; no Kubernetes, Terraform, Flux, Gateway, storage, secret reference, or
+  app behavior changes.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/implementation-workflow.md` and
+  `docs/runbooks/spec-driven-development.md`.
+- Generated docs: `python3 tools/architecture/render.py --check` passed; no
+  generated architecture update required.
+- No-docs rationale: N/A; runbooks will be updated.
+
+## Exceptions And Follow-Ups
+
+- Development smoke is intentionally not run for this local-only guard PR.
+
+## Final State
+
+- Final branch: `codex/sdd-workflow-guards`
+- Final HEAD: Deferred to `.codex/tmp/pr-summary.md` and implementation
+  handoff after commit.
+- Commit: Conventional commit created; exact final SHA is recorded in
+  `.codex/tmp/pr-summary.md` and the implementation handoff after commit.
+- Verifier approval: not created by implementation owner

--- a/specs/sdd-workflow-guards/plan.md
+++ b/specs/sdd-workflow-guards/plan.md
@@ -1,0 +1,125 @@
+# Implementation Plan: sdd-workflow-guards
+
+**Branch**: `codex/sdd-workflow-guards` | **Date**: 2026-07-03 | **Spec**:
+`specs/sdd-workflow-guards/spec.md`
+
+**Input**: Feature specification from
+`specs/sdd-workflow-guards/spec.md`
+
+## Summary
+
+Add reusable SDD artifact validation to the Codex harness, wire it into tracked
+edit guards, verifier approval/PR creation gates, and push guard tests, and
+document the resulting workflow contract. The implementation keeps runtime
+markers in `.codex/tmp/` while making `specs/<implementation>/` the durable
+context required for normal implementation progress.
+
+## Technical Context
+
+**Risk Tier**: low
+**Workflow Tier**: low
+**Primary Areas**: Codex harness, hooks, PR script, tests, runbooks
+**Dependencies**: Python standard library, shell, git, GitHub CLI for real PR
+creation paths
+**Storage**: N/A
+**Ingress**: N/A
+**Secrets**: No new secrets; `.codex/tmp` token evidence stays ignored
+**Development Validation**: none; local-only workflow guard changes with no
+cluster-facing manifests or app behavior
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Sibling clone ownership files validated before tracked edits.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] Separate verifier approval required before PR creation.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/sdd-workflow-guards/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+.codex/hooks/implementation_workflow_guard.sh
+.codex/hooks/verifier_push_guard.sh
+.codex/scripts/create_implementation_pr.sh
+tools/codex-harness/
+tools/codex-harness/tests/
+docs/runbooks/spec-driven-development.md
+docs/runbooks/implementation-workflow.md
+specs/sdd-workflow-guards/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add focused unit tests for the changed harness and script
+behavior. Because this is a guard-hardening change rather than a bug with an
+existing failing fixture, tests may be added with implementation and must cover
+the requested pass/fail cases.
+
+**Local checks**:
+
+- `python3 -m unittest discover -s tools/codex-harness/tests`
+- `pre-commit run --all-files`
+- `python3 tools/architecture/render.py --check`
+- `python3 -m unittest discover -s tools/development/tests`
+- `python3 -m unittest discover -s tools/context-pack/tests`
+- `uv run --project tools/agent-memory pytest tools/agent-memory/tests`
+- `npx -y agnix@0.25.0 .`
+
+**Development smoke**: none; changes are local harness, hooks, and docs only.
+
+**Evidence destination**: `specs/sdd-workflow-guards/evidence.md` and
+`.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+Update `docs/runbooks/spec-driven-development.md` and
+`docs/runbooks/implementation-workflow.md` only where needed to describe the new
+guard gates, evidence freshness check, and smoke push exception.
+
+## Implementation Steps
+
+1. Inspect existing hook, push guard, PR script, validators, and tests.
+2. Add reusable SDD context validation helper or script entrypoint with focused
+   tests.
+3. Wire required checks into tracked edit guard behavior, verifier/PR gates, and
+   push guard behavior.
+4. Update docs for the enforced behavior.
+5. Run feasible checks and record all command evidence.
+6. Commit with a conventional commit and report final `HEAD` without creating
+   verifier approval or a PR.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| SDD artifact gate blocks bootstrap edits needed to create artifacts | Allow bootstrap/spec artifact creation while requiring artifacts for later non-bootstrap tracked edits. |
+| Smoke push exception weakens verifier gates | Scope the exception to active `codex/<implementation>` branch pushes from a valid implementation clone/spec context only. |
+| PR creation tests accidentally invoke network or `gh` | Keep tests in dry-run or stubbed command paths. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/sdd-workflow-guards/spec.md
+++ b/specs/sdd-workflow-guards/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: sdd-workflow-guards
+
+**Feature Branch**: `codex/sdd-workflow-guards`
+**Created**: 2026-07-03
+**Status**: Draft
+**Risk Tier**: low
+**Input**: User description: "Teach workflow guards and PR creation to require durable SDD context, exact verifier evidence, and a narrow development smoke push exception."
+
+## Summary
+
+Workflow automation must treat `specs/<implementation>/` as the durable planning
+and evidence record for implementation work. Local scratch files under
+`.codex/tmp/` remain required for active runtime state, but non-bootstrap tracked
+edits, verifier handoff, and automatic PR creation should fail when required SDD
+artifacts or exact-HEAD evidence are missing or stale.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+
+## Scope
+
+### In Scope
+
+- Require non-empty `spec.md`, `plan.md`, and `tasks.md` in
+  `specs/<implementation>/` for non-bootstrap tracked edits.
+- Require `evidence.md` before verifier approval or automatic PR creation, with
+  stale-HEAD rejection where evidence declares a final or approved HEAD.
+- Move PR creation self-checks into `.codex/scripts/create_implementation_pr.sh
+  --auto` so PR creation performs its own workflow gates.
+- Preserve exact-HEAD verifier approval for final handoff and PR creation.
+- Permit only the development smoke push pattern needed to push
+  `codex/<implementation>` from a valid active implementation clone and SDD
+  context.
+- Add focused automated checks and documentation for the enforced behavior.
+
+### Out Of Scope
+
+- Repo-local skill cleanup.
+- Development smoke matrix expansion.
+- Removing old untracked files from the main checkout.
+- Broad workflow rewrites beyond guard enforcement.
+- Creating verifier approval or opening the PR from this implementation owner
+  pass.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Durable SDD Context Is Required (Priority: P1)
+
+An implementation owner cannot continue non-bootstrap tracked edits unless the
+branch has durable SDD planning artifacts.
+
+**Why this priority**: This is the smallest useful guard against losing design
+context in ignored runtime files.
+
+**Independent Test**: Focused harness tests cover valid, missing, and empty SDD
+artifact combinations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid implementation marker and owner attestation, **When** a
+   non-bootstrap tracked edit is attempted without `spec.md`, `plan.md`, or
+   `tasks.md`, **Then** the workflow guard exits non-zero with a useful message.
+2. **Given** non-empty `spec.md`, `plan.md`, and `tasks.md`, **When** the same
+   tracked edit is checked, **Then** the SDD context gate passes.
+
+### User Story 2 - PR Creation Self-Gates (Priority: P1)
+
+Automatic PR creation must not depend on a separate Stop hook to catch missing
+verifier evidence.
+
+**Why this priority**: PR creation is the durable boundary where exact verifier
+approval and evidence need to be checked deterministically.
+
+**Independent Test**: Script tests exercise `create_implementation_pr.sh --auto`
+with missing and valid exact-HEAD verifier approval, verifier attestation, and
+`evidence.md`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a branch without exact-HEAD verifier approval or verifier
+   attestation, **When** `create_implementation_pr.sh --auto` runs, **Then** it
+   fails before pushing or creating a PR.
+2. **Given** a branch where `evidence.md` records a final HEAD that differs from
+   branch `HEAD`, **When** PR gates run, **Then** the stale evidence is rejected.
+
+### User Story 3 - Smoke Push Exception Is Narrow (Priority: P2)
+
+Development validation can push an active implementation branch for smoke
+testing without weakening final verifier approval.
+
+**Why this priority**: Branch smoke validation needs a pre-verifier push, while
+handoff and PR creation still need exact verifier evidence.
+
+**Independent Test**: Push guard tests cover allowed active
+`codex/<implementation>` smoke pushes and rejected invalid branch/context pushes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid implementation clone, active `codex/<implementation>`
+   branch, owner attestation, and SDD context, **When** a push targets
+   `origin codex/<implementation>` for development smoke, **Then** the push
+   guard allows it before verifier approval.
+2. **Given** any non-smoke branch or invalid implementation context, **When** a
+   push is checked without exact-HEAD verifier approval, **Then** the push guard
+   rejects it.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST add or update guard validation for
+  non-empty `specs/<implementation>/spec.md`, `plan.md`, and `tasks.md` before
+  non-bootstrap tracked edits.
+- **FR-002**: The implementation MUST require `specs/<implementation>/evidence.md`
+  before verifier approval or PR creation, or explicit deferred/unavailable
+  evidence text where applicable.
+- **FR-003**: Automatic PR creation MUST perform its own exact-HEAD verifier
+  approval, verifier attestation, and SDD evidence gates.
+- **FR-004**: The smoke push exception MUST apply only to pushes of the active
+  `codex/<implementation>` branch from a valid implementation clone and SDD
+  context.
+- **FR-005**: Final PR creation, final handoff, and non-smoke pushes MUST
+  continue to require exact-HEAD verifier approval.
+- **FR-006**: Automated checks MUST cover valid/invalid SDD artifacts, PR gate
+  failures, smoke push allowance/rejection, and stale evidence when practical.
+- **FR-007**: Evidence MUST record commands run, outcomes, docs impact, final
+  branch, and final `HEAD`.
+
+## Risk And Validation Expectations
+
+**Low**: This changes local harness, hook, and script behavior. Add focused unit
+tests around changed executable paths and run broader local checks that are
+feasible. Development-cluster validation is not required because no Kubernetes,
+Terraform, Flux, Gateway, storage, secret reference, or app behavior changes are
+included.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `python3 -m unittest discover -s tools/codex-harness/tests` passes
+  with new SDD, PR gate, and push guard coverage.
+- **SC-002**: `.codex/scripts/create_implementation_pr.sh --auto` has testable
+  internal workflow gates and does not rely on a Stop hook for PR blocking.
+- **SC-003**: Documentation describes the durable SDD artifact gates and smoke
+  push exception without expanding the workflow beyond this PR scope.
+- **SC-004**: Final branch has no tracked `.codex/tmp/*` runtime files.
+
+## Assumptions
+
+- Spec Kit scaffolding from PR #317 is already present on `origin/main`.
+- Development validation pushes target the implementation branch
+  `codex/<implementation>` and are distinguishable from final PR creation or
+  non-smoke pushes by guard mode or command context.
+- Evidence freshness can be checked when `evidence.md` declares a final,
+  approved, or branch `HEAD`; otherwise the guard only enforces that evidence is
+  present and non-empty.
+
+## Open Questions
+
+- None

--- a/specs/sdd-workflow-guards/tasks.md
+++ b/specs/sdd-workflow-guards/tasks.md
@@ -1,0 +1,80 @@
+---
+description: "Homelab SDD task list for workflow guard hardening"
+---
+
+# Tasks: sdd-workflow-guards
+
+**Input**: `specs/sdd-workflow-guards/spec.md` and
+`specs/sdd-workflow-guards/plan.md`
+**Risk Tier**: low
+**Prerequisites**: Valid workflow marker, implementation plan, owner
+attestation, and delegation token under `.codex/tmp/`
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Workflow Setup
+
+- [x] T001 [FR-OWN] Create the sibling clone at
+      `/workspaces/homelab-ideas/sdd-workflow-guards` on
+      `codex/sdd-workflow-guards`.
+- [x] T002 [FR-OWN] Create `.codex/tmp/active-implementation`,
+      `.codex/tmp/implementation-plan.yaml`,
+      `.codex/tmp/implementation-owner-attestation.yaml`, and matching
+      delegation token evidence.
+- [x] T003 [FR-OWN] Run the three owner workflow validators and record outcomes
+      in `specs/sdd-workflow-guards/evidence.md`.
+
+## Phase 2: Spec And Plan
+
+- [x] T004 [FR-SPEC] Write `specs/sdd-workflow-guards/spec.md`.
+- [x] T005 [FR-PLAN] Write `specs/sdd-workflow-guards/plan.md`, including
+      tiered TDD and development validation expectations.
+- [x] T006 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations.
+
+## Phase 3: Implementation
+
+- [x] T007 [P] [FR-001,FR-002] Add SDD context validation under
+      `tools/codex-harness/`.
+- [x] T008 [P] [FR-001] Wire SDD artifact checks into
+      `.codex/hooks/implementation_workflow_guard.sh`.
+- [x] T009 [FR-003] Move PR creation gates into
+      `.codex/scripts/create_implementation_pr.sh --auto`.
+- [x] T010 [FR-004,FR-005] Update `.codex/hooks/verifier_push_guard.sh` for the
+      narrow smoke push exception while preserving exact-HEAD gates.
+- [x] T011 [FR-006] Add focused tests under `tools/codex-harness/tests/`.
+- [x] T012 [FR-DOCS] Update
+      `docs/runbooks/spec-driven-development.md` and
+      `docs/runbooks/implementation-workflow.md`.
+- [x] T013 [FR-IMPL] Re-check constitution gates after implementation edits.
+
+## Phase 4: Verification
+
+- [x] T014 [FR-TEST] Run `python3 -m unittest discover -s
+      tools/codex-harness/tests`.
+- [x] T015 [FR-TEST] Run `pre-commit run --all-files`.
+- [x] T016 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T017 [FR-TEST] Run `python3 -m unittest discover -s
+      tools/development/tests`.
+- [x] T018 [FR-TEST] Run `python3 -m unittest discover -s
+      tools/context-pack/tests`.
+- [x] T019 [FR-TEST] Run `uv run --project tools/agent-memory pytest
+      tools/agent-memory/tests`.
+- [x] T020 [FR-TEST] Run `npx -y agnix@0.25.0 .`.
+- [x] T021 [FR-SMOKE] Record development smoke exception for local-only
+      workflow guard changes.
+- [x] T022 [FR-EVIDENCE] Record command outcomes, exceptions, final branch, and
+      final `HEAD` in `specs/sdd-workflow-guards/evidence.md`.
+
+## Phase 5: Commit And Handoff
+
+- [x] T023 [FR-PR] Write `.codex/tmp/pr-summary.md` from the plan and final
+      evidence.
+- [x] T024 [FR-PR] Commit with a conventional commit message.
+- [ ] T025 [FR-PR] Report exact `HEAD` and do not create verifier approval or a
+      PR.

--- a/tools/codex-harness/tests/test_create_implementation_pr.py
+++ b/tools/codex-harness/tests/test_create_implementation_pr.py
@@ -12,6 +12,7 @@ SCRIPT_SOURCE = REPO_ROOT / ".codex" / "scripts" / "create_implementation_pr.sh"
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
 VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
@@ -29,8 +30,10 @@ class CreateImplementationPrTest(unittest.TestCase):
         _install_harness_files(self.root, self.sibling_root)
         subprocess.run(["git", "switch", "-c", self.branch], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
         _write_marker(self.root, self.implementation)
+        _write_plan(self.root, self.implementation)
         _write_owner_attestation(self.root, self.implementation)
         self.head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.root, text=True).strip()
+        _write_sdd_artifacts(self.root, self.implementation, final_head=self.head)
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()
@@ -44,6 +47,12 @@ class CreateImplementationPrTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("verifier attestation is missing", result.stderr)
 
+    def test_auto_blocks_without_exact_head_verifier_approval(self) -> None:
+        result = _run_script(self.root, "--auto")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("verifier approval is missing for exact HEAD", result.stderr)
+
     def test_blocks_with_wrong_head_verifier_attestation(self) -> None:
         _write_verifier_approval(self.root, self.head)
         _write_verifier_attestation(self.root, self.implementation, "0" * 40)
@@ -52,6 +61,27 @@ class CreateImplementationPrTest(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("verifier attestation validation failed", result.stderr)
+
+    def test_blocks_without_evidence_md(self) -> None:
+        _write_verifier_approval(self.root, self.head)
+        _write_verifier_attestation(self.root, self.implementation, self.head)
+        (self.root / "specs" / self.implementation / "evidence.md").unlink()
+
+        result = _run_script(self.root)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SDD evidence validation failed", result.stderr)
+        self.assertIn("Missing required SDD artifact", result.stderr)
+
+    def test_blocks_stale_evidence_head(self) -> None:
+        _write_verifier_approval(self.root, self.head)
+        _write_verifier_attestation(self.root, self.implementation, self.head)
+        _write_sdd_artifacts(self.root, self.implementation, final_head="0" * 40)
+
+        result = _run_script(self.root)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("records HEAD", result.stderr)
 
 
 def _init_repo(root: Path) -> None:
@@ -73,6 +103,7 @@ def _install_harness_files(root: Path, sibling_root: Path) -> None:
     shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
     shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
     shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+    shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
     shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
     _patch_sibling_root(
@@ -144,6 +175,50 @@ def _write_owner_attestation(root: Path, implementation: str) -> None:
     )
 
 
+def _write_plan(root: Path, implementation: str) -> None:
+    tmp = root / ".codex" / "tmp"
+    tmp.mkdir(parents=True, exist_ok=True)
+    (tmp / "implementation-plan.yaml").write_text(
+        "\n".join(
+            [
+                f"implementation: {implementation}",
+                f"branch: codex/{implementation}",
+                "base: origin/main",
+                f"clone_path: {root}",
+                "owner_agent: implementation-agent-deterministic-role-enforcement",
+                "summary: Harden implementation workflow enforcement.",
+                "scope:",
+                "  - Add plan validation.",
+                "out_of_scope:",
+                "  - Live cluster changes.",
+                "planned_changes:",
+                "  - Add validator and hook checks.",
+                "docs_impact: Update workflow runbooks.",
+                "tests:",
+                "  - python3 -m unittest discover -s tools/codex-harness/tests",
+                "verification:",
+                "  - Harness tests pass.",
+                "risks:",
+                "  - Conservative guard behavior.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_sdd_artifacts(root: Path, implementation: str, *, final_head: str | None = None) -> None:
+    specs = root / "specs" / implementation
+    specs.mkdir(parents=True, exist_ok=True)
+    (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (specs / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (specs / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+    lines = ["# Evidence"]
+    if final_head is not None:
+        lines.append(f"- Final HEAD: {final_head}")
+    (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 def _write_verifier_approval(root: Path, head: str) -> None:
     tmp = root / ".codex" / "tmp"
     tmp.mkdir(parents=True, exist_ok=True)
@@ -205,9 +280,9 @@ def _write_delegation_token(
     )
 
 
-def _run_script(root: Path) -> subprocess.CompletedProcess[str]:
+def _run_script(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", ".codex/scripts/create_implementation_pr.sh"],
+        ["bash", ".codex/scripts/create_implementation_pr.sh", *args],
         cwd=root,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tools/codex-harness/tests/test_implementation_workflow_guard.py
+++ b/tools/codex-harness/tests/test_implementation_workflow_guard.py
@@ -15,6 +15,7 @@ USER_PROMPT_HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "user_prompt_submit.s
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
 VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
@@ -61,7 +62,33 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
         self._write_marker()
         self._write_plan()
         self._write_owner_attestation()
+        self._write_sdd_artifacts()
         (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
+
+        result = self._run_hook()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_post_change_blocks_without_sdd_context(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+        (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
+
+        result = self._run_hook()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required SDD artifact", result.stderr)
+
+    def test_post_change_allows_sdd_artifact_bootstrap(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+        specs = self.root / "specs" / self.implementation
+        specs.mkdir(parents=True, exist_ok=True)
+        (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
 
         result = self._run_hook()
 
@@ -143,6 +170,59 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_preflight_mutation_allows_sdd_artifact_bootstrap_after_workflow_validation(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+
+        result = self._run_hook(
+            "--preflight-mutation",
+            {"tool_input": {"path": f"specs/{self.implementation}/spec.md"}},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_preflight_mutation_blocks_non_sdd_change_without_sdd_artifacts(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+
+        result = self._run_hook("--preflight-mutation", {"tool_input": {"path": "README.md"}})
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing required SDD artifact", result.stderr)
+
+    def test_preflight_mutation_blocks_verifier_approval_without_evidence(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+        self._write_sdd_artifacts(include_evidence=False)
+
+        result = self._run_hook(
+            "--preflight-mutation",
+            {"tool_input": {"path": ".codex/tmp/verifier-approved"}},
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SDD evidence validation failed", result.stderr)
+
+    def test_preflight_bash_allows_verifier_approval_with_evidence(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_marker()
+        self._write_plan()
+        self._write_owner_attestation()
+        self._write_sdd_artifacts()
+
+        result = self._run_hook(
+            "--preflight-bash",
+            {"command": "touch .codex/tmp/verifier-approved"},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_user_prompt_submit_marks_repo_change_intent_and_reminds(self) -> None:
         result = self._run_prompt_hook({"prompt": "Please update the workflow harness tests."})
 
@@ -217,6 +297,7 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
         shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
         shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
         shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+        shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
         shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
         shutil.copytree(TOOLS_LIB_SOURCE, target_root / "tools" / "lib")
         self._patch_sibling_root(
@@ -331,6 +412,18 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
             + "\n",
             encoding="utf-8",
         )
+
+    def _write_sdd_artifacts(self, *, include_evidence: bool = True, final_head: str | None = None) -> None:
+        specs = self.root / "specs" / self.implementation
+        specs.mkdir(parents=True, exist_ok=True)
+        (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (specs / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        (specs / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+        if include_evidence:
+            lines = ["# Evidence"]
+            if final_head is not None:
+                lines.append(f"- Final HEAD: {final_head}")
+            (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     def _run_hook(
         self,

--- a/tools/codex-harness/tests/test_validate_sdd_context.py
+++ b/tools/codex-harness/tests/test_validate_sdd_context.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HARNESS_ROOT = REPO_ROOT / "tools" / "codex-harness"
+if str(HARNESS_ROOT) not in sys.path:
+    sys.path.insert(0, str(HARNESS_ROOT))
+
+import validate_active_implementation
+from validate_active_implementation import parse_marker
+from validate_sdd_context import validate_sdd_context
+
+
+class ValidateSddContextTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_parent = tempfile.TemporaryDirectory(prefix="sdd-root-")
+        self.sibling_root = Path(self.temp_parent.name) / "homelab-ideas"
+        self.sibling_root.mkdir()
+        self.root = self.sibling_root / "sdd-context-test"
+        self.root.mkdir()
+        self.implementation = "sdd-context-test"
+        self.branch = f"codex/{self.implementation}"
+        self.original_sibling_root = validate_active_implementation.SIBLING_CLONE_ROOT
+        validate_active_implementation.SIBLING_CLONE_ROOT = self.sibling_root
+        self._write_marker()
+
+    def tearDown(self) -> None:
+        validate_active_implementation.SIBLING_CLONE_ROOT = self.original_sibling_root
+        self.temp_parent.cleanup()
+
+    def test_allows_valid_plan_artifacts_and_evidence(self) -> None:
+        self._write_sdd_artifacts(final_head="1" * 40)
+
+        result = self._validate(require_evidence=True, current_head="1" * 40)
+
+        self.assertTrue(result.ok, result.errors)
+
+    def test_blocks_missing_plan_artifact(self) -> None:
+        self._write_sdd_artifacts()
+        (self.root / "specs" / self.implementation / "tasks.md").unlink()
+
+        result = self._validate()
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("Missing required SDD artifact" in error for error in result.errors))
+
+    def test_blocks_empty_plan_artifact(self) -> None:
+        self._write_sdd_artifacts()
+        (self.root / "specs" / self.implementation / "plan.md").write_text("", encoding="utf-8")
+
+        result = self._validate()
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("must not be empty" in error for error in result.errors))
+
+    def test_blocks_missing_evidence_when_required(self) -> None:
+        self._write_sdd_artifacts(include_evidence=False)
+
+        result = self._validate(require_evidence=True)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("evidence.md" in error for error in result.errors))
+
+    def test_blocks_stale_evidence_head(self) -> None:
+        self._write_sdd_artifacts(final_head="0" * 40)
+
+        result = self._validate(require_evidence=True, current_head="1" * 40)
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("records HEAD" in error for error in result.errors))
+
+    def _write_marker(self) -> None:
+        tmp = self.root / ".codex" / "tmp"
+        tmp.mkdir(parents=True, exist_ok=True)
+        (tmp / "active-implementation").write_text(
+            "\n".join(
+                [
+                    f"implementation={self.implementation}",
+                    f"branch={self.branch}",
+                    "base=origin/main",
+                    "role=implementation",
+                    f"clone_path={self.root}",
+                    "owner_role=implementation-agent",
+                    "owner_agent=implementation-agent-sdd-context-test",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def _write_sdd_artifacts(self, *, include_evidence: bool = True, final_head: str | None = None) -> None:
+        specs = self.root / "specs" / self.implementation
+        specs.mkdir(parents=True, exist_ok=True)
+        (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
+        (specs / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        (specs / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+        if include_evidence:
+            lines = ["# Evidence"]
+            if final_head is not None:
+                lines.append(f"- Final HEAD: {final_head}")
+            (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _validate(self, *, require_evidence: bool = False, current_head: str | None = None):
+        marker = parse_marker(self.root / ".codex" / "tmp" / "active-implementation")
+        return validate_sdd_context(
+            root=self.root,
+            marker=marker,
+            current_branch=self.branch,
+            require_evidence=require_evidence,
+            current_head=current_head,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/codex-harness/tests/test_verifier_push_guard.py
+++ b/tools/codex-harness/tests/test_verifier_push_guard.py
@@ -12,6 +12,7 @@ HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "verifier_push_guard.sh"
 ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
 PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
 ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
+SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
 VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
@@ -29,8 +30,10 @@ class VerifierPushGuardTest(unittest.TestCase):
         _install_harness_files(self.root, self.sibling_root)
         subprocess.run(["git", "switch", "-c", self.branch], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
         _write_marker(self.root, self.implementation)
+        _write_plan(self.root, self.implementation)
         _write_owner_attestation(self.root, self.implementation)
         self.head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.root, text=True).strip()
+        _write_sdd_artifacts(self.root, self.implementation)
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()
@@ -52,6 +55,34 @@ class VerifierPushGuardTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_allows_smoke_push_to_active_implementation_branch_without_verifier_approval(self) -> None:
+        result = _run_hook(
+            self.root,
+            stdin=f"HEAD {self.head} refs/heads/{self.branch} {'0' * 40}\n",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_blocks_smoke_push_to_non_active_branch_without_verifier_approval(self) -> None:
+        result = _run_hook(
+            self.root,
+            stdin=f"HEAD {self.head} refs/heads/codex/other-implementation {'0' * 40}\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing to push to origin", result.stderr)
+
+    def test_blocks_smoke_push_without_sdd_context(self) -> None:
+        (self.root / "specs" / self.implementation / "tasks.md").unlink()
+
+        result = _run_hook(
+            self.root,
+            stdin=f"HEAD {self.head} refs/heads/{self.branch} {'0' * 40}\n",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing to push to origin", result.stderr)
+
 
 def _init_repo(root: Path) -> None:
     subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, stdout=subprocess.DEVNULL)
@@ -72,6 +103,7 @@ def _install_harness_files(root: Path, sibling_root: Path) -> None:
     shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
     shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
     shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
+    shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
     shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
     _patch_sibling_root(
@@ -142,6 +174,47 @@ def _write_owner_attestation(root: Path, implementation: str) -> None:
     )
 
 
+def _write_plan(root: Path, implementation: str) -> None:
+    tmp = root / ".codex" / "tmp"
+    tmp.mkdir(parents=True, exist_ok=True)
+    (tmp / "implementation-plan.yaml").write_text(
+        "\n".join(
+            [
+                f"implementation: {implementation}",
+                f"branch: codex/{implementation}",
+                "base: origin/main",
+                f"clone_path: {root}",
+                "owner_agent: implementation-agent-deterministic-role-enforcement",
+                "summary: Harden implementation workflow enforcement.",
+                "scope:",
+                "  - Add plan validation.",
+                "out_of_scope:",
+                "  - Live cluster changes.",
+                "planned_changes:",
+                "  - Add validator and hook checks.",
+                "docs_impact: Update workflow runbooks.",
+                "tests:",
+                "  - python3 -m unittest discover -s tools/codex-harness/tests",
+                "verification:",
+                "  - Harness tests pass.",
+                "risks:",
+                "  - Conservative guard behavior.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_sdd_artifacts(root: Path, implementation: str) -> None:
+    specs = root / "specs" / implementation
+    specs.mkdir(parents=True, exist_ok=True)
+    (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
+    (specs / "plan.md").write_text("# Plan\n", encoding="utf-8")
+    (specs / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
+    (specs / "evidence.md").write_text("# Evidence\n", encoding="utf-8")
+
+
 def _write_verifier_approval(root: Path, head: str) -> None:
     tmp = root / ".codex" / "tmp"
     tmp.mkdir(parents=True, exist_ok=True)
@@ -203,10 +276,11 @@ def _write_delegation_token(
     )
 
 
-def _run_hook(root: Path) -> subprocess.CompletedProcess[str]:
+def _run_hook(root: Path, *, stdin: str = "") -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", ".codex/hooks/verifier_push_guard.sh", "origin", "https://github.com/petebeegle/homelab.git"],
         cwd=root,
+        input=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/tools/codex-harness/validate_sdd_context.py
+++ b/tools/codex-harness/validate_sdd_context.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate durable Spec Kit context for an active implementation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+TOOLS_LIB = Path(__file__).resolve().parents[2] / "tools" / "lib"
+if str(TOOLS_LIB) not in sys.path:
+    sys.path.insert(0, str(TOOLS_LIB))
+
+from homelab_tools.git import discover_git_branch, discover_git_head, discover_git_root
+from validation_common import ValidationResult, path_from_cwd
+from validate_active_implementation import parse_marker, validate_marker
+
+
+REQUIRED_PLAN_ARTIFACTS = ("spec.md", "plan.md", "tasks.md")
+EVIDENCE_ARTIFACT = "evidence.md"
+EXPLICIT_HEAD_RE = re.compile(
+    r"^\s*(?:[-*]\s*)?(?:\*\*)?"
+    r"(?:(?:final|verified|approved|branch|current)\s+)?head"
+    r"(?:\*\*)?\s*:\s*`?([0-9a-f]{40})`?\b",
+    re.IGNORECASE,
+)
+
+
+SddContextValidationResult = ValidationResult
+
+
+def validate_sdd_context(
+    *,
+    root: Path | str,
+    marker: Mapping[str, str],
+    current_branch: str | None = None,
+    require_plan_artifacts: bool = True,
+    require_evidence: bool = False,
+    current_head: str | None = None,
+) -> SddContextValidationResult:
+    errors: list[str] = []
+    root_path = Path(root)
+
+    marker_result = validate_marker(marker, current_root=root_path, current_branch=current_branch)
+    errors.extend(f"Active implementation marker: {error}" for error in marker_result.errors)
+
+    implementation = marker.get("implementation", "")
+    specs_dir = root_path / "specs" / implementation if implementation else root_path / "specs" / "<implementation>"
+
+    if require_plan_artifacts:
+        for name in REQUIRED_PLAN_ARTIFACTS:
+            _require_non_empty(specs_dir / name, errors)
+
+    evidence_path = specs_dir / EVIDENCE_ARTIFACT
+    if require_evidence:
+        _require_non_empty(evidence_path, errors)
+
+    if current_head and evidence_path.is_file():
+        stale_heads = _stale_recorded_heads(evidence_path, current_head=current_head)
+        for recorded_head in stale_heads:
+            errors.append(
+                f"{_display_path(root_path, evidence_path)} records HEAD {recorded_head}, "
+                f"but current HEAD is {current_head}."
+            )
+
+    return SddContextValidationResult({"implementation": implementation}, tuple(errors))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate specs/<implementation>/ durable SDD context.")
+    parser.add_argument("--marker", default=".codex/tmp/active-implementation")
+    parser.add_argument("--root", help="Current repository root. Defaults to git rev-parse --show-toplevel.")
+    parser.add_argument("--branch", help="Current branch. Defaults to git branch --show-current.")
+    parser.add_argument(
+        "--require-plan-artifacts",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Require non-empty spec.md, plan.md, and tasks.md.",
+    )
+    parser.add_argument("--require-evidence", action="store_true", help="Require non-empty evidence.md.")
+    parser.add_argument(
+        "--head",
+        help="Current HEAD SHA. When provided, explicit HEAD records in evidence.md must match.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    root = Path(args.root) if args.root is not None else discover_git_root(Path.cwd())
+    branch = args.branch if args.branch is not None else discover_git_branch(Path.cwd())
+    head = args.head if args.head is not None else discover_git_head(Path.cwd())
+    marker_path = path_from_cwd(args.marker)
+
+    if not marker_path.is_file():
+        print(f"Active implementation marker not found: {marker_path}", file=sys.stderr)
+        return 1
+
+    try:
+        marker = parse_marker(marker_path)
+    except (OSError, ValueError) as exc:
+        print(f"Active implementation marker is invalid: {exc}", file=sys.stderr)
+        return 1
+
+    result = validate_sdd_context(
+        root=root,
+        marker=marker,
+        current_branch=branch,
+        require_plan_artifacts=args.require_plan_artifacts,
+        require_evidence=args.require_evidence,
+        current_head=head,
+    )
+    if result.ok:
+        return 0
+
+    print("SDD context is invalid:", file=sys.stderr)
+    for error in result.errors:
+        print(f"  - {error}", file=sys.stderr)
+    print(
+        "\nExpected durable SDD files under specs/<implementation>/: "
+        "spec.md, plan.md, tasks.md"
+        + (", evidence.md." if args.require_evidence else "."),
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _require_non_empty(path: Path, errors: list[str]) -> None:
+    if not path.is_file():
+        errors.append(f"Missing required SDD artifact: {path}.")
+        return
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"Unable to read required SDD artifact {path}: {exc}.")
+        return
+    if not content.strip():
+        errors.append(f"Required SDD artifact must not be empty: {path}.")
+
+
+def _stale_recorded_heads(evidence_path: Path, *, current_head: str) -> tuple[str, ...]:
+    stale: list[str] = []
+    try:
+        lines = evidence_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ()
+
+    for line in lines:
+        match = EXPLICIT_HEAD_RE.match(line)
+        if not match:
+            continue
+        recorded_head = match.group(1)
+        if recorded_head != current_head:
+            stale.append(recorded_head)
+    return tuple(stale)
+
+
+def _display_path(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements `sdd-workflow-guards`, the second SDD migration PR, on
`codex/sdd-workflow-guards`.

Summary:
- Adds `tools/codex-harness/validate_sdd_context.py` for durable
  `specs/<implementation>/` checks.
- Requires non-empty `spec.md`, `plan.md`, and `tasks.md` for non-bootstrap
  tracked edits while preserving initial SDD artifact bootstrap.
- Requires `evidence.md` for verifier approval preflight and automatic PR
  creation, with stale explicit HEAD detection.
- Makes `.codex/scripts/create_implementation_pr.sh --auto` fail closed on
  implementation branches unless exact-HEAD verifier approval, verifier
  attestation, owner workflow context, and SDD evidence are valid.
- Adds the narrow development smoke push exception for
  `origin HEAD:refs/heads/codex/<implementation>` from valid active
  implementation/spec context only; other origin pushes still require
  exact-HEAD verifier approval.

Documentation impact:
- Updated `docs/runbooks/implementation-workflow.md`.
- Updated `docs/runbooks/spec-driven-development.md`.
- `python3 tools/architecture/render.py --check` passed; no generated
  architecture update required.

Validation:
- PASS: `python3 -m unittest discover -s tools/codex-harness/tests`
  (75 tests).
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `python3 -m unittest discover -s tools/development/tests` (28 tests).
- PASS: `python3 -m unittest discover -s tools/context-pack/tests` (2 tests).
- FAIL: `uv run --project tools/agent-memory pytest tools/agent-memory/tests`
  could not start because `uv` could not find Python 3.14.6.
- PASS: `pre-commit run --all-files`.
- PASS with warnings: `npx -y agnix@0.25.0 .` reported 0 errors, 14 warnings,
  and 1 info.
- FAIL then PASS: initial `npm test` in `tests/smoke` failed because
  Playwright was not installed; `npm ci && npm test` then passed 6 tests.

Development validation:
- Not run. This is a local-only harness, hook, script, and documentation change
  with no Kubernetes, Terraform, Flux, Gateway, storage, secret reference, or
  app behavior changes.

Final branch:
- `codex/sdd-workflow-guards`

Final HEAD:
- `bdb77965ecfb1b38e72fbdf55d3150e4e38558a8`

Verifier approval:
- Not created by implementation owner.


## Changes
- .codex/hooks/implementation_workflow_guard.sh
- .codex/hooks/verifier_push_guard.sh
- .codex/scripts/create_implementation_pr.sh
- docs/runbooks/implementation-workflow.md
- docs/runbooks/spec-driven-development.md
- specs/sdd-workflow-guards/evidence.md
- specs/sdd-workflow-guards/plan.md
- specs/sdd-workflow-guards/spec.md
- specs/sdd-workflow-guards/tasks.md
- tools/codex-harness/tests/test_create_implementation_pr.py
- tools/codex-harness/tests/test_implementation_workflow_guard.py
- tools/codex-harness/tests/test_validate_sdd_context.py
- tools/codex-harness/tests/test_verifier_push_guard.py
- tools/codex-harness/validate_sdd_context.py

## Commits
- bdb7796 feat(codex): enforce sdd workflow guards

## Verification
- Verified HEAD: `bdb77965ecfb1b38e72fbdf55d3150e4e38558a8`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
