### PR TITLE
Implementation: dev-secret-staging-for-smoke

### DIFF
--- a/.codex/scripts/prepare_development_smoke_secrets.sh
+++ b/.codex/scripts/prepare_development_smoke_secrets.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+umask 077
+
+usage() {
+  {
+    printf 'Usage: %s <implementation> [clone-path ...]\n' "${0##*/}"
+    printf '\n'
+    printf 'Stages terraform/development/terraform.tfvars from this checkout and installs it into implementation or verifier clones before development smoke.\n'
+    printf 'When no clone path is provided, installs into /workspaces/homelab-ideas/<implementation>.\n'
+  } >&2
+}
+
+fail() {
+  printf 'Development smoke secret prep: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+implementation="$1"
+shift
+
+if [[ ! "$implementation" =~ ^[a-z0-9][a-z0-9._-]*$ ]]; then
+  fail "implementation must be a safe slug, got $implementation."
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+tfvars_path="terraform/development/terraform.tfvars"
+if [[ ! -f "$tfvars_path" ]]; then
+  fail "required ignored file is missing: $tfvars_path"
+fi
+
+if git ls-files --error-unmatch -- "$tfvars_path" >/dev/null 2>&1; then
+  fail "refusing tracked file: $tfvars_path"
+fi
+
+if ! git check-ignore -q -- "$tfvars_path"; then
+  fail "refusing non-ignored file: $tfvars_path"
+fi
+
+clones=("$@")
+if [[ ${#clones[@]} -eq 0 ]]; then
+  clones=("/workspaces/homelab-ideas/$implementation")
+fi
+
+for clone in "${clones[@]}"; do
+  [[ -d "$clone" ]] || fail "clone path not found: $clone"
+  git -C "$clone" rev-parse --show-toplevel >/dev/null 2>&1 ||
+    fail "clone path is not a Git checkout: $clone"
+done
+
+stage_script="$root/.codex/scripts/stage_implementation_secrets.sh"
+install_script="$root/.codex/scripts/install_implementation_secrets.sh"
+[[ -x "$stage_script" ]] || fail "stage script is not executable: $stage_script"
+[[ -x "$install_script" ]] || fail "install script is not executable: $install_script"
+
+"$stage_script" "$implementation" "$tfvars_path"
+
+stage_root="$root/.codex/tmp/implementation-secrets/$implementation"
+[[ -d "$stage_root" ]] || fail "staged secret root was not created: $stage_root"
+
+find "$stage_root" -type d -exec chmod 700 {} +
+while IFS= read -r -d '' staged_file; do
+  [[ "${staged_file#$stage_root/}" == "MANIFEST.txt" ]] && continue
+  chmod 600 "$staged_file"
+done < <(find "$stage_root" -type f -print0)
+
+for clone in "${clones[@]}"; do
+  (cd "$clone" && "$install_script" "$implementation" "$stage_root")
+done
+
+printf 'Development smoke secret prep: installed %s into %s clone(s) for %s.\n' \
+  "$tfvars_path" "${#clones[@]}" "$implementation"

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -149,6 +149,10 @@ Prerequisites:
 - The development cluster exists and the base Flux path is healthy.
 - `terraform`, `kubectl`, and `flux` are installed locally.
 - The default kubeconfig exists at `~/.kube/homelab-development.config`, or pass `--kubeconfig <path>`.
+- Ignored development Terraform vars are staged into the clone that runs smoke
+  when Terraform preflight may run:
+  `.codex/scripts/prepare_development_smoke_secrets.sh <implementation>
+  [/workspaces/homelab-ideas/<implementation> ...]`.
 - The branch named by `--branch` is available on origin. Use `--push` to push the current HEAD to origin as that branch before activation.
 - `--slug` is deterministic and DNS-safe: lowercase letters, numbers, and hyphens; starts and ends with an alphanumeric character; and is short enough for the selected app's `${app}-${branch_slug}` Kubernetes names.
 

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -16,7 +16,7 @@ Use this runbook for every repository code change. The binding decision is `docs
 
 1. Plan in the main checkout at `/workspaces/homelab`; do not edit tracked files there.
 2. Choose a single implementation name. One implementation maps to one pull request and branch `codex/<implementation>`.
-3. If ignored local secrets or configs are required, stage them under `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout, preserving repo-relative paths and never logging contents.
+3. If ignored local secrets or configs are required, stage them under `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout, preserving repo-relative paths and never logging contents. For development branch smoke that needs Terraform preflight, run `.codex/scripts/prepare_development_smoke_secrets.sh <implementation> [/workspaces/homelab-ideas/<implementation> ...]` from the main checkout before the implementation or verifier clone runs `tools/development/verify_branch_deploy.py`.
 4. Clone the repo into `/workspaces/homelab-ideas/<implementation>` and create `codex/<implementation>` from `origin/main`.
 5. Before tracked edits, create `.codex/tmp/active-implementation` with `implementation`, `branch`, `base`, `role`, `clone_path`, `owner_role`, and `owner_agent`.
 6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development validation expectations for the implementation, or explain why they do not apply.
@@ -221,6 +221,22 @@ Development validation expectations by tier:
 - `high`: run development validation for the affected app or base path. For shared cluster base changes, include a sequential development base reconcile before app acceptance.
 
 If the development cluster, kubeconfig, required staged development secrets, or required credentials are unavailable, record a documented exception with the blocker and safest substitute checks. A real development validation failure is not an exception; fix the change, rerun validation, or leave the PR incomplete.
+
+Before smoke commands that may run development Terraform preflight, prepare the
+required ignored development tfvars from the main checkout:
+
+```bash
+.codex/scripts/prepare_development_smoke_secrets.sh <implementation>
+```
+
+Pass both implementation and verifier clone paths when a verifier will rerun the
+same smoke:
+
+```bash
+.codex/scripts/prepare_development_smoke_secrets.sh <implementation> \
+  /workspaces/homelab-ideas/<implementation> \
+  /workspaces/homelab-ideas/<verification-clone>
+```
 
 Default development validation paths:
 

--- a/specs/dev-secret-staging-for-smoke/evidence.md
+++ b/specs/dev-secret-staging-for-smoke/evidence.md
@@ -1,0 +1,68 @@
+# Evidence: dev-secret-staging-for-smoke
+
+**Branch**: `codex/dev-secret-staging-for-smoke`
+**Risk Tier**: low
+**Started**: 2026-07-03
+**Owner**: implementation-agent-dev-secret-staging-for-smoke
+
+## Spec Kit Initialization
+
+- Command: Not run by this slice
+- Outcome: Existing repository Spec Kit scaffolding used
+- Spec Kit version: Not changed
+- Integration: Existing repository integration
+- Fallback: None
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest discover -s tools/codex-harness/tests -p test_prepare_development_smoke_secrets.py` | PASS | 5 tests passed for success, multi-clone install, missing tfvars, tracked tfvars, and non-ignored tfvars. |
+| `python3 -m unittest discover -s tools/codex-harness/tests` | PASS | 80 tests passed. |
+| `bash -n .codex/scripts/*.sh` | PASS | Shell syntax validation passed for Codex scripts. |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts are present and non-empty. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `pre-commit run --all-files` | PASS | All hooks passed. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: Pending final commit
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Local tooling and docs only. No Kubernetes, Terraform,
+  Flux, Gateway, storage, secret reference, app behavior, or branch overlay
+  change requires live development smoke. The change prepares future smoke
+  commands but does not itself activate Flux resources or touch the cluster.
+
+## Documentation Impact
+
+- Updated: `.codex/scripts/prepare_development_smoke_secrets.sh`,
+  `docs/runbooks/implementation-workflow.md`,
+  `docs/runbooks/development-cluster.md`, `tools/development/README.md`, and
+  `specs/dev-secret-staging-for-smoke/`.
+- Generated docs: `docs/architecture.md` unchanged; pre-commit architecture
+  check passed.
+- No-docs rationale: N/A
+
+## Exceptions And Follow-Ups
+
+- Main-agent self-implementation fallback used after the previous delegated
+  implementation-owner lane stalled; the user explicitly requested
+  implementation.
+
+## Final State
+
+- Final branch: `codex/dev-secret-staging-for-smoke`
+- Final HEAD: Recorded in `.codex/tmp/pr-summary.md` after commit.
+- Commit: `fix(codex): prepare dev smoke secrets`
+- Verifier approval: not created by implementation owner

--- a/specs/dev-secret-staging-for-smoke/plan.md
+++ b/specs/dev-secret-staging-for-smoke/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: dev-secret-staging-for-smoke
+
+**Branch**: `codex/dev-secret-staging-for-smoke` | **Date**: 2026-07-03 |
+**Spec**: `specs/dev-secret-staging-for-smoke/spec.md`
+
+**Input**: Feature specification from
+`specs/dev-secret-staging-for-smoke/spec.md`
+
+## Summary
+
+Add a focused shell wrapper around the existing secret staging and installation
+scripts so development smoke prerequisites are installed into implementation and
+verifier clones consistently before live branch validation.
+
+## Technical Context
+
+**Risk Tier**: low
+**Workflow Tier**: low
+**Primary Areas**: Codex scripts, local tooling tests, runbooks
+**Dependencies**: Bash, Git, Python unittest
+**Storage**: N/A
+**Ingress**: N/A
+**Secrets**: Copies ignored local Terraform tfvars by path only; no values are
+printed or committed
+**Development Validation**: none; local tooling/docs only
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Sibling clone ownership files validated before tracked edits.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] Separate verifier approval required before PR creation.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/dev-secret-staging-for-smoke/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+.codex/scripts/prepare_development_smoke_secrets.sh
+tools/codex-harness/tests/test_prepare_development_smoke_secrets.py
+docs/runbooks/implementation-workflow.md
+docs/runbooks/development-cluster.md
+tools/development/README.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add focused unit tests for the wrapper behavior.
+
+**Local checks**:
+
+- `python3 -m unittest tools.codex-harness.tests.test_prepare_development_smoke_secrets`
+- `python3 -m unittest discover -s tools/codex-harness/tests`
+- `bash -n .codex/scripts/*.sh`
+- `pre-commit run --all-files`
+
+**Development smoke**: none. The change helps prepare live smoke but does not
+change cluster behavior.
+
+**Evidence destination**: `specs/dev-secret-staging-for-smoke/evidence.md` and
+`.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+Update workflow and development validation docs so operators run the wrapper
+before smoke commands that perform Terraform preflight.
+
+## Implementation Steps
+
+1. Add failing unit tests for required wrapper behavior.
+2. Add `.codex/scripts/prepare_development_smoke_secrets.sh`.
+3. Update docs with the standard pre-smoke command.
+4. Run focused tests, harness tests, shell syntax checks, and pre-commit.
+5. Record evidence and commit.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Secret values are exposed | Print paths/counts only; tests assert behavior without real secrets |
+| Unsafe tfvars source is copied | Refuse missing, tracked, and non-ignored sources before staging |
+| Verifier clone misses inputs | Support one or more clone paths in a single command |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/dev-secret-staging-for-smoke/spec.md
+++ b/specs/dev-secret-staging-for-smoke/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: dev-secret-staging-for-smoke
+
+**Feature Branch**: `codex/dev-secret-staging-for-smoke`
+**Created**: 2026-07-03
+**Status**: Draft
+**Risk Tier**: low
+**Input**: User description: "Fix the dev smoke blocker: staged development Terraform vars/secrets were missing, so live branch smoke keeps stopping before Flux activation."
+
+## Summary
+
+Make development smoke preparation reliable by providing one repo-local command
+that stages `terraform/development/terraform.tfvars` from the planner checkout
+and installs it into implementation or verifier clones before live branch smoke
+commands run.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/development-cluster.md`
+- `docs/decisions/terraform-sensitive-values.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+
+## Scope
+
+### In Scope
+
+- Add `.codex/scripts/prepare_development_smoke_secrets.sh`.
+- Validate missing, tracked, non-ignored, single-clone, and multi-clone behavior.
+- Document the wrapper as the pre-smoke setup step for development branch
+  validation.
+
+### Out Of Scope
+
+- Running live development smoke.
+- Printing, reading, decrypting, or committing secret values.
+- Adding new smoke profiles or changing Kubernetes/Terraform desired state.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Prepare Smoke Inputs Reliably (Priority: P1)
+
+As an implementation owner or verifier, I can run one safe command before live
+development smoke so the required development Terraform vars exist in the clone
+that runs `verify_branch_deploy.py`.
+
+**Why this priority**: This directly addresses the blocker that stopped live
+smoke before Flux branch activation.
+
+**Independent Test**: Unit tests create temporary repos and confirm the wrapper
+stages and installs only the expected ignored tfvars path.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ignored `terraform/development/terraform.tfvars` in the planner
+   checkout, **When** the wrapper runs for an implementation clone, **Then** the
+   clone receives the same repo-relative file with mode `0600`.
+2. **Given** two clone paths, **When** the wrapper runs, **Then** both clones
+   receive the staged tfvars file.
+
+### User Story 2 - Refuse Unsafe Secret Sources (Priority: P2)
+
+As an operator, I need the wrapper to fail before copying anything unsafe.
+
+**Why this priority**: The command handles local secret material and must not
+normalize unsafe source paths.
+
+**Independent Test**: Unit tests cover missing, tracked, and non-ignored
+`terraform/development/terraform.tfvars`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the development tfvars file is missing, **When** the wrapper runs,
+   **Then** it exits non-zero before staging.
+2. **Given** the development tfvars file is tracked or not ignored, **When** the
+   wrapper runs, **Then** it exits non-zero and does not install the file.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The wrapper MUST default to installing into
+  `/workspaces/homelab-ideas/<implementation>` when clone paths are omitted.
+- **FR-002**: The wrapper MUST stage only
+  `terraform/development/terraform.tfvars` for this workflow.
+- **FR-003**: The wrapper MUST refuse missing, tracked, or non-ignored source
+  tfvars files.
+- **FR-004**: The wrapper MUST install staged tfvars into every requested clone
+  with file mode `0600`.
+- **FR-005**: Documentation MUST make the wrapper the standard pre-smoke step
+  before `verify_branch_deploy.py --push`, `--terraform-apply`, or verifier
+  reruns that need development Terraform preflight.
+- **FR-006**: Evidence MUST record local tests, shell syntax checks, pre-commit,
+  and the docs-only/local-tooling development smoke exception.
+
+## Risk And Validation Expectations
+
+This is a `low` SDD change because it adds local wrapper tooling and docs. It
+does not change live cluster desired state. Focused unit tests are required.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Unit tests pass for success, missing, tracked, non-ignored, mode,
+  and multi-clone scenarios.
+- **SC-002**: `bash -n .codex/scripts/*.sh` passes.
+- **SC-003**: `pre-commit run --all-files` passes.
+
+## Assumptions
+
+- The wrapper is run from the planner checkout containing local ignored
+  development Terraform vars.
+- Secret values are never printed; path names and counts are acceptable
+  operational output.
+
+## Open Questions
+
+- None.

--- a/specs/dev-secret-staging-for-smoke/tasks.md
+++ b/specs/dev-secret-staging-for-smoke/tasks.md
@@ -1,0 +1,31 @@
+---
+description: "Development smoke secret staging tasks"
+---
+
+# Tasks: dev-secret-staging-for-smoke
+
+## Phase 1: Workflow Setup
+
+- [x] T001 Create the sibling clone on `codex/dev-secret-staging-for-smoke`.
+- [x] T002 Create workflow marker, implementation plan, owner attestation, and
+      delegation token evidence under `.codex/tmp/`.
+- [x] T003 Run owner workflow validators.
+- [x] T004 Create `specs/dev-secret-staging-for-smoke/spec.md`,
+      `plan.md`, `tasks.md`, and `evidence.md`.
+
+## Phase 2: Tests And Implementation
+
+- [x] T005 Add wrapper unit tests in
+      `tools/codex-harness/tests/test_prepare_development_smoke_secrets.py`.
+- [x] T006 Add `.codex/scripts/prepare_development_smoke_secrets.sh`.
+- [x] T007 Update `docs/runbooks/implementation-workflow.md`,
+      `docs/runbooks/development-cluster.md`, and `tools/development/README.md`.
+
+## Phase 3: Verification
+
+- [x] T008 Run focused wrapper tests.
+- [x] T009 Run `python3 -m unittest discover -s tools/codex-harness/tests`.
+- [x] T010 Run `bash -n .codex/scripts/*.sh`.
+- [x] T011 Run `pre-commit run --all-files`.
+- [x] T012 Record evidence, final state, and PR summary.
+- [x] T013 Commit and hand off for verifier approval.

--- a/tools/codex-harness/tests/test_prepare_development_smoke_secrets.py
+++ b/tools/codex-harness/tests/test_prepare_development_smoke_secrets.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_SOURCE = REPO_ROOT / ".codex" / "scripts" / "prepare_development_smoke_secrets.sh"
+STAGE_SOURCE = REPO_ROOT / ".codex" / "scripts" / "stage_implementation_secrets.sh"
+INSTALL_SOURCE = REPO_ROOT / ".codex" / "scripts" / "install_implementation_secrets.sh"
+
+
+class PrepareDevelopmentSmokeSecretsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="smoke-secrets-")
+        self.root = Path(self.tempdir.name) / "source"
+        self.clone = Path(self.tempdir.name) / "clone"
+        self.second_clone = Path(self.tempdir.name) / "verifier"
+        _init_repo(self.root, ignore_tfvars=True)
+        _install_scripts(self.root)
+        _init_repo(self.clone, ignore_tfvars=True)
+        _init_repo(self.second_clone, ignore_tfvars=True)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_installs_development_tfvars_with_private_mode(self) -> None:
+        _write_tfvars(self.root)
+
+        result = _run(self.root, "example", str(self.clone))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        installed = self.clone / "terraform" / "development" / "terraform.tfvars"
+        self.assertEqual(installed.read_text(encoding="utf-8"), 'pm_api_url = "supersecret"\n')
+        self.assertEqual(stat.S_IMODE(installed.stat().st_mode), 0o600)
+        self.assertNotIn("supersecret", result.stdout)
+        self.assertNotIn("supersecret", result.stderr)
+
+    def test_installs_into_multiple_clones(self) -> None:
+        _write_tfvars(self.root)
+
+        result = _run(self.root, "example", str(self.clone), str(self.second_clone))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for clone in (self.clone, self.second_clone):
+            installed = clone / "terraform" / "development" / "terraform.tfvars"
+            self.assertTrue(installed.is_file())
+            self.assertEqual(stat.S_IMODE(installed.stat().st_mode), 0o600)
+
+    def test_fails_when_development_tfvars_is_missing(self) -> None:
+        result = _run(self.root, "example", str(self.clone))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("required ignored file is missing", result.stderr)
+        self.assertFalse((self.clone / "terraform" / "development" / "terraform.tfvars").exists())
+
+    def test_fails_when_development_tfvars_is_tracked(self) -> None:
+        _write_tfvars(self.root)
+        subprocess.run(
+            ["git", "add", "-f", "terraform/development/terraform.tfvars"],
+            cwd=self.root,
+            check=True,
+        )
+
+        result = _run(self.root, "example", str(self.clone))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing tracked file", result.stderr)
+        self.assertFalse((self.clone / "terraform" / "development" / "terraform.tfvars").exists())
+
+    def test_fails_when_development_tfvars_is_not_ignored(self) -> None:
+        shutil.rmtree(self.root)
+        _init_repo(self.root, ignore_tfvars=False)
+        _install_scripts(self.root)
+        _write_tfvars(self.root)
+
+        result = _run(self.root, "example", str(self.clone))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refusing non-ignored file", result.stderr)
+        self.assertFalse((self.clone / "terraform" / "development" / "terraform.tfvars").exists())
+
+
+def _init_repo(root: Path, *, ignore_tfvars: bool) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(["git", "config", "user.email", "codex@example.invalid"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Codex"], cwd=root, check=True)
+    (root / ".gitignore").write_text("*.tfvars\n" if ignore_tfvars else "", encoding="utf-8")
+    (root / "README.md").write_text("# test\n", encoding="utf-8")
+    subprocess.run(["git", "add", ".gitignore", "README.md"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-m", "test: initialize"], cwd=root, check=True, stdout=subprocess.DEVNULL)
+
+
+def _install_scripts(root: Path) -> None:
+    script_dir = root / ".codex" / "scripts"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    for source in (SCRIPT_SOURCE, STAGE_SOURCE, INSTALL_SOURCE):
+        target = script_dir / source.name
+        shutil.copy2(source, target)
+        target.chmod(0o755)
+
+
+def _write_tfvars(root: Path) -> None:
+    tfvars = root / "terraform" / "development" / "terraform.tfvars"
+    tfvars.parent.mkdir(parents=True, exist_ok=True)
+    tfvars.write_text('pm_api_url = "supersecret"\n', encoding="utf-8")
+
+
+def _run(root: Path, implementation: str, *clones: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("GIT_DIR", None)
+    env.pop("GIT_WORK_TREE", None)
+    return subprocess.run(
+        [str(root / ".codex" / "scripts" / "prepare_development_smoke_secrets.sh"), implementation, *clones],
+        cwd=root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/development/README.md
+++ b/tools/development/README.md
@@ -4,6 +4,14 @@
 
 Operational authority lives in [Development Cluster](../../docs/runbooks/development-cluster.md). Start there for prerequisites, cleanup expectations, and what this tool proves.
 
+Before running live smoke from an implementation or verifier clone, stage the
+development Terraform vars from the main checkout into the clone that will run
+the command:
+
+```sh
+.codex/scripts/prepare_development_smoke_secrets.sh example-change /workspaces/homelab-ideas/example-change
+```
+
 ```sh
 python3 tools/development/verify_branch_deploy.py --app whoami --branch codex/example-change --slug example-change --push
 ```


### PR DESCRIPTION
## Summary
# dev-secret-staging-for-smoke PR Summary

## Summary

- Added `.codex/scripts/prepare_development_smoke_secrets.sh` to stage
  `terraform/development/terraform.tfvars` and install it into smoke-running
  clones.
- Added unit coverage for success, multi-clone install, missing tfvars, tracked
  tfvars, and non-ignored tfvars cases.
- Documented the wrapper as the pre-smoke setup step for implementation and
  verifier clones.

## Validation

- `python3 -m unittest discover -s tools/codex-harness/tests -p test_prepare_development_smoke_secrets.py`: PASS
- `python3 -m unittest discover -s tools/codex-harness/tests`: PASS
- `bash -n .codex/scripts/*.sh`: PASS
- `git diff --check`: PASS
- `pre-commit run --all-files`: PASS

## Development Smoke

`smoke_profile: none`; local tooling/docs change only. The wrapper prepares
future smoke runs but does not activate Flux resources or touch the development
cluster.

## Workflow Notes

Main-agent self-implementation fallback was used after the previous delegated
implementation-owner lane stalled; the user explicitly requested implementation.

Final HEAD: 452414246122e63087f96d95ac67d0a559602f9b


## Changes
- .codex/scripts/prepare_development_smoke_secrets.sh
- docs/runbooks/development-cluster.md
- docs/runbooks/implementation-workflow.md
- specs/dev-secret-staging-for-smoke/evidence.md
- specs/dev-secret-staging-for-smoke/plan.md
- specs/dev-secret-staging-for-smoke/spec.md
- specs/dev-secret-staging-for-smoke/tasks.md
- tools/codex-harness/tests/test_prepare_development_smoke_secrets.py
- tools/development/README.md

## Commits
- 4524142 fix(codex): prepare dev smoke secrets

## Verification
- Verified HEAD: `452414246122e63087f96d95ac67d0a559602f9b`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
