### PR TITLE
Implementation: sdd-dev-smoke-matrix

### DIFF
--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -128,9 +128,9 @@ Branch environments are for app-scoped validation on the development cluster. Us
 <app>-${branch_slug}.dev.lab.petebeegle.com
 ```
 
-Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. The tool loads JSON smoke profiles from `tools/development/smoke-profiles/`, renders the matching activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, runs profile resource checks, and then removes the temporary branch Flux resources unless `--keep` is set. Automated profiles currently cover `whoami` and `jellyfin`.
+Use `tools/development/verify_branch_deploy.py` as the canonical path for future branch validation. The tool loads JSON smoke profiles from `tools/development/smoke-profiles/`, renders the matching activation template, applies it directly to the development cluster, forces Flux reconciliation, checks the branch namespace and active pods, runs profile resource checks, and then removes the temporary branch Flux resources unless `--keep` is set. Automated profiles currently cover `whoami`, `jellyfin`, and `home-assistant`.
 
-The `whoami` profile checks the branch namespace, active pods, Service, and HTTPRoute. The `jellyfin` profile checks the branch namespace, branch Flux Kustomization readiness, HelmRelease readiness, active pods, config PVC binding on `nfs-csi-storage`, Service, HTTPRoute, and an in-cluster HTTP probe for the Jellyfin web shell.
+The `whoami` profile checks the branch namespace, branch Flux Kustomization readiness, active pods, Service, and HTTPRoute. The `jellyfin` profile checks the branch namespace, branch Flux Kustomization readiness, HelmRelease readiness, active pods, config PVC binding on `nfs-csi-storage`, Service, HTTPRoute, and an in-cluster HTTP probe for the Jellyfin web shell. The `home-assistant` profile checks the branch namespace, branch Flux Kustomization readiness, active pods, config PVC binding on `nfs-csi-storage`, Service, HTTPRoute, and an in-cluster HTTP probe for the Home Assistant web shell.
 
 Activation templates are in `kubernetes/clusters/development/branches/`, and branch-aware app payload overlays live under paths such as `kubernetes/apps/whoami/branch/` and `kubernetes/apps/jellyfin/branch/`. The cluster-layer template creates the Flux `GitRepository` and `Kustomization` that point at a branch; the app overlay is the rendered workload payload that Flux applies after substituting `${branch_slug}`. The templates are not referenced from the live development entrypoint and are suspended by default. The verification tool fills `branch_name` and `branch_slug`, sets both Flux objects to `suspend: false`, and applies the rendered activation temporarily.
 
@@ -162,6 +162,12 @@ Normal live verification for Jellyfin:
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-change --slug jellyfin-change --push
+```
+
+Normal live verification for Home Assistant:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-change --slug home-assistant-change --push
 ```
 
 Run Terraform apply first when the development cluster base may need to be created or repaired:
@@ -198,7 +204,7 @@ kubectl --kubeconfig ~/.kube/homelab-development.config wait namespace/whoami-ex
 kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system delete gitrepository.source.toolkit.fluxcd.io/branch-example-change
 ```
 
-This proves that the pushed branch can be fetched by Flux, the selected app branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, and the selected profile checks pass. For `whoami`, that includes Service existence and an HTTPRoute with `Accepted` and `ResolvedRefs`. For `jellyfin`, that also includes HelmRelease readiness, config PVC binding, and an in-cluster Jellyfin web-shell probe. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps without a selected smoke profile.
+This proves that the pushed branch can be fetched by Flux, the selected app branch overlay can reconcile on the development cluster, the branch namespace exists, at least one branch app pod is active, active branch app pods report Ready, and the selected profile checks pass. For `whoami`, that includes Service existence and an HTTPRoute with `Accepted` and `ResolvedRefs`. For `jellyfin`, that also includes HelmRelease readiness, config PVC binding, and an in-cluster Jellyfin web-shell probe. For `home-assistant`, that includes config PVC binding and an in-cluster Home Assistant web-shell probe. Without `--include-cluster-base`, it does not prove production readiness, cross-app behavior, cluster-scoped changes, public Cloudflare routing, or apps without a selected smoke profile.
 
 ### Touched-App Smoke Matrix
 
@@ -215,7 +221,45 @@ For each implementation that changes app behavior, manifests, Gateway routing, s
 
 ### Smoke Profiles
 
-Smoke profiles are JSON files under `tools/development/smoke-profiles/`. A profile names the app, branch GitRepository, activation template, expected namespace, Services, routes, PVCs, HelmReleases, app-specific probes, and any other checks the verifier can run consistently for that app.
+Smoke profiles are JSON files under `tools/development/smoke-profiles/`. A profile names the app, branch GitRepository, activation template, expected namespace, route URLs for browser handoff, Services, routes, PVCs, HelmReleases, app-specific probes, and any other checks the verifier can run consistently for that app.
+
+Supported profile fields:
+
+| Field | Meaning |
+| --- | --- |
+| `routeUrls` | External branch URLs, usually under `dev.lab.petebeegle.com`, that can be printed for browser or Playwright smoke handoff. |
+| `checks.kustomizations` | Flux `Kustomization` names in `flux-system` that must reach Ready. |
+| `checks.helmReleases` | HelmRelease names in the profile namespace that must reach Ready. |
+| `checks.services` | Service names in the profile namespace that must exist. |
+| `checks.httpRoutes` | HTTPRoute names in the profile namespace that must have one parent with `Accepted=True` and `ResolvedRefs=True`. |
+| `checks.tlsRoutes` | TLSRoute names in the profile namespace that must have one parent with `Accepted=True` and `ResolvedRefs=True`. |
+| `checks.secretRefs` | Kubernetes Secret names in the profile namespace that must exist; the verifier does not request or print Secret data. |
+| `checks.pvcs` | PVC names and optional `storageClass` expectations. |
+| `checks.httpProbes` | In-cluster HTTP probes against profile Services. |
+
+Print the rendered route URLs without applying anything to the cluster:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --print-route-urls
+```
+
+When a profile exposes `routeUrls`, browser smoke can use those rendered URLs as the Playwright target under `dev.lab.petebeegle.com`. The repository does not yet run a generic profile-driven Playwright command for branch URLs; record screenshots and traces only for failed browser smoke attempts and attach the failure artifact path in implementation evidence.
+
+### Current Profile Coverage And Gaps
+
+| App or stack | Development profile status | Notes |
+| --- | --- | --- |
+| `whoami` | Automated | Branch overlay is isolated by `${branch_slug}` and verifies Flux Kustomization, namespace, pods, Service, and HTTPRoute. |
+| `jellyfin` | Automated | Branch overlay is isolated by `${branch_slug}` and verifies Flux Kustomization, HelmRelease, PVC, Service, HTTPRoute, and web-shell probe. |
+| `home-assistant` | Automated | Branch overlay is isolated by `${branch_slug}` and verifies Flux Kustomization, PVC, Service, HTTPRoute, and web-shell probe. |
+| `pihole` | Gap | Production app uses a SOPS-managed admin password Secret and a DNS LoadBalancer address. Add a branch overlay only with staged development secret evidence and a development-safe DNS Service shape. |
+| `foundryvtt` | Gap | Production app requires the SOPS-managed Foundry credential/license Secret and persistent data PVC. Use the existing foundry blue/green fixture for deployment mechanics; add a real branch smoke only with safe development secrets and storage expectations. |
+| `authentik` | Gap | Lives under `kubernetes/infra/authentik`, depends on encrypted secrets and infra-level dependencies, and is not part of the current development app branch overlay model. |
+| `monitoring`/Grafana | Gap | Lives under `kubernetes/infra/monitoring`, spans multiple namespaces and Grafana operator resources, and requires encrypted Grafana credentials/env secrets. Use monitoring-specific validation until a dedicated development infra profile exists. |
+
+### Synthetic Smoke Source Audit
+
+There are two Playwright smoke source trees: `tests/smoke` for local/manual smoke and `kubernetes/apps/synthetics/smoke` for the in-cluster synthetics workload. They are not currently exact mirrors. The in-cluster tree includes `run-smoke.sh`, summary reporter code, unit tests, and a Home Assistant route case that the local tree does not contain. Until a generation or mirror check exists, update both trees intentionally or record why only one tree changed.
 
 Document one of:
 

--- a/specs/sdd-dev-smoke-matrix/checklists/smoke-readiness.md
+++ b/specs/sdd-dev-smoke-matrix/checklists/smoke-readiness.md
@@ -1,0 +1,18 @@
+# Smoke Readiness Checklist
+
+- [x] Owner workflow marker, plan, attestation, and delegation token exist.
+- [x] Owner workflow validators passed before tracked edits.
+- [x] SDD spec, plan, tasks, and evidence files exist.
+- [x] Existing `whoami`, `jellyfin`, and `home-assistant` behavior remains
+      covered by tests or profile parsing.
+- [x] Flux Kustomization readiness is profile-driven.
+- [x] TLSRoute readiness is profile-driven.
+- [x] Secret reference checks are name-only and do not inspect secret contents.
+- [x] Route URL or Playwright handoff is documented.
+- [x] `pihole` and `foundryvtt` coverage is added or explicitly deferred with
+      reasons.
+- [x] `authentik` and `monitoring` gaps are documented.
+- [x] Synthetic smoke mirroring is enforced or explicitly deferred with a
+      follow-up.
+- [x] Required local checks and development validation exception/evidence are
+      recorded.

--- a/specs/sdd-dev-smoke-matrix/evidence.md
+++ b/specs/sdd-dev-smoke-matrix/evidence.md
@@ -1,0 +1,85 @@
+# Evidence: sdd-dev-smoke-matrix
+
+**Branch**: `codex/sdd-dev-smoke-matrix`
+**Risk Tier**: medium
+**Started**: 2026-07-03
+**Owner**: implementation-agent-sdd-dev-smoke-matrix
+
+## Spec Kit Initialization
+
+- Command: Not rerun; repository Spec Kit scaffolding already present on
+  `origin/main`.
+- Outcome: Used existing `.specify/` templates and constitution.
+- Spec Kit version: Not changed by this implementation.
+- Integration: Existing repository integration.
+- Fallback: None.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest discover -s tools/development/tests` | FAIL then PASS | Red phase failed with missing `SmokeProfile.kustomizations`, missing `assert_tlsroute_ready`, and missing profile-driven Kustomization wait. Final run: 31 tests passed. |
+| `python3 -m unittest discover -s tools/codex-harness/tests` | PASS | 75 tests passed. |
+| `python3 -m unittest discover -s tools/context-pack/tests` | PASS | 2 tests passed. |
+| `pre-commit run --all-files` | PASS | All hooks passed, including generated architecture check. |
+| `python3 tools/architecture/render.py --check` | PASS | No generated architecture changes required. |
+| `npx -y agnix@0.25.0 .` | PASS with warnings | Initial parallel run saw `tests/smoke/node_modules`; removed generated dependency directory and reran with 0 errors, 14 existing warnings, 1 info. |
+| `npm ci && npm test` in `tests/smoke` | PASS | 6 Playwright smoke tests passed against default production smoke domain; generated `node_modules` and `test-results` were removed. |
+| `uv run --project tools/agent-memory pytest tools/agent-memory/tests` | SKIP | Environment limitation: uv could not find required Python 3.14.6. |
+| `python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/sdd-dev-smoke-matrix --slug sdd-dev-smoke-matrix --print-route-urls` | PASS | Rendered `https://whoami-sdd-dev-smoke-matrix.dev.lab.petebeegle.com` without cluster access. |
+| `kubectl --kubeconfig ~/.kube/homelab-development.config get namespace flux-system --request-timeout=10s` | PASS | Read-only credential check succeeded; live smoke attempt is deferred until after the branch has a committed HEAD to push. |
+
+## Development Validation
+
+- Profile: `whoami`
+- Branch slug: `sdd-dev-smoke-matrix`
+- HEAD: Final committed branch HEAD is reported in handoff; live `--push` smoke must run against committed content.
+- Report path: None yet.
+- Cleanup: None yet.
+- Result or exception: Development kubeconfig exists and read-only access works. The mutating `--push` smoke command is intentionally attempted after the conventional commit so Flux fetches a real implementation branch HEAD instead of the pre-commit base.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/development-cluster.md` and
+  `tools/development/README.md`.
+- Generated docs: `docs/architecture.md` unchanged; `render.py --check` passed.
+- No-docs rationale: N/A.
+
+## App Coverage And Gaps
+
+- Preserved coverage: `whoami`, `jellyfin`, and `home-assistant` profiles still load and now include branch Flux Kustomization checks plus route URL handoff.
+- New coverage: No new app branch overlays were added. `pihole` and
+  `foundryvtt` were investigated and documented as gaps because current
+  production manifests rely on encrypted secrets and app-specific live
+  dependencies that are unsafe to synthesize in this slice.
+- Gaps: `authentik` and `monitoring` are infra stacks, not current app branch
+  overlays, and require encrypted secrets/cross-stack dependencies. Generic
+  branch Playwright execution is documented as a handoff path through
+  `routeUrls` and `--print-route-urls`; failure screenshots/traces are not yet
+  automated by the dev verifier.
+- Synthetic smoke audit: `tests/smoke` and `kubernetes/apps/synthetics/smoke`
+  are not exact mirrors. The cluster copy includes runner/reporter files and a
+  Home Assistant route case that the local copy lacks; this slice documents the
+  gap instead of enforcing generation.
+
+## Exceptions And Follow-Ups
+
+- `uv run --project tools/agent-memory pytest tools/agent-memory/tests` could
+  not run because Python 3.14.6 is unavailable in this environment.
+- Exact live branch smoke evidence is attempted after commit because
+  `verify_branch_deploy.py --push` pushes `HEAD` to origin for Flux to fetch.
+
+## Final State
+
+- Final branch: `codex/sdd-dev-smoke-matrix`
+- Final commit SHA: reported in final handoff after commit.
+- Commit: Conventional commit pending at evidence write time.
+- Verifier approval: not created by implementation owner

--- a/specs/sdd-dev-smoke-matrix/evidence.md
+++ b/specs/sdd-dev-smoke-matrix/evidence.md
@@ -35,16 +35,28 @@
 | `npm ci && npm test` in `tests/smoke` | PASS | 6 Playwright smoke tests passed against default production smoke domain; generated `node_modules` and `test-results` were removed. |
 | `uv run --project tools/agent-memory pytest tools/agent-memory/tests` | SKIP | Environment limitation: uv could not find required Python 3.14.6. |
 | `python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/sdd-dev-smoke-matrix --slug sdd-dev-smoke-matrix --print-route-urls` | PASS | Rendered `https://whoami-sdd-dev-smoke-matrix.dev.lab.petebeegle.com` without cluster access. |
-| `kubectl --kubeconfig ~/.kube/homelab-development.config get namespace flux-system --request-timeout=10s` | PASS | Read-only credential check succeeded; live smoke attempt is deferred until after the branch has a committed HEAD to push. |
+| `kubectl --kubeconfig ~/.kube/homelab-development.config get namespace flux-system --request-timeout=10s` | PASS | Read-only credential check succeeded before the live smoke attempt. |
+| `python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/sdd-dev-smoke-matrix --slug sdd-dev-smoke-matrix --push` | FAIL/BLOCKED | Attempted after commit `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f` was pushed to `origin/codex/sdd-dev-smoke-matrix`; blocked during Terraform plan preflight before Flux activation because development Terraform inputs were not staged in this clone. |
+| `kubectl --kubeconfig ~/.kube/homelab-development.config -n flux-system get kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-sdd-dev-smoke-matrix gitrepository.source.toolkit.fluxcd.io/branch-sdd-dev-smoke-matrix --ignore-not-found` | PASS | Returned no resources; branch Flux activation was not created. |
+| `kubectl --kubeconfig ~/.kube/homelab-development.config get namespace whoami-sdd-dev-smoke-matrix --ignore-not-found` | PASS | Returned no namespace; no branch namespace cleanup was required. |
 
 ## Development Validation
 
 - Profile: `whoami`
 - Branch slug: `sdd-dev-smoke-matrix`
-- HEAD: Final committed branch HEAD is reported in handoff; live `--push` smoke must run against committed content.
-- Report path: None yet.
-- Cleanup: None yet.
-- Result or exception: Development kubeconfig exists and read-only access works. The mutating `--push` smoke command is intentionally attempted after the conventional commit so Flux fetches a real implementation branch HEAD instead of the pre-commit base.
+- Tested commit SHA: `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f`
+- Report path: None; the verifier stopped before Flux activation and did not produce an app smoke report.
+- Cleanup: Confirmed absent after the failed preflight: no
+  `branch-whoami-sdd-dev-smoke-matrix` Flux Kustomization, no
+  `branch-sdd-dev-smoke-matrix` GitRepository, and no
+  `whoami-sdd-dev-smoke-matrix` namespace.
+- Result or exception: Development kubeconfig exists and read-only access works.
+  The live command pushed commit
+  `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f`, then failed during
+  `terraform -chdir=terraform/development plan -detailed-exitcode -input=false -no-color`
+  before Flux activation. Missing local inputs, without secret values, were
+  `pm_api_url`, Proxmox token fields, GitHub and Docker variables, and
+  `talos_version`.
 
 ## Documentation Impact
 
@@ -74,12 +86,17 @@
 
 - `uv run --project tools/agent-memory pytest tools/agent-memory/tests` could
   not run because Python 3.14.6 is unavailable in this environment.
-- Exact live branch smoke evidence is attempted after commit because
-  `verify_branch_deploy.py --push` pushes `HEAD` to origin for Flux to fetch.
+- Live `whoami` smoke is blocked until development Terraform variables/secrets
+  are staged in the implementation clone. The failure occurred before branch
+  Flux activation, and absence checks confirmed no branch Flux resources or
+  namespace remained.
 
 ## Final State
 
 - Final branch: `codex/sdd-dev-smoke-matrix`
-- Final commit SHA: reported in final handoff after commit.
-- Commit: Conventional commit pending at evidence write time.
+- Pushed/tested commit SHA: `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f`
+- Evidence refresh commit SHA: reported in final implementation-owner handoff
+  after this evidence update is committed.
+- Commit: `feat(dev-smoke): expand development smoke profile checks`, followed
+  by a conventional evidence refresh commit.
 - Verifier approval: not created by implementation owner

--- a/specs/sdd-dev-smoke-matrix/plan.md
+++ b/specs/sdd-dev-smoke-matrix/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: sdd-dev-smoke-matrix
+
+**Branch**: `codex/sdd-dev-smoke-matrix` | **Date**: 2026-07-03 | **Spec**:
+`specs/sdd-dev-smoke-matrix/spec.md`
+
+**Input**: Feature specification from
+`specs/sdd-dev-smoke-matrix/spec.md`
+
+## Summary
+
+Extend the existing config-driven development smoke verifier rather than adding
+production synthetic smoke as the first proof. The slice will add generic profile
+fields and checker steps, preserve current app behavior, add safe app coverage
+where manifests can be isolated by branch slug, and document coverage gaps for
+apps that require secrets, shared dependencies, or larger refactors.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Python smoke tooling, Kubernetes branch overlays, Gateway API
+routes, secret references, docs, SDD evidence
+**Dependencies**: Python unittest, kubectl command wrappers, Flux CRDs, Gateway
+API CRDs, pre-commit, agnix, npm smoke tests when applicable
+**Storage**: Branch PVC checks must preserve `nfs-csi-storage` expectations
+**Ingress**: Gateway API `HTTPRoute` and `TLSRoute`; no Kubernetes `Ingress`
+**Secrets**: Check only Secret object existence by referenced names; do not
+inspect, decrypt, or log Secret data
+**Development Validation**: Attempt `whoami` profile against
+`codex/sdd-dev-smoke-matrix` with slug `sdd-dev-smoke-matrix` only if
+development cluster credentials are available and safe; otherwise record an
+unavailable-infrastructure exception
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Sibling clone ownership files validated before tracked edits.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] Separate verifier approval required before PR creation.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/sdd-dev-smoke-matrix/
+├── checklists/
+│   └── smoke-readiness.md
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+tools/development/devverify/config.py
+tools/development/devverify/profiles.py
+tools/development/devverify/checks.py
+tools/development/devverify/cleanup.py
+tools/development/devverify/flux.py
+tools/development/devverify/workflow.py
+tools/development/devverify/cli.py
+tools/development/tests/test_verify_branch_deploy.py
+tools/development/smoke-profiles/*.json
+kubernetes/clusters/development/branches/*
+kubernetes/apps/pihole/branch/*
+kubernetes/apps/foundryvtt/branch/*
+docs/runbooks/development-cluster.md
+tools/development/README.md
+tests/smoke
+kubernetes/apps/synthetics/smoke
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add or update focused unit tests for schema parsing,
+checker execution, cleanup behavior, and command sequencing before or alongside
+implementation. Record any red-test command that cannot be isolated.
+
+**Local checks**:
+
+- `python3 -m unittest discover -s tools/development/tests`
+- `python3 -m unittest discover -s tools/codex-harness/tests`
+- `python3 -m unittest discover -s tools/context-pack/tests`
+- `pre-commit run --all-files`
+- `python3 tools/architecture/render.py --check`
+- `npx -y agnix@0.25.0 .`
+- `npm ci && npm test` in `tests/smoke` if touched or quick
+- `uv run --project tools/agent-memory pytest tools/agent-memory/tests`
+
+**Development smoke**: Attempt
+`python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/sdd-dev-smoke-matrix --slug sdd-dev-smoke-matrix --push`
+only if development kubeconfig and credentials are available and safe. Use
+`--include-cluster-base` only if shared base resources change.
+
+**Evidence destination**: `specs/sdd-dev-smoke-matrix/evidence.md` and
+`.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+- Update `docs/runbooks/development-cluster.md` with profile coverage, route URL
+  and Playwright handoff, app gaps, and live validation exception guidance.
+- Update `tools/development/README.md` with new schema fields and profile
+  examples.
+- Update `docs/architecture.md` only if Kubernetes/Terraform source changes
+  affect generated architecture output.
+
+## Implementation Steps
+
+1. Inspect existing devverify code, tests, profiles, app manifests, branch
+   overlays, synthetic smoke sources, and development docs.
+2. Add focused tests for the new schema/checks and command sequencing.
+3. Implement profile parsing and checker support for Kustomizations, TLSRoutes,
+   Secret references, and route URLs while preserving existing behavior.
+4. Add safe smoke profiles and branch overlays for `pihole` and/or
+   `foundryvtt`; document gaps for `authentik` and `monitoring`.
+5. Audit synthetic smoke duplication and implement a mirror check only if small
+   and safe; otherwise document the follow-up.
+6. Run required validation, update evidence, commit, and stop before PR creation.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Secret checks accidentally reveal data | Only call metadata/existence checks by Secret name and avoid printing payloads |
+| App overlays collide with production | Require branch slug in names, hostnames, and generated resources |
+| Complex apps exceed slice size | Document exact gap and leave follow-up instead of broad refactors |
+| Development credentials unavailable | Record exception and run unit/static/render checks |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/sdd-dev-smoke-matrix/spec.md
+++ b/specs/sdd-dev-smoke-matrix/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: sdd-dev-smoke-matrix
+
+**Feature Branch**: `codex/sdd-dev-smoke-matrix`
+**Created**: 2026-07-03
+**Status**: Draft
+**Risk Tier**: medium
+**Input**: User description: "Expand the config-driven development smoke matrix and generic checks for sdd-dev-smoke-matrix."
+
+## Summary
+
+Development branch smoke validation should prove more app behavior from
+config-driven profiles before relying on production synthetic smoke as the first
+signal. Operators need reusable profile fields for Flux Kustomization readiness,
+TLSRoute readiness, scoped Secret reference presence, route URLs for browser
+handoff, and documented app coverage or gaps for apps that cannot be safely
+represented in this slice.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/development-cluster.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/sops-age-secrets.md`
+- `docs/decisions/synology-nfs-storage.md`
+
+## Scope
+
+### In Scope
+
+- Preserve existing dev smoke profile behavior for `whoami`, `jellyfin`, and
+  `home-assistant`.
+- Add schema and verification support for Flux Kustomization readiness,
+  TLSRoute readiness, Kubernetes Secret reference presence, and route URL fields.
+- Add tests that cover the new schema/checks and command sequencing.
+- Add safe profile and branch overlay support for `pihole` and `foundryvtt` if
+  their development-only names, routes, PVCs, and secret references can avoid
+  production collisions.
+- Investigate `authentik` and `monitoring`; document gaps instead of forcing
+  unsafe profile support when dependencies exceed this slice.
+- Audit the synthetic smoke source duplication between `tests/smoke` and
+  `kubernetes/apps/synthetics/smoke` and either enforce mirroring or document a
+  follow-up.
+- Update development-cluster and tooling documentation plus implementation
+  evidence.
+
+### Out Of Scope
+
+- Production-first live cluster mutations or durable changes outside Git.
+- Reading, decrypting, or logging Kubernetes Secret contents.
+- Broad application refactors to make complex apps fit smoke profiles.
+- Verifier approval artifacts, PR creation, or final verifier sign-off.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Generic Smoke Checks (Priority: P1)
+
+An operator can add a branch smoke profile that verifies Flux Kustomizations,
+HTTPRoutes, TLSRoutes, Services, PVC storage classes, referenced Secret names,
+and route probes from profile data.
+
+**Why this priority**: Generic checks are the smallest reusable improvement and
+unlock later app coverage without one-off scripts.
+
+**Independent Test**: `python3 -m unittest discover -s tools/development/tests`
+includes profile parsing and checker sequencing coverage.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile with kustomizations, tls_routes, secret_refs, and
+   route_urls, **When** the branch verifier builds and runs checks, **Then** it
+   sequences the new checks without dropping existing namespace, pod,
+   HelmRelease, Service, HTTPRoute, PVC, or HTTP probe checks.
+2. **Given** a profile secret reference, **When** the secret check runs, **Then**
+   it only checks for the referenced Kubernetes Secret name in the namespace and
+   never reads or logs Secret data.
+
+### User Story 2 - App Coverage And Gaps (Priority: P2)
+
+An operator can see which development smoke profiles are available and why any
+requested app remains documentation-only.
+
+**Why this priority**: Coverage expansion is valuable only if unsafe gaps are
+explicit and do not masquerade as verified support.
+
+**Independent Test**: Unit/static checks plus rendered branch overlay review
+show safe isolation for any added app profiles.
+
+**Acceptance Scenarios**:
+
+1. **Given** a safe app branch overlay, **When** its smoke profile is rendered,
+   **Then** branch-specific names include the branch slug and avoid production
+   collisions.
+2. **Given** an app that depends on secrets, shared stacks, or broader refactors
+   beyond the slice, **When** documentation is updated, **Then** the exact gap
+   and follow-up path are recorded.
+
+### User Story 3 - Browser Smoke Handoff (Priority: P3)
+
+An operator has a profile-level route URL field and documented Playwright handoff
+for branch hostnames under `dev.lab.petebeegle.com`.
+
+**Why this priority**: Browser smoke is useful for routed apps but should not
+force live cluster credentials into unit tests.
+
+**Independent Test**: Profile schema tests and documentation verify the handoff
+path; live execution is attempted only when development credentials are
+available and safe.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile route URL, **When** documentation describes validation,
+   **Then** it records browser smoke expectations and failure artifact behavior.
+2. **Given** live cluster credentials are unavailable, **When** evidence is
+   finalized, **Then** the development smoke exception and substitute checks are
+   recorded.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST preserve existing `whoami`, `jellyfin`,
+  and `home-assistant` smoke profile behavior.
+- **FR-002**: The profile schema and checker MUST support Flux Kustomization
+  readiness checks.
+- **FR-003**: The profile schema and checker MUST support TLSRoute readiness
+  checks without replacing HTTPRoute readiness.
+- **FR-004**: The profile schema and checker MUST support Secret reference
+  presence checks by Kubernetes Secret name only, without inspecting Secret
+  contents.
+- **FR-005**: The profile schema or documentation MUST support route URL handoff
+  for Playwright smoke under `dev.lab.petebeegle.com`.
+- **FR-006**: The implementation MUST add tests for new profile fields, checks,
+  and command sequencing where the codebase has test seams.
+- **FR-007**: The implementation MUST add safe profile or overlay coverage for
+  `pihole` and `foundryvtt`, or document why a profile is unsafe in this slice.
+- **FR-008**: The implementation MUST investigate `authentik` and `monitoring`
+  and record explicit gaps when profile support requires secrets,
+  cross-stack dependencies, or broader refactors.
+- **FR-009**: The implementation MUST audit synthetic smoke source duplication
+  and either add mirroring enforcement or record a follow-up.
+- **FR-010**: Evidence MUST record required command outcomes, development smoke
+  results or unavailable-infrastructure exceptions, and final `HEAD`.
+
+## Risk And Validation Expectations
+
+**Medium**: Include focused unit tests for tooling and rendered/static checks
+for Kubernetes branch overlays. Attempt development-cluster validation for the
+`whoami` branch profile if kube credentials are available and safe; otherwise
+document the unavailable-infrastructure exception with substitute checks.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `python3 -m unittest discover -s tools/development/tests` passes
+  with coverage for new profile fields and check sequencing.
+- **SC-002**: Existing smoke profiles continue to parse and existing checks are
+  not removed.
+- **SC-003**: Added branch overlays, if any, use `${branch_slug}` in names,
+  hostnames, and resources that could collide with production.
+- **SC-004**: `docs/runbooks/development-cluster.md`,
+  `tools/development/README.md`, and `specs/sdd-dev-smoke-matrix/evidence.md`
+  record app coverage, Playwright handoff, synthetic smoke audit, and gaps.
+
+## Assumptions
+
+- No development cluster credentials or local secret staging are assumed at the
+  start of implementation.
+- Branch smoke pushes are allowed only through the validated implementation clone
+  and only for development validation.
+- Secret presence checks can use Kubernetes object metadata APIs without
+  retrieving or printing secret data payloads.
+
+## Open Questions
+
+- None.

--- a/specs/sdd-dev-smoke-matrix/tasks.md
+++ b/specs/sdd-dev-smoke-matrix/tasks.md
@@ -1,0 +1,107 @@
+---
+description: "Development smoke matrix expansion task list"
+---
+
+# Tasks: sdd-dev-smoke-matrix
+
+**Input**: `specs/sdd-dev-smoke-matrix/spec.md` and
+`specs/sdd-dev-smoke-matrix/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Valid workflow marker, implementation plan, owner attestation,
+and delegation token under `.codex/tmp/`
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Workflow Setup
+
+- [x] T001 [FR-OWN] Create or refresh the sibling clone at
+      `/workspaces/homelab-ideas/sdd-dev-smoke-matrix` on
+      `codex/sdd-dev-smoke-matrix`.
+- [x] T002 [FR-OWN] Create `.codex/tmp/active-implementation`,
+      `.codex/tmp/implementation-plan.yaml`,
+      `.codex/tmp/implementation-owner-attestation.yaml`, and matching
+      `.codex/tmp/delegation-tokens/implementation-agent-sdd-dev-smoke-matrix.token`.
+- [x] T003 [FR-OWN] Run owner workflow validators and record outcomes in
+      `specs/sdd-dev-smoke-matrix/evidence.md`.
+
+## Phase 2: Spec And Plan
+
+- [x] T004 [FR-SPEC] Write `specs/sdd-dev-smoke-matrix/spec.md`.
+- [x] T005 [FR-PLAN] Write `specs/sdd-dev-smoke-matrix/plan.md`, including
+      tiered TDD and development validation expectations.
+- [x] T006 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations.
+- [x] T007 [FR-SPEC] Add
+      `specs/sdd-dev-smoke-matrix/checklists/smoke-readiness.md`.
+
+## Phase 3: Investigation And Tests
+
+- [x] T008 [P] [FR-001] Inspect existing devverify code and tests:
+      `tools/development/devverify/*.py` and
+      `tools/development/tests/test_verify_branch_deploy.py`.
+- [x] T009 [P] [FR-007,FR-008] Inspect current app manifests and branch
+      overlays for `whoami`, `jellyfin`, `home-assistant`, `pihole`,
+      `foundryvtt`, `authentik`, and `monitoring`.
+- [x] T010 [P] [FR-009] Audit `tests/smoke` and
+      `kubernetes/apps/synthetics/smoke` duplication.
+- [x] T011 [FR-002,FR-003,FR-004,FR-005,FR-006] Add or update focused tests in
+      `tools/development/tests/test_verify_branch_deploy.py` for new profile
+      fields, check construction, cleanup, and command sequencing.
+
+## Phase 4: Implementation
+
+- [x] T012 [FR-002,FR-003,FR-004,FR-005] Update
+      `tools/development/devverify/config.py`,
+      `tools/development/devverify/profiles.py`, and
+      `tools/development/devverify/checks.py` for Kustomization, TLSRoute,
+      Secret reference, and route URL support.
+- [x] T013 [FR-002,FR-003,FR-004] Update
+      `tools/development/devverify/cleanup.py`,
+      `tools/development/devverify/flux.py`,
+      `tools/development/devverify/workflow.py`, and/or
+      `tools/development/devverify/cli.py` only where sequencing or cleanup
+      requires it.
+- [x] T014 [FR-001,FR-007] Update
+      `tools/development/smoke-profiles/*.json` and safe branch overlays under
+      `kubernetes/apps/*/branch/*` or `kubernetes/clusters/development/branches/*`.
+- [x] T015 [FR-008,FR-009] Document authentik, monitoring, Playwright, and
+      synthetic smoke mirroring gaps when not implemented directly.
+- [x] T016 [FR-DOCS] Update `docs/runbooks/development-cluster.md` and
+      `tools/development/README.md`.
+- [x] T017 [FR-PLAN] Re-check constitution gates after implementation edits.
+
+## Phase 5: Verification
+
+- [x] T018 [FR-TEST] Run
+      `python3 -m unittest discover -s tools/development/tests`.
+- [x] T019 [FR-TEST] Run
+      `python3 -m unittest discover -s tools/codex-harness/tests`.
+- [x] T020 [FR-TEST] Run
+      `python3 -m unittest discover -s tools/context-pack/tests`.
+- [x] T021 [FR-TEST] Run `pre-commit run --all-files`.
+- [x] T022 [FR-TEST] Run `python3 tools/architecture/render.py --check`; run
+      `--write` first if Kubernetes/Terraform changes require generated docs.
+- [x] T023 [FR-TEST] Run `npx -y agnix@0.25.0 .`.
+- [x] T024 [FR-TEST] Run `npm ci && npm test` in `tests/smoke` if touched or
+      quick.
+- [x] T025 [FR-TEST] Run
+      `uv run --project tools/agent-memory pytest tools/agent-memory/tests` or
+      record any unrelated Python version limitation.
+- [x] T026 [FR-SMOKE] Attempt the whoami development smoke command when
+      credentials are available and safe, or record the exception.
+- [x] T027 [FR-EVIDENCE] Run SDD context validator with evidence and final
+      `HEAD` after commit.
+- [x] T028 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
+      and final `HEAD` in `specs/sdd-dev-smoke-matrix/evidence.md`.
+
+## Phase 6: Commit And Handoff
+
+- [x] T029 [FR-PR] Write `.codex/tmp/pr-summary.md` from the plan and final
+      evidence.
+- [x] T030 [FR-PR] Commit with a conventional commit message.
+- [x] T031 [FR-PR] Report exact `HEAD` and do not create verifier approval.

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -1,6 +1,6 @@
 # Development Tools
 
-`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. It loads smoke profiles from `tools/development/smoke-profiles/` and currently supports `whoami` and `jellyfin`.
+`verify_branch_deploy.py` is the canonical live acceptance helper for app-scoped development branch environments. It loads smoke profiles from `tools/development/smoke-profiles/` and currently supports `whoami`, `jellyfin`, and `home-assistant`.
 
 Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
 
@@ -8,10 +8,33 @@ Operational authority lives in [Development Cluster](../../docs/runbooks/develop
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
 ```
 
+The profile schema supports:
+
+- `checks.kustomizations`: Flux `Kustomization` names in `flux-system` that must be Ready.
+- `checks.helmReleases`: HelmRelease names in the profile namespace that must be Ready.
+- `checks.services`: Service names that must exist.
+- `checks.httpRoutes` and `checks.tlsRoutes`: Gateway API routes that must have `Accepted` and `ResolvedRefs` on one parent.
+- `checks.secretRefs`: Kubernetes Secret names that must exist in the profile namespace. The verifier checks names only and does not request or print Secret data.
+- `checks.pvcs`: PVC names and optional `storageClass` expectations.
+- `checks.httpProbes`: in-cluster curl probes against Services.
+- `routeUrls`: rendered external route URLs for browser or Playwright handoff.
+
+Print route URLs without touching the cluster:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --print-route-urls
+```
+
 The Jellyfin profile verifies the branch namespace, Flux Kustomization and HelmRelease readiness, active pod readiness, config PVC binding on `nfs-csi-storage`, Service existence, HTTPRoute attachment, and an in-cluster HTTP probe against the Jellyfin web shell:
 
 ```sh
 python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-change --slug jellyfin-change --push
+```
+
+The Home Assistant profile verifies the branch namespace, Flux Kustomization readiness, active pod readiness, config PVC binding on `nfs-csi-storage`, Service existence, HTTPRoute attachment, and an in-cluster HTTP probe against the Home Assistant web shell:
+
+```sh
+python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/ha-change --slug ha-change --push
 ```
 
 Use `--include-cluster-base` to first reconcile the development base from `--branch` in the known order and restore the `flux-system` GitRepository to `main` before the tool exits:

--- a/tools/development/devverify/__init__.py
+++ b/tools/development/devverify/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .checks import (
     assert_httproute_ready,
+    assert_tlsroute_ready,
     assert_pvc_bound,
     assert_pvc_ready,
     assert_smoke_profile,
@@ -75,6 +76,7 @@ __all__ = (
     "VerificationError",
     "apply_activation",
     "assert_httproute_ready",
+    "assert_tlsroute_ready",
     "assert_pvc_bound",
     "assert_pvc_ready",
     "assert_smoke_profile",

--- a/tools/development/devverify/checks.py
+++ b/tools/development/devverify/checks.py
@@ -6,7 +6,7 @@ import json
 import shlex
 from typing import Sequence
 
-from .config import AppConfig, HttpProbe, Runner, VerificationError
+from .config import FLUX_NAMESPACE, AppConfig, HttpProbe, Runner, VerificationError
 from .kube import kubectl, run_command
 from .profiles import load_smoke_profile, render_profile_value
 
@@ -14,6 +14,24 @@ from .profiles import load_smoke_profile, render_profile_value
 def assert_smoke_profile(config: AppConfig, profile, *, runner: Runner) -> None:
     name = render_profile_value(profile.namespace, config=config, field="namespace")
     run_command(kubectl(config, "get", "namespace", name), runner=runner, timeout=config.timeout)
+    for kustomization in profile.kustomizations:
+        resource_name = render_profile_value(kustomization, config=config, field="kustomization")
+        run_command(
+            kubectl(
+                config,
+                "-n",
+                FLUX_NAMESPACE,
+                "wait",
+                f"kustomization.kustomize.toolkit.fluxcd.io/{resource_name}",
+                "--for=condition=Ready",
+                f"--timeout={config.timeout.raw}",
+            ),
+            runner=runner,
+            timeout=config.timeout,
+        )
+    for secret_ref in profile.secret_refs:
+        resource_name = render_profile_value(secret_ref, config=config, field="secretRef")
+        run_command(kubectl(config, "-n", name, "get", "secret", resource_name), runner=runner, timeout=config.timeout)
     for helm_release in profile.helm_releases:
         resource_name = render_profile_value(helm_release, config=config, field="helmRelease")
         run_command(
@@ -51,6 +69,15 @@ def assert_smoke_profile(config: AppConfig, profile, *, runner: Runner) -> None:
             capture_output=True,
         )
         assert_httproute_ready(str(getattr(route, "stdout", "")), route_name=resource_name)
+    for tls_route in profile.tls_routes:
+        resource_name = render_profile_value(tls_route, config=config, field="tlsRoute")
+        route = run_command(
+            kubectl(config, "-n", name, "get", "tlsroute", resource_name, "-o", "json"),
+            runner=runner,
+            timeout=config.timeout,
+            capture_output=True,
+        )
+        assert_tlsroute_ready(str(getattr(route, "stdout", "")), route_name=resource_name)
     for index, probe in enumerate(profile.http_probes):
         run_command(
             build_http_probe_command(config, namespace=name, probe=probe, probe_index=index, total_probes=len(profile.http_probes)),
@@ -254,10 +281,18 @@ def pod_namespace_name(pod: dict[str, object], *, default: str | None) -> str | 
 
 
 def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
+    assert_gateway_route_ready(route_json, route_kind="HTTPRoute", route_name=route_name)
+
+
+def assert_tlsroute_ready(route_json: str, *, route_name: str) -> None:
+    assert_gateway_route_ready(route_json, route_kind="TLSRoute", route_name=route_name)
+
+
+def assert_gateway_route_ready(route_json: str, *, route_kind: str, route_name: str) -> None:
     try:
         route = json.loads(route_json)
     except json.JSONDecodeError as exc:
-        raise VerificationError(f"HTTPRoute {route_name} did not return valid JSON: {exc}") from exc
+        raise VerificationError(f"{route_kind} {route_name} did not return valid JSON: {exc}") from exc
 
     parents = route.get("status", {}).get("parents", [])
     for parent in parents:
@@ -267,4 +302,4 @@ def assert_httproute_ready(route_json: str, *, route_name: str) -> None:
             for condition_type in ("Accepted", "ResolvedRefs")
         ):
             return
-    raise VerificationError(f"HTTPRoute {route_name} has no parent with Accepted and ResolvedRefs conditions")
+    raise VerificationError(f"{route_kind} {route_name} has no parent with Accepted and ResolvedRefs conditions")

--- a/tools/development/devverify/cli.py
+++ b/tools/development/devverify/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Sequence
 
 from .config import DEFAULT_KUBECONFIG, DEFAULT_TIMEOUT, VerificationError, config_from_args, parse_duration, validate_app, validate_branch, validate_slug
-from .profiles import supported_apps
+from .profiles import load_smoke_profile, render_profile_value, supported_apps
 from .workflow import run_acceptance
 
 
@@ -29,6 +29,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--kubeconfig", type=Path, default=DEFAULT_KUBECONFIG)
     parser.add_argument("--timeout", type=parse_duration, default=parse_duration(DEFAULT_TIMEOUT))
     parser.add_argument("--keep", action="store_true", help="Keep branch Flux resources for debugging.")
+    parser.add_argument(
+        "--print-route-urls",
+        action="store_true",
+        help="Print rendered profile route URLs for browser or Playwright smoke handoff, then exit.",
+    )
     return parser
 
 
@@ -36,6 +41,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     config = config_from_args(args)
+    if args.print_route_urls:
+        profile = load_smoke_profile(config.app)
+        for route_url in profile.route_urls:
+            print(render_profile_value(route_url, config=config, field="routeUrls"))
+        return 0
     try:
         run_acceptance(config)
     except VerificationError as exc:

--- a/tools/development/devverify/config.py
+++ b/tools/development/devverify/config.py
@@ -89,11 +89,15 @@ class SmokeProfile:
     git_repository: str
     activation_template: str
     namespace: str
+    kustomizations: tuple[str, ...]
     helm_releases: tuple[str, ...]
     services: tuple[str, ...]
     http_routes: tuple[str, ...]
+    tls_routes: tuple[str, ...]
+    secret_refs: tuple[str, ...]
     pvcs: tuple[PvcCheck, ...]
     http_probes: tuple[HttpProbe, ...]
+    route_urls: tuple[str, ...]
 
 
 def parse_duration(value: str) -> Duration:

--- a/tools/development/devverify/profiles.py
+++ b/tools/development/devverify/profiles.py
@@ -39,11 +39,15 @@ def load_smoke_profile_file(path: Path) -> SmokeProfile:
         git_repository=raw.get("gitRepository") if isinstance(raw.get("gitRepository"), str) else "branch-${branch_slug}",
         activation_template=_required_string(raw, "activationTemplate", path),
         namespace=_required_string(raw, "namespace", path),
+        kustomizations=tuple(_string_list(checks.get("kustomizations", []), f"{path}:checks.kustomizations")),
         helm_releases=tuple(_string_list(checks.get("helmReleases", []), f"{path}:checks.helmReleases")),
         services=tuple(_string_list(checks.get("services", []), f"{path}:checks.services")),
         http_routes=tuple(_string_list(checks.get("httpRoutes", []), f"{path}:checks.httpRoutes")),
+        tls_routes=tuple(_string_list(checks.get("tlsRoutes", []), f"{path}:checks.tlsRoutes")),
+        secret_refs=tuple(_string_list(checks.get("secretRefs", []), f"{path}:checks.secretRefs")),
         pvcs=tuple(_pvc_checks(checks.get("pvcs", []), path)),
         http_probes=tuple(_http_probes(checks.get("httpProbes", []), path)),
+        route_urls=tuple(_string_list(raw.get("routeUrls", []), f"{path}:routeUrls")),
     )
     return profile
 

--- a/tools/development/smoke-profiles/home-assistant.json
+++ b/tools/development/smoke-profiles/home-assistant.json
@@ -3,7 +3,13 @@
   "gitRepository": "branch-home-assistant-${branch_slug}",
   "activationTemplate": "kubernetes/clusters/development/branches/home-assistant-template.yaml",
   "namespace": "home-assistant-${branch_slug}",
+  "routeUrls": [
+    "https://homeassistant-${branch_slug}.dev.lab.petebeegle.com"
+  ],
   "checks": {
+    "kustomizations": [
+      "branch-home-assistant-${branch_slug}"
+    ],
     "pvcs": [
       {
         "name": "home-assistant-config-${branch_slug}",

--- a/tools/development/smoke-profiles/jellyfin.json
+++ b/tools/development/smoke-profiles/jellyfin.json
@@ -3,7 +3,13 @@
   "gitRepository": "branch-jellyfin-${branch_slug}",
   "activationTemplate": "kubernetes/clusters/development/branches/jellyfin-template.yaml",
   "namespace": "jellyfin-${branch_slug}",
+  "routeUrls": [
+    "https://jellyfin-${branch_slug}.dev.lab.petebeegle.com"
+  ],
   "checks": {
+    "kustomizations": [
+      "branch-jellyfin-${branch_slug}"
+    ],
     "helmReleases": [
       "jellyfin-${branch_slug}"
     ],

--- a/tools/development/smoke-profiles/whoami.json
+++ b/tools/development/smoke-profiles/whoami.json
@@ -3,7 +3,13 @@
   "gitRepository": "branch-${branch_slug}",
   "activationTemplate": "kubernetes/clusters/development/branches/whoami-template.yaml",
   "namespace": "whoami-${branch_slug}",
+  "routeUrls": [
+    "https://whoami-${branch_slug}.dev.lab.petebeegle.com"
+  ],
   "checks": {
+    "kustomizations": [
+      "branch-whoami-${branch_slug}"
+    ],
     "services": [
       "whoami-${branch_slug}"
     ],

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import subprocess
 import sys
@@ -31,6 +33,8 @@ READY_HTTPROUTE = """{
     ]
   }
 }"""
+
+READY_TLSROUTE = READY_HTTPROUTE
 
 READY_PODS = json.dumps(
     {
@@ -183,6 +187,8 @@ class FakeRunner:
             return SimpleNamespace(returncode=0, stdout=self.pods_json)
         if "get" in args and "httproute" in args and args[-2:] == ["-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=READY_HTTPROUTE)
+        if "get" in args and "tlsroute" in args and args[-2:] == ["-o", "json"]:
+            return SimpleNamespace(returncode=0, stdout=READY_TLSROUTE)
         if "get" in args and "pvc" in args and args[-2:] == ["-o", "json"]:
             return SimpleNamespace(returncode=0, stdout=self.pvc_json)
         return SimpleNamespace(returncode=0, stdout="")
@@ -204,15 +210,19 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("Verify an app branch environment", result.stdout)
 
-    def test_profile_loading_discovers_whoami_and_jellyfin(self) -> None:
+    def test_profile_loading_discovers_current_supported_apps(self) -> None:
         profiles = verify.load_smoke_profiles()
 
         self.assertEqual(set(profiles), {"home-assistant", "jellyfin", "whoami"})
         self.assertEqual(profiles["whoami"].activation_template, "kubernetes/clusters/development/branches/whoami-template.yaml")
         self.assertEqual(profiles["whoami"].git_repository, "branch-${branch_slug}")
+        self.assertEqual(profiles["whoami"].kustomizations, ("branch-whoami-${branch_slug}",))
+        self.assertEqual(profiles["whoami"].route_urls, ("https://whoami-${branch_slug}.dev.lab.petebeegle.com",))
         self.assertEqual(profiles["jellyfin"].git_repository, "branch-jellyfin-${branch_slug}")
+        self.assertEqual(profiles["jellyfin"].kustomizations, ("branch-jellyfin-${branch_slug}",))
         self.assertEqual(profiles["jellyfin"].pvcs[0].name, "jellyfin-config-${branch_slug}")
         self.assertEqual(profiles["home-assistant"].git_repository, "branch-home-assistant-${branch_slug}")
+        self.assertEqual(profiles["home-assistant"].kustomizations, ("branch-home-assistant-${branch_slug}",))
         self.assertEqual(profiles["home-assistant"].pvcs[0].name, "home-assistant-config-${branch_slug}")
 
     def test_supported_apps_are_loaded_from_profile_json(self) -> None:
@@ -224,13 +234,25 @@ class VerifyBranchDeployTest(unittest.TestCase):
                         "app": "custom",
                         "activationTemplate": "template.yaml",
                         "namespace": "custom-${branch_slug}",
-                        "checks": {"services": ["custom-${branch_slug}"]},
+                        "routeUrls": ["https://custom-${branch_slug}.dev.lab.petebeegle.com"],
+                        "checks": {
+                            "kustomizations": ["branch-custom-${branch_slug}"],
+                            "services": ["custom-${branch_slug}"],
+                            "tlsRoutes": ["custom-${branch_slug}"],
+                            "secretRefs": ["custom-secret-${branch_slug}"],
+                        },
                     }
                 ),
                 encoding="utf-8",
             )
 
+            profiles = verify.load_smoke_profiles(profile_dir)
+
             self.assertEqual(verify.supported_apps(profile_dir), frozenset({"custom"}))
+            self.assertEqual(profiles["custom"].kustomizations, ("branch-custom-${branch_slug}",))
+            self.assertEqual(profiles["custom"].tls_routes, ("custom-${branch_slug}",))
+            self.assertEqual(profiles["custom"].secret_refs, ("custom-secret-${branch_slug}",))
+            self.assertEqual(profiles["custom"].route_urls, ("https://custom-${branch_slug}.dev.lab.petebeegle.com",))
 
     def test_branch_validation_accepts_common_git_branch_name(self) -> None:
         self.assertEqual(verify.validate_branch("codex/example-change"), "codex/example-change")
@@ -276,6 +298,25 @@ class VerifyBranchDeployTest(unittest.TestCase):
         self.assertEqual(verify.parse_duration("1h30m5s").seconds, 5405)
         with self.assertRaises(argparse.ArgumentTypeError):
             verify.parse_duration("soon")
+
+    def test_print_route_urls_renders_profile_urls_without_cluster_access(self) -> None:
+        stdout = io.StringIO()
+
+        with contextlib.redirect_stdout(stdout):
+            result = verify.main(
+                [
+                    "--app",
+                    "whoami",
+                    "--branch",
+                    "codex/example-change",
+                    "--slug",
+                    "example-change",
+                    "--print-route-urls",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stdout.getvalue().strip(), "https://whoami-example-change.dev.lab.petebeegle.com")
 
     def test_run_command_wraps_subprocess_timeout(self) -> None:
         config = self._config()
@@ -337,6 +378,19 @@ class VerifyBranchDeployTest(unittest.TestCase):
         with self.assertRaisesRegex(verify.VerificationError, "Accepted and ResolvedRefs"):
             verify.assert_httproute_ready(missing_resolved_refs, route_name="whoami-example-change")
 
+    def test_tlsroute_assert_requires_accepted_and_resolved_refs_on_one_parent(self) -> None:
+        missing_resolved_refs = """{
+          "status": {
+            "parents": [
+              {"conditions": [{"type": "Accepted", "status": "True"}]},
+              {"conditions": [{"type": "ResolvedRefs", "status": "True"}]}
+            ]
+          }
+        }"""
+
+        with self.assertRaisesRegex(verify.VerificationError, "Accepted and ResolvedRefs"):
+            verify.assert_tlsroute_ready(missing_resolved_refs, route_name="whoami-example-change")
+
     def test_pod_readiness_waits_for_active_pods(self) -> None:
         runner = FakeRunner()
         config = self._config()
@@ -383,8 +437,43 @@ class VerifyBranchDeployTest(unittest.TestCase):
         verify.assert_whoami(config, runner=runner)
 
         commands = [" ".join(command) for command in runner.commands]
+        self.assertTrue(any("wait kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change" in command for command in commands))
         self.assertTrue(any("get service whoami-example-change" in command for command in commands))
         self.assertTrue(any("get httproute whoami-example-change -o json" in command for command in commands))
+
+    def test_profile_checks_flux_kustomization_secret_reference_tlsroute_and_keeps_secret_data_unread(self) -> None:
+        runner = FakeRunner()
+        config = self._config()
+        profile = verify.SmokeProfile(
+            app="whoami",
+            git_repository="branch-${branch_slug}",
+            activation_template="template.yaml",
+            namespace="whoami-${branch_slug}",
+            kustomizations=("branch-whoami-${branch_slug}",),
+            helm_releases=(),
+            services=("whoami-${branch_slug}",),
+            http_routes=(),
+            tls_routes=("whoami-tls-${branch_slug}",),
+            secret_refs=("whoami-secret-${branch_slug}",),
+            pvcs=(),
+            http_probes=(),
+            route_urls=("https://whoami-${branch_slug}.dev.lab.petebeegle.com",),
+        )
+
+        verify.assert_smoke_profile(config, profile, runner=runner)
+
+        commands = [" ".join(command) for command in runner.commands]
+        kustomization_index = self._index_containing(
+            commands,
+            "wait kustomization.kustomize.toolkit.fluxcd.io/branch-whoami-example-change",
+        )
+        secret_index = self._index_containing(commands, "get secret whoami-secret-example-change")
+        pods_index = self._index_containing(commands, "get pods -o json")
+        tlsroute_index = self._index_containing(commands, "get tlsroute whoami-tls-example-change -o json")
+        self.assertLess(kustomization_index, secret_index)
+        self.assertLess(secret_index, pods_index)
+        self.assertLess(pods_index, tlsroute_index)
+        self.assertFalse(any("secret whoami-secret-example-change -o json" in command for command in commands))
 
     def test_jellyfin_profile_checks_helm_pvc_service_route_and_http_probe(self) -> None:
         runner = FakeRunner(pods_json=READY_JELLYFIN_PODS)
@@ -574,6 +663,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
             "--push",
             "--terraform-apply",
             "--include-cluster-base",
+            "--print-route-urls",
             "--kubeconfig",
             "--timeout",
             "--keep",


### PR DESCRIPTION
## Summary
## Summary

- Expanded development smoke profiles with Flux Kustomization readiness, TLSRoute readiness, name-only Secret reference checks, and route URL handoff support.
- Added `--print-route-urls` for no-cluster browser/Playwright handoff under `dev.lab.petebeegle.com`.
- Preserved `whoami`, `jellyfin`, and `home-assistant` profile coverage; documented `pihole`, `foundryvtt`, `authentik`, `monitoring`, Playwright live execution, and synthetic smoke mirroring gaps.

## Validation

- PASS: `python3 -m unittest discover -s tools/development/tests` after red phase.
- PASS: `python3 -m unittest discover -s tools/codex-harness/tests`.
- PASS: `python3 -m unittest discover -s tools/context-pack/tests`.
- PASS: `pre-commit run --all-files`.
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `npx -y agnix@0.25.0 .` after removing generated `tests/smoke/node_modules`.
- PASS: `npm ci && npm test` in `tests/smoke`.
- SKIP: `uv run --project tools/agent-memory pytest tools/agent-memory/tests`; Python 3.14.6 unavailable.

## Development Smoke

- Read-only kubeconfig check passed for `~/.kube/homelab-development.config`.
- PASS: `--print-route-urls` rendered
  `https://whoami-sdd-dev-smoke-matrix.dev.lab.petebeegle.com`.
- Pushed/tested commit:
  `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f`.
- FAIL/BLOCKED: live `whoami` smoke command:
  `python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/sdd-dev-smoke-matrix --slug sdd-dev-smoke-matrix --push`.
- Failure stage: `terraform -chdir=terraform/development plan -detailed-exitcode -input=false -no-color` preflight, before Flux activation.
- Missing local inputs, without values: `pm_api_url`, Proxmox token fields, GitHub and Docker variables, and `talos_version`.
- Cleanup/absence: confirmed no `branch-whoami-sdd-dev-smoke-matrix` Flux Kustomization, no `branch-sdd-dev-smoke-matrix` GitRepository, and no `whoami-sdd-dev-smoke-matrix` namespace.
- Final local HEAD after evidence refresh:
  `2d0c1808fa651e337c3993485cc46d2ee75c9f7e`.
- Push status: not pushed after the evidence-only refresh because non-smoke origin pushes require verifier approval; the prior smoke command pushed `6c1a7a2a5b2d02e45a9d65329661632ad6ecb33f` before Terraform preflight failed.

## Handoff Notes

- Do not create verifier approval as implementation owner.
- Verifier should audit that Secret checks only use Kubernetes Secret names and do not request `-o json` or data payloads.


## Changes
- docs/runbooks/development-cluster.md
- specs/sdd-dev-smoke-matrix/checklists/smoke-readiness.md
- specs/sdd-dev-smoke-matrix/evidence.md
- specs/sdd-dev-smoke-matrix/plan.md
- specs/sdd-dev-smoke-matrix/spec.md
- specs/sdd-dev-smoke-matrix/tasks.md
- tools/development/README.md
- tools/development/devverify/__init__.py
- tools/development/devverify/checks.py
- tools/development/devverify/cli.py
- tools/development/devverify/config.py
- tools/development/devverify/profiles.py
- tools/development/smoke-profiles/home-assistant.json
- tools/development/smoke-profiles/jellyfin.json
- tools/development/smoke-profiles/whoami.json
- tools/development/tests/test_verify_branch_deploy.py

## Commits
- 2d0c180 docs(dev-smoke): refresh smoke evidence
- 6c1a7a2 feat(dev-smoke): expand development smoke profile checks

## Verification
- Verified HEAD: `2d0c1808fa651e337c3993485cc46d2ee75c9f7e`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
