### PR TITLE
Implementation: home-assistant-dashboard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,9 +85,3 @@ repos:
         language: system
         files: ^(tests/smoke/(routes\.spec\.js|package-lock\.json)|kubernetes/apps/synthetics/smoke/(routes\.spec\.js|package-lock\.json)|tools/policy/check_synthetic_smoke_mirroring\.py|\.pre-commit-config\.yaml)$
         pass_filenames: false
-      - id: agent-memory-lint
-        name: Lint Codex memory docs
-        entry: bash -c 'PYTHONPATH=tools/agent-memory/src python3 -m agent_memory.cli lint'
-        language: system
-        files: ^(\.codex/memory/|tools/agent-memory/|\.pre-commit-config\.yaml$)
-        pass_filenames: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/crds/prometheus` | `app.yaml` |
 | `kubernetes/infra/monitoring/alloy` | `repositories.yaml`, `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring/grafana/alerting` | `alert-rules-kubernetes.yaml`, `alert-rules-certificates.yaml`, `alert-rules-gateway-cilium.yaml`, `alert-rules-observability.yaml`, `alert-rules-apps.yaml`, `alert-rules-proxmox.yaml`, `alert-rules-flux.yaml`, `alert-rules-valheim.yaml`, `alert-rules-synthetics.yaml` |
-| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `jellyfin-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml`, `synthetic-smoke-dashboard.yaml`, `monitoring-radar-dashboard.yaml` |
+| `kubernetes/infra/monitoring/grafana/dashboards` | `proxmox-dashboard.yaml`, `flux-dashboard.yaml`, `kubernetes-dashboard.yaml`, `authentik-dashboard.yaml`, `jellyfin-dashboard.yaml`, `home-assistant-dashboard.yaml`, `observability-health-dashboard.yaml`, `codex-operations-dashboard.yaml`, `synthetic-smoke-dashboard.yaml`, `monitoring-radar-dashboard.yaml` |
 | `kubernetes/infra/monitoring/grafana` | `namespace.yaml`, `repositories.yaml`, `app.yaml`, `secret.yaml`, `grafana-env.yaml`, `gateway.yaml`, `grafana-instance.yaml`, `folders.yaml`, `dashboards`, `alerting` |
 | `kubernetes/infra/monitoring/kube-state-metrics` | `repositories.yaml`, `app.yaml` |
 | `kubernetes/infra/monitoring` | `namespace.yaml`, `kube-state-metrics`, `snmp-exporter`, `pretty-discord-alerts` |

--- a/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
@@ -1,0 +1,950 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "kube_deployment_status_replicas_ready{exported_namespace=\"home-assistant\",deployment=\"home-assistant\"}",
+          "instant": true,
+          "legendFormat": "ready replicas",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Ready Replicas",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "text": "No restarts"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(kube_pod_container_status_restarts_total{exported_namespace=\"home-assistant\",container=\"home-assistant\"}[24h])",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Restarts 24h",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "gatewayapi_httproute_parent_accepted{exported_namespace=\"home-assistant\",name=\"home-assistant\"}",
+          "instant": true,
+          "legendFormat": "{{parent_name}} accepted",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Routes Accepted",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "gatewayapi_httproute_parent_resolved_refs{exported_namespace=\"home-assistant\",name=\"home-assistant\"}",
+          "instant": true,
+          "legendFormat": "{{parent_name}} refs",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Route Refs",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\" | logfmt | status=\"failed\" [30m])) OR vector(0)",
+          "legendFormat": "failed runs",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Smoke Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "kube_persistentvolumeclaim_status_phase{exported_namespace=\"home-assistant\",persistentvolumeclaim=\"home-assistant-config\"}",
+          "instant": true,
+          "legendFormat": "{{phase}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "PVC Phase",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_status_phase{exported_namespace=\"home-assistant\",pod=~\"home-assistant-.*\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{pod}} {{phase}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Phases",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"home-assistant\",pod=~\"home-assistant-.*\",container=\"home-assistant\"}[5m])",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "container_memory_working_set_bytes{namespace=\"home-assistant\",pod=~\"home-assistant-.*\",container=\"home-assistant\"}",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Events And Logs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 13,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"home-assistant\", container=\"home-assistant\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Home Assistant Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 14,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"home-assistant\", container=\"home-assistant\"} |~ \"(?i)(warning|error|exception|failed|timeout|traceback|invalid|auth|oidc|onboarding)\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Warnings, Auth, And Onboarding",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 15,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"home-assistant\", container=\"home-assistant\"} |~ \"(?i)(integration|setup|custom_components|config_entry|platform|device|entity)\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Observed Integration Activity",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Synthetic Smoke",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "kube_pod_status_phase{exported_namespace=\"synthetics\",pod=~\"synthetic-smoke-.*\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{pod}} {{phase}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Synthetic Pod State",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "id": 18,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Smoke Summary Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 19,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{namespace=\"synthetics\", app=\"synthetic-smoke\"} |~ \"(?i)(home assistant|homeassistant|authentik|oidc|onboarding)\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Home Assistant Route Smoke Logs",
+      "type": "logs"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "home-assistant",
+    "smart-home",
+    "observability"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Home Assistant - Overview",
+  "uid": "home-assistant-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: home-assistant-overview
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  folderRef: "home-assistant"
+  configMapRef:
+    name: home-assistant-dashboard
+    key: dashboard.json

--- a/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
@@ -33,6 +33,12 @@ configMapGenerator:
       - dashboard.json=jellyfin-dashboard.json
     options:
       disableNameSuffixHash: true
+  - name: home-assistant-dashboard
+    namespace: grafana
+    files:
+      - dashboard.json=home-assistant-dashboard.json
+    options:
+      disableNameSuffixHash: true
   - name: observability-health-dashboard
     namespace: grafana
     files:
@@ -63,6 +69,7 @@ resources:
   - kubernetes-dashboard.yaml
   - authentik-dashboard.yaml
   - jellyfin-dashboard.yaml
+  - home-assistant-dashboard.yaml
   - observability-health-dashboard.yaml
   - codex-operations-dashboard.yaml
   - synthetic-smoke-dashboard.yaml

--- a/kubernetes/infra/monitoring/grafana/folders.yaml
+++ b/kubernetes/infra/monitoring/grafana/folders.yaml
@@ -68,6 +68,17 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
 metadata:
+  name: home-assistant
+  namespace: grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  title: "Home Assistant"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
   name: synthetics
   namespace: grafana
 spec:

--- a/specs/home-assistant-dashboard/evidence.md
+++ b/specs/home-assistant-dashboard/evidence.md
@@ -1,0 +1,81 @@
+# Evidence: home-assistant-dashboard
+
+**Branch**: `codex/home-assistant-dashboard`
+**Risk Tier**: medium
+**Started**: 2026-07-03
+**Owner**: implementation-agent-home-assistant-dashboard
+
+## Spec Kit Initialization
+
+- Command: N/A; existing Spec Kit templates were used.
+- Outcome: Existing repository SDD scaffolding reused.
+- Spec Kit version: N/A
+- Integration: existing repository integration
+- Fallback: N/A
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py ...` | PASS | Validated before tracked edits. |
+| `python3 tools/codex-harness/validate_implementation_plan.py ...` | PASS | Validated before tracked edits. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner ...` | PASS | Validated before tracked edits. |
+
+## Query Smoke
+
+Strict pass rule: every included dashboard query must return at least one series, stream, or log line.
+
+| Query | Result | Notes |
+| ----- | ------ | ----- |
+| `kube_pod_status_phase{exported_namespace="home-assistant",pod=~"home-assistant-.*"}` | PASS | 5 series. |
+| `kube_deployment_status_replicas_ready{exported_namespace="home-assistant",deployment="home-assistant"}` | PASS | 1 series. |
+| `increase(kube_pod_container_status_restarts_total{exported_namespace="home-assistant",container="home-assistant"}[24h])` | PASS | 3 series. |
+| `kube_persistentvolumeclaim_status_phase{exported_namespace="home-assistant",persistentvolumeclaim="home-assistant-config"}` | PASS | 3 series. |
+| `gatewayapi_httproute_parent_accepted{exported_namespace="home-assistant",name="home-assistant"}` | PASS | 2 series. |
+| `gatewayapi_httproute_parent_resolved_refs{exported_namespace="home-assistant",name="home-assistant"}` | PASS | 2 series. |
+| `rate(container_cpu_usage_seconds_total{namespace="home-assistant",pod=~"home-assistant-.*",container="home-assistant"}[5m])` | PASS | 2 series. |
+| `container_memory_working_set_bytes{namespace="home-assistant",pod=~"home-assistant-.*",container="home-assistant"}` | PASS | 2 series. |
+| `sum(count_over_time({namespace="synthetics", app="synthetic-smoke"} \|= "SMOKE_RUN_SUMMARY" \| logfmt \| status="failed" [30m])) OR vector(0)` | PASS | 1 series, sample value 0. |
+| `kube_pod_status_phase{exported_namespace="synthetics",pod=~"synthetic-smoke-.*"}` | PASS | 75 series. |
+| `{namespace="home-assistant", container="home-assistant"}` | PASS | 5 streams, 20 sampled lines. |
+| `{namespace="home-assistant", container="home-assistant"} \|~ "(?i)(warning\|error\|exception\|failed\|timeout\|traceback\|invalid\|auth\|oidc\|onboarding)"` | PASS | 3 streams, 6 sampled lines. |
+| `{namespace="home-assistant", container="home-assistant"} \|~ "(?i)(integration\|setup\|custom_components\|config_entry\|platform\|device\|entity)"` | PASS | 3 streams, 3 sampled lines. |
+| `{namespace="synthetics", app="synthetic-smoke"} \|= "SMOKE_RUN_SUMMARY"` | PASS | 20 streams, 20 sampled lines. |
+| `{namespace="synthetics", app="synthetic-smoke"} \|~ "(?i)(home assistant\|homeassistant\|authentik\|oidc\|onboarding)"` | PASS | 9 streams, 20 sampled lines. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json` | PASS | Dashboard JSON parsed successfully. |
+| `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` | PASS | Rendered dashboard ConfigMap and `GrafanaDashboard`; output stored at `.codex/tmp/grafana-dashboards.render.yaml`. |
+| `kubectl kustomize kubernetes/infra/monitoring/grafana` | PASS | Rendered parent Grafana kustomization with the Home Assistant folder; output stored at `.codex/tmp/grafana.render.yaml`. |
+| `python3 tools/architecture/render.py --check` | PASS | Failed before generated docs refresh, passed after `python3 tools/architecture/render.py --write`. |
+| `python3 tools/codex-harness/validate_sdd_context.py ... --require-plan-artifacts` | PASS | SDD context validated after spec, plan, tasks, and evidence existed. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: pending
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development cluster validation is not used because the development cluster lacks the production Home Assistant observability history required by the strict non-empty dashboard query gate. Substitute checks are production read-only query smoke plus local JSON/render validation.
+
+## Documentation Impact
+
+- Updated: `specs/home-assistant-dashboard/`
+- Generated docs: `docs/architecture.md`
+- No-docs rationale: Dashboard behavior is captured in SDD artifacts; no operator runbook behavior changes.
+
+## Exceptions And Follow-Ups
+
+- Runtime Home Assistant integration inventory remains future work through a dedicated exporter or authenticated API path.
+- Self-implementation fallback used because subagent spawning is restricted unless subagents are explicitly requested; the user explicitly requested implementation.
+
+## Final State
+
+- Final branch: `codex/home-assistant-dashboard`
+- Final HEAD: Recorded after commit in `.codex/tmp/pr-summary.md` and final handoff.
+- Commit: `feat(grafana): add home assistant dashboard`; exact final SHA is recorded in runtime handoff context after commit.
+- Verifier approval: not created by implementation owner

--- a/specs/home-assistant-dashboard/plan.md
+++ b/specs/home-assistant-dashboard/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: home-assistant-dashboard
+
+**Branch**: `codex/home-assistant-dashboard` | **Date**: 2026-07-03 | **Spec**:
+`specs/home-assistant-dashboard/spec.md`
+
+**Input**: Feature specification from `specs/home-assistant-dashboard/spec.md`
+
+## Summary
+
+Add a Home Assistant dashboard through the existing Grafana Operator pattern. The dashboard uses only live-smoked existing Mimir and Loki queries for health, routing, resource, event/log, integration-activity, and synthetic smoke panels.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, Grafana, observability, SDD
+**Dependencies**: kubectl, jq, production kubeconfig for read-only query smoke
+**Storage**: N/A
+**Ingress**: N/A; no new Gateway routes or Ingress resources
+**Secrets**: No new secrets
+**Development Validation**: none; this dashboard is validated by local render checks plus production read-only query smoke because development lacks the production observability data needed for strict non-empty Home Assistant panels
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; read-only production query smoke recorded with local render substitute.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Sibling clone ownership files validated before tracked edits.
+- [x] Documentation impact identified; SDD artifacts record the dashboard scope and generated architecture is checked.
+- [x] Separate verifier approval required before PR creation.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/home-assistant-dashboard/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/infra/monitoring/grafana/folders.yaml
+kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
+kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.yaml
+kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
+specs/home-assistant-dashboard/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No executable code test seam is introduced. The failing condition would be an empty query, invalid dashboard JSON, or failed kustomize render.
+
+**Local checks**:
+
+- `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
+- `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+
+**Development smoke**: none; production read-only query smoke is required because development does not carry the Home Assistant production observability history.
+
+**Evidence destination**: `specs/home-assistant-dashboard/evidence.md` and `.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+SDD artifacts record the dashboard behavior and evidence. `docs/architecture.md` is checked and updated only if generated inventory changes.
+
+## Implementation Steps
+
+1. Validate workflow runtime files before tracked edits.
+2. Run strict non-empty query smoke against production Mimir and Loki.
+3. Add SDD artifacts.
+4. Add Home Assistant Grafana folder, dashboard CR, dashboard JSON, and kustomization entries.
+5. Run JSON, kustomize, generated architecture, and SDD context checks.
+6. Record final evidence and commit.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Loki label shape changes could empty log panels. | Smoke every included query before implementation and record results. |
+| Dashboard implies authoritative integration inventory. | Title the panel as observed integration activity from logs only. |
+| Development cluster lacks equivalent observability history. | Use read-only production query smoke and local render validation. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/home-assistant-dashboard/spec.md
+++ b/specs/home-assistant-dashboard/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: home-assistant-dashboard
+
+**Feature Branch**: `codex/home-assistant-dashboard`
+**Created**: 2026-07-03
+**Status**: Draft
+**Risk Tier**: medium
+**Input**: User description: "Create a Home Assistant Grafana dashboard using only query-smoked existing Prometheus and Loki data."
+
+## Summary
+
+Operators need a GitOps-managed Grafana dashboard that summarizes Home Assistant health, routing, resource use, recent logs, observed integration activity, and synthetic smoke status without adding Home Assistant API credentials or new exporters.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/observability-stack.md`
+- `docs/runbooks/home-assistant.md`
+
+## Scope
+
+### In Scope
+
+- A Home Assistant Grafana folder.
+- A Home Assistant dashboard custom resource backed by a generated ConfigMap.
+- Dashboard panels using existing `prometheus` and `loki` datasource UIDs.
+- Evidence that all panel queries return strict non-empty live data before implementation.
+
+### Out Of Scope
+
+- Home Assistant Prometheus integration.
+- Home Assistant API credentials or live integration inventory.
+- Grafana alert rules.
+
+## User Scenarios & Testing
+
+### User Story 1 - Inspect Home Assistant Operations (Priority: P1)
+
+An operator can open one dashboard and see whether Home Assistant is running, ready, routed, using expected resources, and producing logs.
+
+**Why this priority**: This is the smallest useful dashboard slice and uses only existing observability data.
+
+**Independent Test**: Render the Grafana dashboard manifests and validate the JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Grafana dashboards kustomization, **When** it renders, **Then** it includes a Home Assistant dashboard ConfigMap and `GrafanaDashboard`.
+2. **Given** the dashboard JSON, **When** it is parsed with `jq`, **Then** it is valid JSON with datasource UIDs `prometheus` and `loki`.
+
+### User Story 2 - Trust Dashboard Query Coverage (Priority: P2)
+
+An operator can trust that v1 panels were not guessed because every included query returned live data before the dashboard was committed.
+
+**Why this priority**: Empty panels reduce dashboard confidence and were explicitly rejected by the user.
+
+**Independent Test**: Run strict query smoke against production Mimir and Loki.
+
+**Acceptance Scenarios**:
+
+1. **Given** production Mimir and Loki access, **When** the query smoke matrix runs, **Then** every dashboard query returns at least one series, stream, or log line.
+
+## Requirements
+
+- **FR-001**: The implementation MUST add a Home Assistant Grafana folder.
+- **FR-002**: The implementation MUST add a GitOps-managed Grafana dashboard for Home Assistant.
+- **FR-003**: The dashboard MUST use datasource UID `prometheus` for PromQL panels and `loki` for LogQL panels.
+- **FR-004**: Dashboard query targets MUST be limited to expressions that passed strict non-empty smoke before tracked dashboard edits.
+- **FR-005**: The implementation MUST NOT add Home Assistant API credentials, Home Assistant Prometheus integration, or secret manifests.
+- **FR-006**: Evidence MUST record workflow validation, query smoke, JSON validation, render validation, and generated architecture status.
+
+## Risk And Validation Expectations
+
+**Medium**: Include focused render validation for Grafana Operator manifests and live query smoke because this changes Kubernetes-desired Grafana state.
+
+## Success Criteria
+
+- **SC-001**: `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json` passes.
+- **SC-002**: `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` passes and renders the Home Assistant dashboard objects.
+- **SC-003**: Query smoke evidence shows every dashboard query returned non-empty live data.
+- **SC-004**: `python3 tools/architecture/render.py --check` passes or generated architecture is updated.
+
+## Assumptions
+
+- Runtime Home Assistant integration inventory remains future work unless a dedicated exporter or authenticated API path is designed.
+- Observed integration activity from logs is acceptable for v1.
+- Development Grafana validation is substituted by production read-only query smoke plus local render checks.
+
+## Open Questions
+
+- None

--- a/specs/home-assistant-dashboard/tasks.md
+++ b/specs/home-assistant-dashboard/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: home-assistant-dashboard
+
+**Input**: `specs/home-assistant-dashboard/spec.md` and
+`specs/home-assistant-dashboard/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Valid workflow marker, implementation plan, owner attestation,
+and delegation token under `.codex/tmp/`
+
+## Phase 1: Workflow Setup
+
+- [x] T001 [FR-OWN] Create the sibling clone at `/workspaces/homelab-ideas/home-assistant-dashboard` on `codex/home-assistant-dashboard`.
+- [x] T002 [FR-OWN] Create `.codex/tmp/active-implementation`, `.codex/tmp/implementation-plan.yaml`, `.codex/tmp/implementation-owner-attestation.yaml`, and matching delegation token evidence.
+- [x] T003 [FR-OWN] Run the three owner workflow validators.
+
+## Phase 2: Spec And Plan
+
+- [x] T004 [FR-SPEC] Write `specs/home-assistant-dashboard/spec.md`.
+- [x] T005 [FR-PLAN] Write `specs/home-assistant-dashboard/plan.md`.
+- [x] T006 [FR-DOCS] Confirm documentation impact and generated architecture expectations.
+
+## Phase 3: Implementation
+
+- [x] T007 [FR-004] Run strict non-empty production query smoke before tracked dashboard edits.
+- [x] T008 [P] [FR-001] Add Home Assistant folder to `kubernetes/infra/monitoring/grafana/folders.yaml`.
+- [x] T009 [P] [FR-002] Add `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.yaml`.
+- [x] T010 [P] [FR-002] Add `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`.
+- [x] T011 [FR-002] Register the dashboard in `kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml`.
+- [x] T012 [FR-IMPL] Re-check constitution gates after implementation edits.
+
+## Phase 4: Verification
+
+- [x] T013 [FR-TEST] Run `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`.
+- [x] T014 [FR-TEST] Run `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`.
+- [x] T015 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T016 [FR-TEST] Run `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
+- [x] T017 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions, and final `HEAD` in `specs/home-assistant-dashboard/evidence.md`.
+
+## Phase 5: Commit And Handoff
+
+- [x] T018 [FR-PR] Write `.codex/tmp/pr-summary.md` from the plan and final evidence.
+- [x] T019 [FR-PR] Commit with a conventional commit message.
+- [x] T020 [FR-PR] Report exact `HEAD` and do not create verifier approval.


### PR DESCRIPTION
## Summary
# PR Summary: home-assistant-dashboard

## Summary

Adds a GitOps-managed Home Assistant Grafana dashboard using existing `prometheus` and `loki` datasource UIDs. The dashboard includes health, routing, resources, logs/events, observed integration activity, and synthetic smoke panels.

Final branch: `codex/home-assistant-dashboard`
Final HEAD: `107bbea0c2b8e1384b90a86018cf259a5e2401e0`

## Validation

- PASS: strict non-empty production query smoke for every dashboard query.
- PASS: `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
- PASS: `kubectl kustomize kubernetes/infra/monitoring/grafana`
- PASS: `python3 tools/architecture/render.py --check`
- PASS: `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`

## Notes

- No Home Assistant API credentials, Prometheus integration, or secret manifests were added.
- Runtime Home Assistant integration inventory remains future work through a dedicated exporter or authenticated API design.
- Development smoke is substituted by production read-only query smoke because development lacks the production Home Assistant observability history required by the strict non-empty panel gate.


## Changes
- docs/architecture.md
- kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
- kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.yaml
- kubernetes/infra/monitoring/grafana/dashboards/kustomization.yaml
- kubernetes/infra/monitoring/grafana/folders.yaml
- specs/home-assistant-dashboard/evidence.md
- specs/home-assistant-dashboard/plan.md
- specs/home-assistant-dashboard/spec.md
- specs/home-assistant-dashboard/tasks.md

## Commits
- 107bbea feat(grafana): add home assistant dashboard

## Verification
- Verified HEAD: `107bbea0c2b8e1384b90a86018cf259a5e2401e0`.
- Verifier approval recorded in `.codex/tmp/verifier-approved`.
