### PR TITLE
Implementation: home-assistant-region

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-cloudflare-tunnels` | `./kubernetes/apps/cloudflare-tunnels` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-external` | `./kubernetes/apps/external` | `gateway` | `cluster-vars` | `no` |
 | `production` | `app-foundryvtt` | `./kubernetes/apps/foundryvtt` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
-| `production` | `app-home-assistant` | `./kubernetes/apps/home-assistant` | `gateway`, `nfs-csi`, `authentik` | `cluster-vars` | `no` |
+| `production` | `app-home-assistant` | `./kubernetes/apps/home-assistant` | `gateway`, `nfs-csi`, `authentik` | `cluster-vars` | `sops` |
 | `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `intel-gpu-device-plugin` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
@@ -138,7 +138,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/foundry-bluegreen-fixture` | `namespace.yaml`, `pvc-blue.yaml`, `pvc-green.yaml`, `deployment-blue.yaml`, `deployment-green.yaml`, `service-blue.yaml`, `service-green.yaml`, `httproute-green-preview.yaml` |
 | `kubernetes/apps/foundryvtt` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml`, `httproute-public.yaml` |
 | `kubernetes/apps/home-assistant/branch` | `home-assistant.yaml` |
-| `kubernetes/apps/home-assistant` | `namespace.yaml`, `pvc.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |
+| `kubernetes/apps/home-assistant` | `namespace.yaml`, `pvc.yaml`, `secret.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |
 | `kubernetes/apps/jellyfin/branch` | `jellyfin.yaml` |
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./pvc.yaml`, `./httproute.yaml`, `./secret.yaml`, `./sso-bootstrap.yaml` |
 | `kubernetes/apps/pihole` | `app.yaml`, `secret.yaml`, `httproute.yaml` |
@@ -201,6 +201,7 @@ This lists secret manifest presence only. Secret values are not rendered.
 | `cloudflare-tunnels` | `cloudflare/tunnel-credentials` | `yes` | `kubernetes/apps/cloudflare-tunnels/secret.yaml` |
 | `controllers/cert-manager` | `cert-manager/cloudflare-api-token` | `yes` | `kubernetes/infra/controllers/cert-manager/secret.yaml` |
 | `foundryvtt` | `foundryvtt/foundryvtt-secret` | `yes` | `kubernetes/apps/foundryvtt/secret.yaml` |
+| `home-assistant` | `home-assistant/home-assistant-secrets` | `yes` | `kubernetes/apps/home-assistant/secret.yaml` |
 | `jellyfin` | `jellyfin/jellyfin-secrets` | `yes` | `kubernetes/apps/jellyfin/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-credentials` | `yes` | `kubernetes/infra/monitoring/grafana/secret.yaml` |
 | `monitoring/grafana` | `grafana/grafana-env` | `yes` | `kubernetes/infra/monitoring/grafana/grafana-env.yaml` |

--- a/docs/runbooks/home-assistant.md
+++ b/docs/runbooks/home-assistant.md
@@ -11,6 +11,16 @@ last_verified: 2026-07-03
 
 Home Assistant runs as a declarative Kubernetes app from `ghcr.io/home-assistant/home-assistant:2026.7.0`. Its writable `/config` directory is backed by the `home-assistant-config` PVC on `nfs-csi-storage`; Git-owned YAML files are mounted over the runtime config files from ConfigMaps. Do not commit runtime `.storage` state.
 
+Home Information is GitOps-owned under the `homeassistant:` key in
+`configuration.yaml`, so the Home Assistant UI intentionally renders those
+fields read-only. Public regional defaults live directly in the ConfigMap:
+`country: US`, `time_zone: America/New_York`, `currency: USD`, and
+`unit_system: us_customary`. Exact home latitude, longitude, and elevation are
+loaded through `!secret` references from `/config/secrets.yaml`, which is
+mounted from the SOPS-encrypted `home-assistant-secrets` Kubernetes Secret.
+Update those location values through `kubernetes/apps/home-assistant/secret.yaml`
+and keep the manifest encrypted before staging.
+
 The production app uses Authentik OIDC through `christiaangoossens/hass-oidc-auth` pinned to `v1.1.1`, installed by the pod init container into `/config/custom_components/auth_oidc`. The Authentik blueprint creates `Home Assistant Users`, `Home Assistant Admins`, the public `home-assistant` OAuth2/OIDC provider, and the strict redirect URI `https://homeassistant.${cluster_domain}/auth/oidc/callback`.
 
 `auth_oidc` is configured in `configuration.yaml` with `default_redirect: true` and `force_https: true`. The native `homeassistant` auth provider stays enabled as a recovery login. To use that fallback while default redirect is enabled, open `https://homeassistant.${cluster_domain}/?skip_oidc_redirect=true`.

--- a/kubernetes/apps/home-assistant/branch/config/configuration.yaml
+++ b/kubernetes/apps/home-assistant/branch/config/configuration.yaml
@@ -2,6 +2,10 @@
 default_config:
 
 homeassistant:
+  unit_system: us_customary
+  currency: USD
+  country: US
+  time_zone: America/New_York
   external_url: https://homeassistant-${branch_slug}.${cluster_domain}
   internal_url: https://homeassistant-${branch_slug}.${cluster_domain}
   auth_providers:

--- a/kubernetes/apps/home-assistant/config/configuration.yaml
+++ b/kubernetes/apps/home-assistant/config/configuration.yaml
@@ -2,6 +2,15 @@
 default_config:
 
 homeassistant:
+  name: Home
+  latitude: !secret home_latitude
+  longitude: !secret home_longitude
+  elevation: !secret home_elevation
+  radius: 100
+  unit_system: us_customary
+  currency: USD
+  country: US
+  time_zone: America/New_York
   external_url: https://homeassistant.${cluster_domain}
   internal_url: https://homeassistant.${cluster_domain}
   auth_providers:

--- a/kubernetes/apps/home-assistant/deployment.yaml
+++ b/kubernetes/apps/home-assistant/deployment.yaml
@@ -84,6 +84,10 @@ spec:
               mountPath: /config/scenes.yaml
               subPath: scenes.yaml
               readOnly: true
+            - name: home-assistant-secrets
+              mountPath: /config/secrets.yaml
+              subPath: secrets.yaml
+              readOnly: true
             - name: home-assistant-packages
               mountPath: /config/packages
               readOnly: true
@@ -105,6 +109,9 @@ spec:
         - name: home-assistant-config
           configMap:
             name: home-assistant-config
+        - name: home-assistant-secrets
+          secret:
+            secretName: home-assistant-secrets
         - name: home-assistant-packages
           configMap:
             name: home-assistant-packages

--- a/kubernetes/apps/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/home-assistant/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - pvc.yaml
+  - secret.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/kubernetes/apps/home-assistant/secret.yaml
+++ b/kubernetes/apps/home-assistant/secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: home-assistant-secrets
+    namespace: home-assistant
+type: Opaque
+stringData:
+    secrets.yaml: ENC[AES256_GCM,data:NNn2GeL5Z+mcUOo/Xd6+s7KH2uRIvsPpaDmBGCszyKOmD3oveGxcFqD7u1+2EdkZ0Gh054n29Ez9G7xj5AtmTSDk3E//8VYGbZQ=,iv:BHG44NdGLywyGTENpokH1g4nxYn0G2lDkgSrqCSVzhE=,tag:fOTJ0Z72gEo4IbMhttQ1bA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWbk1QdUc4NDNhNFVuU3pY
+            NUdsNHU3VjQ2MkV1bjRiWXA1WHp6Zk8vS2d3Ci80YWIwTHU5TE5jQWlzNXZsT2w5
+            M2tsdXZQOC96N2JMQ252OFBuRzRLWTAKLS0tIGNxRVZpZi9KSThaK1hqaDJ2bm1O
+            R1QyekcwSFRrTEVyV09EVXVNSDBTNXcK2nZiUIqBhlGq0GiRB97NfHmuvJ13lzW5
+            H8nWrlmAnkc+3iMWceQPnM3wu65SohtwXzW6nNCE7EAQ4Ke4MCbS+A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-03T21:40:43Z"
+    mac: ENC[AES256_GCM,data:fIWF0fb8RToNiGEETKaAGTNiO5BHEU0v6GgmjtqJOSqMLH/E1FWtDBDztKx0LbK7i0l1/ZabKnyHv+PL98EQXvX0rcwNZnYIsjPITQwtwOPXQksW6p9Xvb7ZtNViyzMw486elJsz4WqAMXqDeQkYXiOogHur4G8zILP95tMmD8s=,iv:WOq6XQCXD+Yd8ThonxsU1eev0H6a1QSYMo3oUmic140=,tag:8EPuwmak4WVbIW4kdPiWsg==,type:str]
+    version: 3.13.0

--- a/kubernetes/clusters/production/apps/home-assistant.yaml
+++ b/kubernetes/clusters/production/apps/home-assistant.yaml
@@ -13,6 +13,10 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   dependsOn:
     - name: gateway
     - name: nfs-csi

--- a/specs/home-assistant-region/evidence.md
+++ b/specs/home-assistant-region/evidence.md
@@ -1,0 +1,64 @@
+# Evidence: home-assistant-region
+
+**Branch**: `codex/home-assistant-region`
+**Risk Tier**: high
+**Started**: 2026-07-03
+**Owner**: implementation-agent-home-assistant-region
+
+## Spec Kit Initialization
+
+- Command: Not run; repository already contains Spec Kit scaffolding.
+- Outcome: Reused existing `.specify/` templates.
+- Spec Kit version: Not changed.
+- Integration: Existing repository integration.
+- Fallback: N/A.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py ...` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_implementation_plan.py ...` | PASS | Completed before tracked edits. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner ...` | PASS | Completed before tracked edits. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `sops -d kubernetes/apps/home-assistant/secret.yaml` | PASS | Decryption succeeded; output was discarded to avoid logging secret contents. |
+| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Render includes `home-assistant-secrets`, `/config/secrets.yaml`, and US/Eastern regional settings. |
+| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Render includes non-sensitive branch regional defaults. |
+| `python3 tools/architecture/render.py --check` | PASS | Initially reported stale generated docs; passed after `python3 tools/architecture/render.py --write`. |
+| `git grep -n -E 'home_latitude:|home_longitude:|home_elevation:' -- . ':!kubernetes/apps/home-assistant/secret.yaml' ':!specs/home-assistant-region/evidence.md'` | PASS | No coordinate secret keys outside the encrypted Secret file and this evidence record. |
+| `rg -n 'home_latitude:|home_longitude:|home_elevation:' kubernetes/apps/home-assistant/secret.yaml` | PASS | Encrypted Secret does not expose inner secret keys. |
+
+## Development Validation
+
+- Profile: manual/home-assistant
+- Branch slug: home-assistant-region
+- HEAD: validation attempted against pre-evidence-amend commit `36f7988`
+- Report path: N/A
+- Cleanup: No development cluster resources were created before failure.
+- Result or exception: `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-region --slug home-assistant-region --push --timeout 600` failed during `terraform -chdir=terraform/development plan -detailed-exitcode -input=false -no-color` because required local development variables were unavailable: `pm_api_url`, `pm_api_token_id`, `pm_api_token_secret`, `github_token`, `github_user`, `docker_user`, `docker_password`, and `talos_version`. Substitute checks were SOPS decryption, production render, branch render, generated architecture check, and secret-safety scans.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/home-assistant.md`
+- Generated docs: `docs/architecture.md`
+- No-docs rationale: N/A
+
+## Exceptions And Follow-Ups
+
+- Delegated implementation ownership is unavailable in this runtime because the
+  available sub-agent tool requires explicit user authorization for spawning.
+  The user explicitly requested implementation by the current agent, and no
+  verifier approval is created by the implementation owner.
+- Development validation could not complete because required local development
+  Terraform variables/secrets were unavailable in this environment.
+
+## Final State
+
+- Final branch: `codex/home-assistant-region`
+- Final HEAD: current branch HEAD at verifier handoff, checked with `validate_sdd_context.py --head`.
+- Commit: `fix: configure home assistant region`
+- Verifier approval: not created by implementation owner

--- a/specs/home-assistant-region/evidence.md
+++ b/specs/home-assistant-region/evidence.md
@@ -31,6 +31,7 @@
 | `python3 tools/architecture/render.py --check` | PASS | Initially reported stale generated docs; passed after `python3 tools/architecture/render.py --write`. |
 | `git grep -n -E 'home_latitude:|home_longitude:|home_elevation:' -- . ':!kubernetes/apps/home-assistant/secret.yaml' ':!specs/home-assistant-region/evidence.md'` | PASS | No coordinate secret keys outside the encrypted Secret file and this evidence record. |
 | `rg -n 'home_latitude:|home_longitude:|home_elevation:' kubernetes/apps/home-assistant/secret.yaml` | PASS | Encrypted Secret does not expose inner secret keys. |
+| `PYTHONPATH=tools/agent-memory/src python3 -m agent_memory.cli lint` | PASS | Added `.codex/memory/.gitkeep` after PR CI reported `missing-root`. |
 
 ## Development Validation
 
@@ -55,6 +56,10 @@
   verifier approval is created by the implementation owner.
 - Development validation could not complete because required local development
   Terraform variables/secrets were unavailable in this environment.
+- PR CI initially failed `agent-memory-lint` because GitHub `main` no longer
+  had a tracked `.codex/memory` root after `.gitkeep` cleanup. This branch adds
+  `.codex/memory/.gitkeep` so the lint root exists without restoring old memory
+  documents.
 
 ## Final State
 

--- a/specs/home-assistant-region/plan.md
+++ b/specs/home-assistant-region/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: home-assistant-region
+
+**Branch**: `codex/home-assistant-region` | **Date**: 2026-07-03 | **Spec**:
+`specs/home-assistant-region/spec.md`
+
+**Input**: Feature specification from
+`specs/home-assistant-region/spec.md`
+
+## Summary
+
+Configure Home Assistant Home Information through GitOps YAML, keeping exact
+location values private through a SOPS-encrypted Kubernetes Secret mounted as
+`/config/secrets.yaml`.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Kubernetes, Flux, app configuration, SOPS secrets,
+documentation
+**Dependencies**: Flux, SOPS/Age, kubectl, Home Assistant YAML secrets
+**Storage**: Existing `nfs-csi-storage` PVC unchanged
+**Ingress**: Existing Gateway API routes unchanged
+**Secrets**: Add `kubernetes/apps/home-assistant/secret.yaml`, encrypted by
+SOPS
+**Development Validation**: Home Assistant branch profile where available, with
+an exception recorded if required cluster access is unavailable
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Sibling clone ownership files validated before tracked edits.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] Separate verifier approval required before PR creation.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/home-assistant-region/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/home-assistant/
+kubernetes/apps/home-assistant/branch/config/configuration.yaml
+kubernetes/clusters/production/apps/home-assistant.yaml
+docs/runbooks/home-assistant.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: This is declarative Kubernetes and app configuration.
+Focused render checks and SOPS verification are the useful local test seam; live
+development validation is required unless infrastructure is unavailable.
+
+**Local checks**:
+
+- `sops -d kubernetes/apps/home-assistant/secret.yaml`
+- `kubectl kustomize kubernetes/apps/home-assistant`
+- `kubectl kustomize kubernetes/apps/home-assistant/branch`
+- `python3 tools/architecture/render.py --check`
+
+**Development smoke**: Run
+`python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-region --slug home-assistant-region --push`
+when cluster credentials and branch deployment prerequisites are available.
+
+**Evidence destination**: `specs/home-assistant-region/evidence.md` and
+`.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+Update `docs/runbooks/home-assistant.md` to document YAML-owned Home Information
+and SOPS-backed exact location values.
+
+## Implementation Steps
+
+1. Install the staged local Home Assistant coordinate file into the
+   implementation clone without logging its contents.
+2. Create and immediately encrypt `kubernetes/apps/home-assistant/secret.yaml`.
+3. Add production YAML home information and mount `/config/secrets.yaml`.
+4. Add Flux SOPS decryption to the production Home Assistant app.
+5. Add non-sensitive regional defaults to branch configuration.
+6. Update Home Assistant runbook and verification evidence.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Plaintext coordinates are committed | Encrypt immediately with SOPS and verify `git diff` shows only encrypted payload fields |
+| Flux cannot decrypt the new Secret | Add `spec.decryption` with `sops-age` to the production app Kustomization |
+| Home Assistant cannot resolve `!secret` values | Mount the Secret key as `/config/secrets.yaml` beside `configuration.yaml` |
+| Development cluster is unavailable | Record exception and substitute SOPS and render checks |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/home-assistant-region/spec.md
+++ b/specs/home-assistant-region/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: home-assistant-region
+
+**Feature Branch**: `codex/home-assistant-region`
+**Created**: 2026-07-03
+**Status**: Draft
+**Risk Tier**: high
+**Input**: User description: "country is not set"
+
+## Summary
+
+Home Assistant should have a complete GitOps-managed home region configuration
+so the UI no longer reports that country is unset while `configuration.yaml`
+owns the Home Information settings.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/add-secret.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/sops-age-secrets.md`
+
+## Scope
+
+### In Scope
+
+- Configure production Home Assistant home information in YAML.
+- Store exact production location values in a SOPS-encrypted Kubernetes Secret.
+- Mount `/config/secrets.yaml` for Home Assistant `!secret` lookups.
+- Add Flux SOPS decryption for the production Home Assistant app.
+- Keep development branch environments on non-sensitive regional defaults.
+- Document the YAML-owned Home Information behavior.
+
+### Out Of Scope
+
+- Public Gateway or Cloudflare Tunnel exposure changes.
+- Runtime `.storage` state.
+- Home Assistant device or integration onboarding.
+
+## User Scenarios & Testing
+
+### User Story 1 - Country Is Configured (Priority: P1)
+
+As a Home Assistant operator, I want country and regional settings defined in
+GitOps so the Home Information page reflects the intended US/Eastern home setup.
+
+**Why this priority**: The UI cannot edit these fields while `configuration.yaml`
+owns the `homeassistant:` key.
+
+**Independent Test**: Render the production app and inspect the mounted
+configuration and Secret volume wiring.
+
+**Acceptance Scenarios**:
+
+1. **Given** production Home Assistant renders from GitOps, **When** the app
+   reconciles, **Then** `country: US`, `time_zone: America/New_York`,
+   `currency: USD`, and `unit_system: us_customary` are present under
+   `homeassistant:`.
+2. **Given** exact home location values are sensitive, **When** the repository is
+   reviewed, **Then** latitude, longitude, and elevation are committed only
+   inside a SOPS-encrypted Secret.
+
+## Requirements
+
+- **FR-001**: Production `configuration.yaml` MUST set Home Assistant home
+  information for US/Eastern regional behavior.
+- **FR-002**: Exact production latitude, longitude, and elevation MUST be loaded
+  through `/config/secrets.yaml` and MUST NOT be committed in plaintext.
+- **FR-003**: Flux MUST be able to decrypt the Home Assistant app Secret through
+  the existing `sops-age` mechanism.
+- **FR-004**: Branch environments MUST receive only non-sensitive regional
+  defaults unless later validation proves exact location is required.
+- **FR-005**: Evidence MUST record workflow validation, SOPS verification, local
+  render checks, and development validation or an explicit exception.
+
+## Risk And Validation Expectations
+
+**High**: Use broad local verification and development validation for the
+affected app. Record any unavailable infrastructure or credential exception with
+substitute checks.
+
+## Success Criteria
+
+- **SC-001**: Rendered production manifests include an encrypted
+  `home-assistant-secrets` Secret and a read-only `/config/secrets.yaml` mount.
+- **SC-002**: Rendered Home Assistant configuration contains the intended public
+  regional defaults and secret references for exact location values.
+- **SC-003**: `sops -d kubernetes/apps/home-assistant/secret.yaml` succeeds
+  without committing plaintext secret data.
+- **SC-004**: Development validation evidence or a documented exception is
+  recorded in `specs/home-assistant-region/evidence.md`.
+
+## Assumptions
+
+- Country is `US`, currency is `USD`, time zone is `America/New_York`, unit
+  system is `us_customary`, and radius is `100` meters.
+- Home Assistant Home Information remains YAML-owned and read-only in the UI.
+- Runtime policy blocks delegated implementation ownership in this session, so
+  the implementation owner identity records the required workflow files while no
+  verifier approval is created.
+
+## Open Questions
+
+- None.

--- a/specs/home-assistant-region/tasks.md
+++ b/specs/home-assistant-region/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: home-assistant-region
+
+**Input**: `specs/home-assistant-region/spec.md` and
+`specs/home-assistant-region/plan.md`
+**Risk Tier**: high
+**Prerequisites**: Valid workflow marker, implementation plan, owner
+attestation, and delegation token under `.codex/tmp/`
+
+## Phase 1: Workflow Setup
+
+- [x] T001 [FR-OWN] Create the sibling clone on
+      `codex/home-assistant-region`.
+- [x] T002 [FR-OWN] Create `.codex/tmp/active-implementation`,
+      `.codex/tmp/implementation-plan.yaml`,
+      `.codex/tmp/implementation-owner-attestation.yaml`, and matching
+      delegation token evidence.
+- [x] T003 [FR-OWN] Run owner workflow validators.
+
+## Phase 2: Spec And Plan
+
+- [x] T004 [FR-SPEC] Write `specs/home-assistant-region/spec.md`.
+- [x] T005 [FR-PLAN] Write `specs/home-assistant-region/plan.md`.
+- [x] T006 [FR-DOCS] Confirm documentation impact.
+
+## Phase 3: Implementation
+
+- [x] T007 [FR-002] Create and encrypt
+      `kubernetes/apps/home-assistant/secret.yaml`.
+- [x] T008 [FR-001] Update
+      `kubernetes/apps/home-assistant/config/configuration.yaml`.
+- [x] T009 [FR-002] Update
+      `kubernetes/apps/home-assistant/deployment.yaml`.
+- [x] T010 [FR-002] Update
+      `kubernetes/apps/home-assistant/kustomization.yaml`.
+- [x] T011 [FR-003] Update
+      `kubernetes/clusters/production/apps/home-assistant.yaml`.
+- [x] T012 [FR-004] Update
+      `kubernetes/apps/home-assistant/branch/config/configuration.yaml`.
+- [x] T013 [FR-DOCS] Update `docs/runbooks/home-assistant.md`.
+
+## Phase 4: Verification
+
+- [x] T014 [FR-005] Run SOPS verification.
+- [x] T015 [FR-005] Run production and branch Kustomize render checks.
+- [x] T016 [FR-005] Run generated architecture check.
+- [x] T017 [FR-005] Run development smoke validation or record exception.
+- [x] T018 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
+      and final `HEAD` in `specs/home-assistant-region/evidence.md`.
+
+## Phase 5: Commit And Handoff
+
+- [x] T019 [FR-PR] Write `.codex/tmp/pr-summary.md` from the plan and final
+      evidence.
+- [x] T020 [FR-PR] Commit with a conventional commit message.
+- [ ] T021 [FR-PR] Report exact `HEAD` and do not create verifier approval.


### PR DESCRIPTION
## Summary

- Configure Home Assistant Home Information in Git-owned YAML with US/Eastern regional defaults.
- Add SOPS-encrypted `home-assistant-secrets` mounted as `/config/secrets.yaml` for exact latitude, longitude, and elevation.
- Enable Flux SOPS decryption for the production Home Assistant app and update generated architecture docs.
- Document that Home Information is YAML-owned and read-only in the UI.

## Validation

- PASS: `sops -d kubernetes/apps/home-assistant/secret.yaml` with output discarded.
- PASS: `kubectl kustomize kubernetes/apps/home-assistant` verified `home-assistant-secrets`, `/config/secrets.yaml`, and US/Eastern regional settings.
- PASS: `kubectl kustomize kubernetes/apps/home-assistant/branch` verified non-sensitive branch regional defaults.
- PASS: `python3 tools/architecture/render.py --check` after regenerating `docs/architecture.md`.
- PASS: secret-safety scans confirmed coordinate keys are not visible outside the encrypted Secret and are not visible inside the encrypted file.
- PASS: verifier approval for exact HEAD `b181966424db7907e8a8d6b99071fe789db643a7`.
- EXCEPTION: `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-region --slug home-assistant-region --push --timeout 600` failed during Terraform plan because required local development variables/secrets were unavailable (`pm_api_url`, `pm_api_token_id`, `pm_api_token_secret`, `github_token`, `github_user`, `docker_user`, `docker_password`, `talos_version`).

## Notes

- No Cloudflare/public Gateway exposure changes.
- No runtime Home Assistant `.storage` state committed.
