### PR TITLE
[codex] adopt spec kit worktree workflow

### DIFF
--- a/.codex/agents/repo_migration_worker.toml
+++ b/.codex/agents/repo_migration_worker.toml
@@ -11,7 +11,7 @@ Follow the canonical repository workflow instead of this prompt:
 - docs/decisions/*
 - tools/codex-harness/
 
-Use the assigned sibling clone and implementation identity from the user request.
-Keep changes narrow, preserve unrelated work, record SDD artifacts and evidence,
-and do not create verifier approval for your own implementation.
+Use the assigned worktree, clone, or checkout and implementation identity from
+the user request. Keep changes narrow, preserve unrelated work, and record SDD
+artifacts and evidence.
 """

--- a/.codex/hooks/implementation_workflow_guard.sh
+++ b/.codex/hooks/implementation_workflow_guard.sh
@@ -6,92 +6,69 @@ cd "$root"
 
 payload="$(cat || true)"
 state_file=".codex/tmp/implementation-workflow-guard-state"
+branch="$(git branch --show-current)"
+
 if [[ "${1:-}" == "--record" ]]; then
   mkdir -p .codex/tmp
   {
-    printf 'branch=%s\n' "$(git branch --show-current)"
+    printf 'branch=%s\n' "$branch"
     printf 'head=%s\n' "$(git rev-parse HEAD)"
   } >"$state_file"
   exit 0
 fi
 
-marker=".codex/tmp/active-implementation"
-plan=".codex/tmp/implementation-plan.yaml"
-owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
-marker_validator="tools/codex-harness/validate_active_implementation.py"
-plan_validator="tools/codex-harness/validate_implementation_plan.py"
-attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
-sdd_validator="tools/codex-harness/validate_sdd_context.py"
-branch="$(git branch --show-current)"
-
 fail() {
   {
-    printf 'Implementation workflow guard: refusing tracked-file changes outside an active implementation.\n'
+    printf 'Spec Kit workflow guard: refusing tracked-file changes outside an active Spec Kit branch.\n'
     printf '%s\n' "$1"
     printf '\nRequired workflow:\n'
-    printf '  1. Clone https://github.com/petebeegle/homelab.git into /workspaces/homelab-ideas/<implementation>.\n'
-    printf '  2. Create codex/<implementation> from origin/main.\n'
-    printf '  3. Record %s with implementation, branch, base, role=implementation, clone_path, owner_role=implementation-agent, and owner_agent.\n' "$marker"
-    printf '  4. Record %s with implementation identity, scope, planned changes, docs impact, tests, verification, and risks.\n' "$plan"
-    printf '  5. Record %s with role=implementation-agent, agent_id matching owner_agent, clone identity, and created_at.\n' "$owner_attestation"
-    printf '  6. Create durable specs/<implementation>/spec.md, plan.md, tasks.md, and evidence.md from the Spec Kit templates.\n'
-    printf '  7. Make tracked-file changes only inside that sibling clone.\n'
+    printf '  1. Use a worktree by default: git worktree add /workspaces/homelab-worktrees/<implementation> -b codex/<implementation> origin/main\n'
+    printf '  2. Make tracked edits only on branch codex/<implementation>.\n'
+    printf '  3. Keep durable Spec Kit artifacts in specs/<implementation>/.\n'
+    printf '  4. After bootstrap, spec.md, plan.md, and tasks.md must be non-empty.\n'
+    printf '  5. Before push or PR automation, evidence.md must be non-empty.\n'
   } >&2
   exit 1
 }
 
-validate_workflow_base() {
+implementation_from_branch() {
+  [[ "$branch" =~ ^codex/.+ ]] || return 1
+  printf '%s\n' "${branch#codex/}"
+}
+
+validate_branch() {
   if [[ "$branch" == "main" ]]; then
     fail "Current branch is main."
   fi
-
   if [[ ! "$branch" =~ ^codex/.+ ]]; then
     fail "Current branch '$branch' does not match codex/<implementation>."
   fi
+}
 
-  if [[ ! -f "$marker" ]]; then
-    fail "Missing $marker."
-  fi
-
-  if ! python3 "$marker_validator" --marker "$marker" --root "$root" --branch "$branch"; then
-    fail "Active implementation marker validation failed."
-  fi
-
-  if [[ ! -f "$plan" ]]; then
-    fail "Missing $plan."
-  fi
-
-  if ! python3 "$plan_validator" --plan "$plan" --marker "$marker" --root "$root" --branch "$branch"; then
-    fail "Implementation plan validation failed."
-  fi
-
-  if [[ ! -f "$owner_attestation" ]]; then
-    fail "Missing $owner_attestation."
-  fi
-
-  if ! python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch"; then
-    fail "Implementation owner attestation validation failed."
+require_sdd_artifact() {
+  local path="$1"
+  if [[ ! -s "$path" ]]; then
+    fail "Missing required SDD artifact: $path"
   fi
 }
 
 validate_sdd_context() {
-  if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts; then
-    fail "SDD context validation failed."
-  fi
+  validate_branch
+  local implementation
+  implementation="$(implementation_from_branch)"
+  require_sdd_artifact "specs/$implementation/spec.md"
+  require_sdd_artifact "specs/$implementation/plan.md"
+  require_sdd_artifact "specs/$implementation/tasks.md"
 }
 
 validate_sdd_evidence() {
-  if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"; then
-    fail "SDD evidence validation failed."
-  fi
-}
-
-validate_workflow() {
-  validate_workflow_base
   validate_sdd_context
+  local implementation
+  implementation="$(implementation_from_branch)"
+  require_sdd_artifact "specs/$implementation/evidence.md"
 }
 
-payload_mentions_verifier_evidence() {
+payload_mentions_evidence_path() {
   PAYLOAD="$payload" python3 - <<'PY'
 import json
 import os
@@ -117,13 +94,11 @@ def walk(value):
 
 walk(data)
 text = "\n".join(haystacks)
-if re.search(r"(?:/workspaces/homelab-ideas/[^/\s]+/)?\.codex/tmp/(?:verifier-approved|verifier-attestation\.yaml)", text):
-    sys.exit(0)
-sys.exit(1)
+sys.exit(0 if re.search(r"specs/[^/\s]+/evidence\.md", text) else 1)
 PY
 }
 
-is_sdd_bootstrap_payload() {
+is_allowed_tmp_payload() {
   PAYLOAD="$payload" python3 - <<'PY'
 import json
 import os
@@ -149,146 +124,136 @@ def walk(value):
 
 walk(data)
 text = "\n".join(haystacks)
-paths = set(re.findall(r"(?:/workspaces/homelab-ideas/[^/\s]+/)?specs/([^/\s]+)/((?:spec|plan|tasks|evidence)\.md)", text))
-if paths:
-    implementations = {implementation for implementation, _ in paths}
-    files = {name for _, name in paths}
-    if len(implementations) == 1 and files <= {"spec.md", "plan.md", "tasks.md", "evidence.md"}:
-        sys.exit(0)
-sys.exit(1)
+paths = set(re.findall(r"(?:^|[\s\"'])((?:/[^/\s]+)*/?\.codex/tmp/repo-change-intent)(?:$|[\s\"'])", text))
+sys.exit(0 if paths else 1)
 PY
+}
+
+is_sdd_payload() {
+  PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+import re
+import sys
+
+payload = os.environ.get("PAYLOAD", "")
+haystacks = [payload]
+try:
+    data = json.loads(payload) if payload.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+def walk(value):
+    if isinstance(value, str):
+        haystacks.append(value)
+    elif isinstance(value, dict):
+        for nested in value.values():
+            walk(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            walk(nested)
+
+walk(data)
+text = "\n".join(haystacks)
+paths = set(re.findall(r"(?:/workspaces/[^/\s]+/[^/\s]+/)?specs/([^/\s]+)/((?:spec|plan|tasks|evidence)\.md)", text))
+if not paths:
+    sys.exit(1)
+implementations = {implementation for implementation, _ in paths}
+sys.exit(0 if len(implementations) == 1 else 1)
+PY
+}
+
+sdd_artifacts_absent_from_head() {
+  validate_branch
+  local implementation
+  implementation="$(implementation_from_branch)"
+  local tracked_at_head
+  tracked_at_head="$(
+    git ls-tree -r --name-only HEAD "specs/$implementation" 2>/dev/null || true
+  )"
+  [[ -z "$tracked_at_head" ]]
 }
 
 tracked_changes_are_sdd_bootstrap() {
-  python3 - "$branch" <<'PY'
-import subprocess
+  validate_branch
+  local implementation
+  implementation="$(implementation_from_branch)"
+  TRACKED_CHANGES="$(git status --porcelain --untracked-files=no)" IMPLEMENTATION="$implementation" python3 - <<'PY'
+import os
 import sys
 
-branch = sys.argv[1]
-if not branch.startswith("codex/"):
-    sys.exit(1)
-implementation = branch.split("/", 1)[1]
+implementation = os.environ["IMPLEMENTATION"]
 allowed = {
     f"specs/{implementation}/spec.md",
     f"specs/{implementation}/plan.md",
     f"specs/{implementation}/tasks.md",
     f"specs/{implementation}/evidence.md",
 }
-result = subprocess.run(
-    ["git", "status", "--porcelain", "--untracked-files=no"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.DEVNULL,
-    text=True,
-    check=False,
-)
 paths = []
-for line in result.stdout.splitlines():
+for line in os.environ.get("TRACKED_CHANGES", "").splitlines():
     path = line[3:]
     if " -> " in path:
         path = path.split(" -> ", 1)[1]
     paths.append(path)
-
-tracked_at_head = subprocess.run(
-    ["git", "ls-tree", "-r", "--name-only", "HEAD", f"specs/{implementation}"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.DEVNULL,
-    text=True,
-    check=False,
-)
-
-if paths and set(paths) <= allowed and not tracked_at_head.stdout.strip():
-    sys.exit(0)
-sys.exit(1)
+sys.exit(0 if paths and set(paths) <= allowed else 1)
 PY
 }
 
-sdd_artifacts_absent_from_head() {
-  python3 - "$branch" <<'PY'
-import subprocess
-import sys
-
-branch = sys.argv[1]
-if not branch.startswith("codex/"):
-    sys.exit(1)
-implementation = branch.split("/", 1)[1]
-result = subprocess.run(
-    ["git", "ls-tree", "-r", "--name-only", "HEAD", f"specs/{implementation}"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.DEVNULL,
-    text=True,
-    check=False,
-)
-sys.exit(0 if not result.stdout.strip() else 1)
-PY
-}
-
-if [[ "${1:-}" == "--preflight-mutation" ]]; then
-  if PAYLOAD="$payload" python3 - <<'PY'
-import json
-import os
-import re
-import sys
-
-payload = os.environ.get("PAYLOAD", "")
-allowed = {
-    ".codex/tmp/active-implementation",
-    ".codex/tmp/implementation-plan.yaml",
-    ".codex/tmp/implementation-owner-attestation.yaml",
-    ".codex/tmp/repo-change-intent",
-}
-
-haystacks = [payload]
-try:
-    data = json.loads(payload) if payload.strip() else {}
-except json.JSONDecodeError:
-    data = {}
-
-def walk(value):
-    if isinstance(value, str):
-        haystacks.append(value)
-    elif isinstance(value, dict):
-        for nested in value.values():
-            walk(nested)
-    elif isinstance(value, list):
-        for nested in value:
-            walk(nested)
-
-walk(data)
-text = "\n".join(haystacks)
-
-paths = set(re.findall(r"(?:/workspaces/homelab-ideas/[^/\s]+/)?\.codex/tmp/(?:active-implementation|implementation-plan\.yaml|implementation-owner-attestation\.yaml|repo-change-intent)", text))
-normalized = {path[path.index(".codex/tmp/") :] for path in paths}
-
-if normalized and normalized <= allowed:
-    # Allow bootstrapping the local workflow artifacts that make validation possible.
-    sys.exit(0)
-sys.exit(1)
-PY
-  then
-    exit 0
-  fi
-  if is_sdd_bootstrap_payload && sdd_artifacts_absent_from_head; then
-    validate_workflow_base
-    exit 0
-  fi
-  if payload_mentions_verifier_evidence; then
-    validate_workflow_base
-    validate_sdd_evidence
-    exit 0
-  fi
-  validate_workflow
-  exit 0
-fi
-
-if [[ "${1:-}" == "--preflight-bash" ]]; then
-  if PAYLOAD="$payload" ROOT="$root" python3 - <<'PY'
+command_is_allowed_worktree_setup() {
+  PAYLOAD="$payload" ROOT="$root" python3 - <<'PY'
 import json
 import os
 import shlex
 import sys
 
 payload = os.environ.get("PAYLOAD", "")
-root = os.environ.get("ROOT", "")
+try:
+    data = json.loads(payload) if payload.strip() else {}
+except json.JSONDecodeError:
+    data = {}
+
+values = []
+for key in ("command", "input", "tool_input"):
+    value = data.get(key)
+    if isinstance(value, str):
+        values.append(value)
+    elif isinstance(value, dict):
+        for nested in ("command", "cmd"):
+            if isinstance(value.get(nested), str):
+                values.append(value[nested])
+
+for value in values:
+    try:
+        lexer = shlex.shlex(value, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        continue
+
+    if tokens[:2] == ["mkdir", "-p"] and len(tokens) == 3:
+        if tokens[2] in {"/workspaces/homelab-worktrees", "/workspaces/homelab-ideas"}:
+            sys.exit(0)
+
+    if len(tokens) >= 7 and tokens[:3] == ["git", "worktree", "add"]:
+        destination = tokens[3]
+        if destination.startswith(("/workspaces/homelab-worktrees/", "/workspaces/homelab-ideas/")):
+            if "-b" in tokens:
+                branch_index = tokens.index("-b") + 1
+                if branch_index < len(tokens) and tokens[branch_index].startswith("codex/") and "origin/main" in tokens:
+                    sys.exit(0)
+
+sys.exit(1)
+PY
+}
+
+payload_has_mutating_command() {
+  PAYLOAD="$payload" python3 - <<'PY'
+import json
+import os
+import shlex
+import sys
+
+payload = os.environ.get("PAYLOAD", "")
 try:
     data = json.loads(payload) if payload.strip() else {}
 except json.JSONDecodeError:
@@ -322,6 +287,7 @@ mutating_commands = {
     "terraform",
     "touch",
 }
+safe_git = {"branch", "diff", "log", "rev-parse", "show", "status"}
 mutating_git = {
     "add",
     "am",
@@ -338,11 +304,10 @@ mutating_git = {
     "reset",
     "restore",
     "revert",
-    "rm",
     "switch",
     "tag",
+    "worktree",
 }
-safe_git = {"branch", "diff", "log", "rev-parse", "show", "status"}
 mutating_terraform = {"apply", "destroy", "fmt", "import", "init", "taint", "untaint", "workspace"}
 separators = {";", "&&", "||", "|"}
 
@@ -371,22 +336,8 @@ for value in values:
             subcommand = next((arg for arg in args if not arg.startswith("-")), "")
             if subcommand in safe_git:
                 continue
-            if subcommand == "clone" and any(arg == "https://github.com/petebeegle/homelab.git" for arg in args) and any(
-                arg.startswith("/workspaces/homelab-ideas/") for arg in args
-            ):
-                continue
-            if (
-                root.startswith("/workspaces/homelab-ideas/")
-                and subcommand in {"switch", "checkout"}
-                and any(arg == "-c" or arg == "-b" for arg in args)
-                and any(arg.startswith("codex/") for arg in args)
-                and any(arg == "origin/main" for arg in args)
-            ):
-                continue
             if subcommand in mutating_git or subcommand:
                 sys.exit(0)
-        elif command == "mkdir" and args == ["-p", ".codex/tmp"]:
-            continue
         elif command == "terraform":
             subcommand = next((arg for arg in args if not arg.startswith("-chdir")), "")
             if subcommand in mutating_terraform:
@@ -398,13 +349,29 @@ for value in values:
 
 sys.exit(1)
 PY
-  then
-    if payload_mentions_verifier_evidence; then
-      validate_workflow_base
-      validate_sdd_evidence
-    else
-      validate_workflow
-    fi
+}
+
+if [[ "${1:-}" == "--preflight-mutation" ]]; then
+  if is_allowed_tmp_payload; then
+    exit 0
+  fi
+  if is_sdd_payload && sdd_artifacts_absent_from_head; then
+    exit 0
+  fi
+  if payload_mentions_evidence_path; then
+    validate_sdd_context
+  else
+    validate_sdd_context
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "--preflight-bash" ]]; then
+  if command_is_allowed_worktree_setup; then
+    exit 0
+  fi
+  if payload_has_mutating_command; then
+    validate_sdd_context
   fi
   exit 0
 fi
@@ -420,9 +387,8 @@ if [[ -z "$tracked_changes" && "$head_before" == "$head_now" ]]; then
   exit 0
 fi
 
-if tracked_changes_are_sdd_bootstrap; then
-  validate_workflow_base
+if tracked_changes_are_sdd_bootstrap && sdd_artifacts_absent_from_head; then
   exit 0
 fi
 
-validate_workflow
+validate_sdd_context

--- a/.codex/hooks/user_prompt_submit.sh
+++ b/.codex/hooks/user_prompt_submit.sh
@@ -83,5 +83,12 @@ mkdir -p .codex/tmp
 } >.codex/tmp/repo-change-intent
 
 cat <<'EOF'
-Implementation workflow reminder: tracked repository changes require a delegated implementation-agent-* owner, a separate verifier-agent-* reviewer, matching delegation token evidence, and exact-HEAD verifier approval before push or PR creation.
+Spec Kit workflow reminder: tracked repository changes default to a dedicated worktree.
+
+Use:
+  git fetch origin
+  git worktree add /workspaces/homelab-worktrees/<implementation> -b codex/<implementation> origin/main
+
+Then run the Spec Kit cycle in that worktree: specify -> plan -> tasks -> implement.
+Use the current checkout only when explicitly requested or for read-only/planning work.
 EOF

--- a/.codex/hooks/verifier_push_guard.sh
+++ b/.codex/hooks/verifier_push_guard.sh
@@ -34,81 +34,39 @@ if [[ "$remote_name" != "origin" ]]; then
   exit 0
 fi
 
+branch="$(git branch --show-current)"
 head_sha="$(git rev-parse HEAD)"
-approval_file=".codex/tmp/verifier-approved"
-attestation_file=".codex/tmp/verifier-attestation.yaml"
-marker=".codex/tmp/active-implementation"
-plan=".codex/tmp/implementation-plan.yaml"
-owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
-marker_validator="tools/codex-harness/validate_active_implementation.py"
-plan_validator="tools/codex-harness/validate_implementation_plan.py"
-attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
-sdd_validator="tools/codex-harness/validate_sdd_context.py"
-push_updates="$(cat || true)"
 
-allow_smoke_push() {
-  local branch
-  branch="$(git branch --show-current)"
-  [[ "$branch" =~ ^codex/.+ ]] || return 1
-  [[ -n "$push_updates" ]] || return 1
-
-  if ! PUSH_UPDATES="$push_updates" BRANCH="$branch" HEAD_SHA="$head_sha" python3 - <<'PY'
-import os
-import sys
-
-branch = os.environ["BRANCH"]
-head = os.environ["HEAD_SHA"]
-updates = [line.split() for line in os.environ.get("PUSH_UPDATES", "").splitlines() if line.strip()]
-if not updates:
-    sys.exit(1)
-
-remote_ref = f"refs/heads/{branch}"
-for fields in updates:
-    if len(fields) != 4:
-        sys.exit(1)
-    local_ref, local_oid, pushed_remote_ref, _remote_oid = fields
-    if pushed_remote_ref != remote_ref:
-        sys.exit(1)
-    if local_oid != head:
-        sys.exit(1)
-    if local_ref not in {"HEAD", remote_ref}:
-        sys.exit(1)
-sys.exit(0)
-PY
-  then
-    return 1
-  fi
-
-  python3 "$marker_validator" --marker "$marker" --root "$root" --branch "$branch" || return 1
-  python3 "$plan_validator" --plan "$plan" --marker "$marker" --root "$root" --branch "$branch" || return 1
-  python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch" || return 1
-  python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts || return 1
-  return 0
+fail() {
+  {
+    printf 'Spec Kit push guard: refusing to push to origin.\n'
+    printf '%s\n' "$1"
+  } >&2
+  exit 1
 }
 
-if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
-  if allow_smoke_push; then
-    exit 0
+if [[ "$branch" == "main" ]]; then
+  fail "Current branch is main."
+fi
+
+if [[ ! "$branch" =~ ^codex/.+ ]]; then
+  fail "Current branch '$branch' does not match codex/<implementation>."
+fi
+
+implementation="${branch#codex/}"
+for artifact in spec.md plan.md tasks.md evidence.md; do
+  if [[ ! -s "specs/$implementation/$artifact" ]]; then
+    fail "Missing required SDD artifact: specs/$implementation/$artifact"
   fi
-  {
-    printf 'Verifier push guard: refusing to push to origin.\n'
-    printf 'Expected %s to contain the exact HEAD SHA:\n' "$approval_file"
-    printf '  %s\n' "$head_sha"
-    printf 'Run verifier-agent review, resolve any blockers, then record approval for the exact HEAD before pushing.\n'
-  } >&2
-  exit 1
-fi
+done
 
-if [[ ! -f "$attestation_file" ]]; then
-  {
-    printf 'Verifier push guard: refusing to push to origin.\n'
-    printf 'Expected %s to contain verifier identity and exact approved_head:\n' "$attestation_file"
-    printf '  %s\n' "$head_sha"
-  } >&2
-  exit 1
-fi
-
-if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --marker "$marker" --owner-attestation "$owner_attestation" --head "$head_sha" --root "$root" --branch "$(git branch --show-current)"; then
-  printf 'Verifier push guard: verifier attestation validation failed.\n' >&2
-  exit 1
+if ! python3 tools/codex-harness/validate_sdd_context.py \
+  --root "$root" \
+  --branch "$branch" \
+  --require-plan-artifacts \
+  --require-evidence \
+  --head "$head_sha" \
+  2>/tmp/spec-kit-push-guard.err; then
+  cat /tmp/spec-kit-push-guard.err >&2
+  fail "SDD evidence validation failed."
 fi

--- a/.codex/scripts/codex_observe.py
+++ b/.codex/scripts/codex_observe.py
@@ -102,14 +102,6 @@ def safe_labels(*, payload: bytes, root: Path, phase: str, hook: str) -> dict[st
 
 
 def implementation_name(*, root: Path, branch: str) -> str:
-    marker = root / ".codex" / "tmp" / "active-implementation"
-    if marker.exists():
-        try:
-            for line in marker.read_text(encoding="utf-8").splitlines():
-                if line.startswith("implementation="):
-                    return line.split("=", 1)[1].strip() or "unknown"
-        except OSError:
-            pass
     if branch.startswith("codex/"):
         return branch.split("/", 1)[1]
     return "unknown"

--- a/.codex/scripts/create_implementation_pr.sh
+++ b/.codex/scripts/create_implementation_pr.sh
@@ -14,104 +14,53 @@ if [[ ! "$branch" =~ ^codex/.+ ]]; then
   if ((auto)); then
     exit 0
   fi
-  printf 'Implementation PR: current branch must match codex/<implementation>, got %s.\n' "$branch" >&2
-  exit 1
-fi
-
-head_sha="$(git rev-parse HEAD)"
-approval_file=".codex/tmp/verifier-approved"
-attestation_file=".codex/tmp/verifier-attestation.yaml"
-if [[ ! -f "$approval_file" ]] || ! grep -Fxq "$head_sha" "$approval_file"; then
-  {
-    printf 'Implementation PR: verifier approval is missing for exact HEAD.\n'
-    printf 'Expected %s to contain:\n' "$approval_file"
-    printf '  %s\n' "$head_sha"
-  } >&2
-  exit 1
-fi
-
-if [[ ! -f "$attestation_file" ]]; then
-  {
-    printf 'Implementation PR: verifier attestation is missing for exact HEAD.\n'
-    printf 'Expected %s with approved_head:\n' "$attestation_file"
-    printf '  %s\n' "$head_sha"
-  } >&2
-  exit 1
-fi
-
-marker=".codex/tmp/active-implementation"
-plan=".codex/tmp/implementation-plan.yaml"
-owner_attestation=".codex/tmp/implementation-owner-attestation.yaml"
-if [[ ! -f "$marker" ]]; then
-  printf 'Implementation PR: missing %s.\n' "$marker" >&2
-  exit 1
-fi
-
-validator="tools/codex-harness/validate_active_implementation.py"
-plan_validator="tools/codex-harness/validate_implementation_plan.py"
-attestation_validator="tools/codex-harness/validate_workflow_attestations.py"
-sdd_validator="tools/codex-harness/validate_sdd_context.py"
-if ! python3 "$validator" --marker "$marker" --root "$root" --branch "$branch"; then
-  printf 'Implementation PR: active implementation marker does not match this checkout.\n' >&2
-  exit 1
-fi
-
-if [[ ! -f "$plan" ]]; then
-  printf 'Implementation PR: missing %s.\n' "$plan" >&2
-  exit 1
-fi
-
-if ! python3 "$plan_validator" --plan "$plan" --marker "$marker" --root "$root" --branch "$branch"; then
-  printf 'Implementation PR: implementation plan validation failed.\n' >&2
-  exit 1
-fi
-
-if [[ ! -f "$owner_attestation" ]]; then
-  printf 'Implementation PR: missing %s.\n' "$owner_attestation" >&2
-  exit 1
-fi
-
-if ! python3 "$attestation_validator" --kind owner --attestation "$owner_attestation" --marker "$marker" --plan "$plan" --root "$root" --branch "$branch"; then
-  printf 'Implementation PR: implementation owner attestation validation failed.\n' >&2
-  exit 1
-fi
-
-if ! python3 "$sdd_validator" --marker "$marker" --root "$root" --branch "$branch" --require-plan-artifacts --require-evidence --head "$head_sha"; then
-  printf 'Implementation PR: SDD evidence validation failed.\n' >&2
-  exit 1
-fi
-
-if ! python3 "$attestation_validator" --kind verifier --attestation "$attestation_file" --marker "$marker" --owner-attestation "$owner_attestation" --head "$head_sha" --root "$root" --branch "$branch"; then
-  printf 'Implementation PR: verifier attestation validation failed.\n' >&2
+  printf 'Spec Kit PR: current branch must match codex/<implementation>, got %s.\n' "$branch" >&2
   exit 1
 fi
 
 implementation="${branch#codex/}"
+head_sha="$(git rev-parse HEAD)"
+
+for artifact in spec.md plan.md tasks.md evidence.md; do
+  if [[ ! -s "specs/$implementation/$artifact" ]]; then
+    printf 'Spec Kit PR: missing required SDD artifact: specs/%s/%s.\n' "$implementation" "$artifact" >&2
+    exit 1
+  fi
+done
+
+if ! python3 tools/codex-harness/validate_sdd_context.py \
+  --root "$root" \
+  --branch "$branch" \
+  --require-plan-artifacts \
+  --require-evidence \
+  --head "$head_sha"; then
+  printf 'Spec Kit PR: SDD evidence validation failed.\n' >&2
+  exit 1
+fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
-  printf 'Implementation PR: working tree must be clean before creating a PR.\n' >&2
+  printf 'Spec Kit PR: working tree must be clean before creating a PR.\n' >&2
   exit 1
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
-  printf 'Implementation PR: gh is required to create the pull request.\n' >&2
+  printf 'Spec Kit PR: gh is required to create the pull request.\n' >&2
   exit 1
 fi
 
 title="Implementation: ${implementation}"
 commit_summary="$(git log --oneline origin/main..HEAD)"
 changed_files="$(git diff --name-only origin/main..HEAD)"
-plan_summary_file=".codex/tmp/pr-summary.md"
 body="$(mktemp)"
 trap 'rm -f "$body"' EXIT
 
 {
   printf '## Summary\n'
-  if [[ -s "$plan_summary_file" ]]; then
-    cat "$plan_summary_file"
+  if [[ -s "specs/$implementation/evidence.md" ]]; then
+    sed -n '1,120p' "specs/$implementation/evidence.md"
     printf '\n'
   else
-    printf 'Implements the `%s` implementation plan. Changes are isolated on `%s`, verified at `%s`, and ready for review.\n' "$implementation" "$branch" "$head_sha"
+    printf 'Implements the `%s` Spec Kit plan on `%s`.\n' "$implementation" "$branch"
   fi
   printf '\n## Changes\n'
   if [[ -n "$changed_files" ]]; then
@@ -126,19 +75,9 @@ trap 'rm -f "$body"' EXIT
     printf '%s\n' '- No commits found relative to origin/main.'
   fi
   printf '\n## Verification\n'
-  printf '%s\n' "- Verified HEAD: \`$head_sha\`."
-  printf '%s\n' "- Verifier approval recorded in \`$approval_file\`."
+  printf '%s\n' "- Spec Kit evidence: \`specs/$implementation/evidence.md\`."
+  printf '%s\n' "- HEAD: \`$head_sha\`."
 } >"$body"
 
 git push -u origin "$branch"
 gh pr create --base main --head "$branch" --title "$title" --body-file "$body"
-
-parent="$(dirname "$root")"
-expected_parent="/workspaces/homelab-ideas"
-if [[ "$parent" != "$expected_parent" ]]; then
-  printf 'Implementation PR: refusing to delete clone outside %s: %s\n' "$expected_parent" "$root" >&2
-  exit 1
-fi
-
-cd "$parent"
-rm -rf -- "$root"

--- a/.codex/scripts/prepare_development_smoke_secrets.sh
+++ b/.codex/scripts/prepare_development_smoke_secrets.sh
@@ -4,10 +4,10 @@ umask 077
 
 usage() {
   {
-    printf 'Usage: %s <implementation> [clone-path ...]\n' "${0##*/}"
+    printf 'Usage: %s <implementation> [checkout-path ...]\n' "${0##*/}"
     printf '\n'
-    printf 'Stages terraform/development/terraform.tfvars from this checkout and installs it into implementation or verifier clones before development smoke.\n'
-    printf 'When no clone path is provided, installs into /workspaces/homelab-ideas/<implementation>.\n'
+    printf 'Stages terraform/development/terraform.tfvars from this checkout and installs it into implementation worktrees or clones before development smoke.\n'
+    printf 'When no path is provided, installs into /workspaces/homelab-worktrees/<implementation>.\n'
   } >&2
 }
 
@@ -44,15 +44,15 @@ if ! git check-ignore -q -- "$tfvars_path"; then
   fail "refusing non-ignored file: $tfvars_path"
 fi
 
-clones=("$@")
-if [[ ${#clones[@]} -eq 0 ]]; then
-  clones=("/workspaces/homelab-ideas/$implementation")
+checkouts=("$@")
+if [[ ${#checkouts[@]} -eq 0 ]]; then
+  checkouts=("/workspaces/homelab-worktrees/$implementation")
 fi
 
-for clone in "${clones[@]}"; do
-  [[ -d "$clone" ]] || fail "clone path not found: $clone"
-  git -C "$clone" rev-parse --show-toplevel >/dev/null 2>&1 ||
-    fail "clone path is not a Git checkout: $clone"
+for checkout in "${checkouts[@]}"; do
+  [[ -d "$checkout" ]] || fail "checkout path not found: $checkout"
+  git -C "$checkout" rev-parse --show-toplevel >/dev/null 2>&1 ||
+    fail "checkout path is not a Git checkout: $checkout"
 done
 
 stage_script="$root/.codex/scripts/stage_implementation_secrets.sh"
@@ -71,9 +71,9 @@ while IFS= read -r -d '' staged_file; do
   chmod 600 "$staged_file"
 done < <(find "$stage_root" -type f -print0)
 
-for clone in "${clones[@]}"; do
-  (cd "$clone" && "$install_script" "$implementation" "$stage_root")
+for checkout in "${checkouts[@]}"; do
+  (cd "$checkout" && "$install_script" "$implementation" "$stage_root")
 done
 
-printf 'Development smoke secret prep: installed %s into %s clone(s) for %s.\n' \
-  "$tfvars_path" "${#clones[@]}" "$implementation"
+printf 'Development smoke secret prep: installed %s into %s checkout(s) for %s.\n' \
+  "$tfvars_path" "${#checkouts[@]}" "$implementation"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
           - test
   - repo: local
     hooks:
-      - id: verifier-push-guard
-        name: Require verifier approval before origin push
+      - id: spec-kit-push-guard
+        name: Require Spec Kit evidence before origin push
         entry: .codex/hooks/verifier_push_guard.sh
         language: system
         stages: [pre-push]

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -60,12 +60,14 @@ Binding sources:
 - `docs/runbooks/development-cluster.md`
 - `docs/runbooks/implementation-workflow.md`
 
-### VII. One Owner, Separate Verifier
+### VII. Branch-Scoped Spec Kit Work
 
-Each implementation uses a sibling clone, one owner identity, one branch, and one
-PR. Runtime scratch files under `.codex/tmp/` prove local ownership and
-validation state but are not committed. A separate verifier approves the exact
-`HEAD`; implementation owners do not self-approve.
+Each implementation uses one `codex/<implementation>` branch, one
+`specs/<implementation>/` directory, and one PR. Tracked changes default to a
+dedicated worktree under `/workspaces/homelab-worktrees/<implementation>` so
+multiple efforts can run concurrently. Runtime scratch files under `.codex/tmp/`
+are local and non-durable; GitHub PR review and status checks provide review
+gating.
 
 Binding source: `docs/decisions/codex-implementation-workflow.md`.
 
@@ -83,9 +85,9 @@ Each implementation keeps durable planning artifacts in
 - `evidence.md` records commands, outcomes, smoke evidence, exceptions, and final
   branch state.
 
-`.codex/tmp/` remains local runtime scratch for active markers, attestations,
-tokens, PR summary drafts, and verifier files. Anything needed by future readers
-belongs in `specs/<implementation>/` or a canonical doc/runbook.
+`.codex/tmp/` remains local runtime scratch for prompt intent, temporary command
+state, and PR summary drafts. Anything needed by future readers belongs in
+`specs/<implementation>/` or a canonical doc/runbook.
 
 ## Tiered Workflow
 
@@ -100,8 +102,7 @@ Use these tiers when writing `plan.md`, `tasks.md`, and `evidence.md`:
   authentication, production traffic paths, secret handling, or multi-app impact.
 
 `docs-only` from `docs/runbooks/implementation-workflow.md` maps to `tiny` or
-`low` SDD work depending on review risk. If a workflow validator needs the exact
-implementation-workflow label, record both labels.
+`low` SDD work depending on review risk.
 
 ## Governance
 
@@ -112,7 +113,7 @@ validator and update this constitution in the same implementation.
 
 Amendments require:
 
-1. A named implementation and sibling-clone workflow.
+1. A named implementation on branch `codex/<implementation>`.
 2. Updated SDD artifacts under `specs/<implementation>/`.
 3. Links to new or changed ADRs/runbooks when authority changes.
 4. Evidence that relevant local checks passed or documented exceptions explain

--- a/.specify/templates/evidence-template.md
+++ b/.specify/templates/evidence-template.md
@@ -3,7 +3,6 @@
 **Branch**: `codex/[IMPLEMENTATION]`
 **Risk Tier**: [tiny|low|medium|high]
 **Started**: [DATE]
-**Owner**: implementation-agent-[IMPLEMENTATION]
 
 ## Spec Kit Initialization
 
@@ -17,9 +16,7 @@
 
 | Command | Result | Notes |
 | ------- | ------ | ----- |
-| `python3 tools/codex-harness/validate_active_implementation.py ...` | [PASS/FAIL/SKIP] | [notes] |
-| `python3 tools/codex-harness/validate_implementation_plan.py ...` | [PASS/FAIL/SKIP] | [notes] |
-| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner ...` | [PASS/FAIL/SKIP] | [notes] |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | [PASS/FAIL/SKIP] | [notes] |
 
 ## Local Checks
 
@@ -51,4 +48,3 @@
 - Final branch:
 - Final HEAD:
 - Commit:
-- Verifier approval: not created by implementation owner

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -32,10 +32,11 @@ none with reason]
 - [ ] SOPS invariant preserved; no plaintext secret manifests staged.
 - [ ] NFS default considered for PVC-backed workloads.
 - [ ] Talos boundary preserved; no SSH-based node operations introduced.
-- [ ] Sibling clone ownership files validated before tracked edits.
+- [ ] Branch is `codex/[IMPLEMENTATION]`; worktree/current-checkout mode is
+      intentional and recorded when relevant.
 - [ ] Documentation impact identified; docs updated or no-docs rationale
       recorded.
-- [ ] Separate verifier approval required before PR creation.
+- [ ] PR review/status checks are the review gate.
 
 ## Project Structure
 
@@ -67,8 +68,7 @@ tier.]
 **Development smoke**: [Profile, manual commands, include-cluster-base, or none
 with reason.]
 
-**Evidence destination**: `specs/[IMPLEMENTATION]/evidence.md` and
-`.codex/tmp/pr-summary.md`.
+**Evidence destination**: `specs/[IMPLEMENTATION]/evidence.md`.
 
 ## Documentation Impact
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -7,8 +7,8 @@ description: "Homelab SDD task list template"
 **Input**: `specs/[IMPLEMENTATION]/spec.md` and
 `specs/[IMPLEMENTATION]/plan.md`
 **Risk Tier**: [tiny|low|medium|high]
-**Prerequisites**: Valid workflow marker, implementation plan, owner attestation,
-and delegation token under `.codex/tmp/`
+**Prerequisites**: Branch `codex/[IMPLEMENTATION]` and matching
+`specs/[IMPLEMENTATION]/` artifacts.
 
 ## Format: `[ID] [P?] [Req] Description`
 
@@ -17,46 +17,33 @@ and delegation token under `.codex/tmp/`
 - **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
 - Include exact file paths in each task.
 
-## Phase 1: Workflow Setup
+## Phase 1: Spec And Plan
 
-- [ ] T001 [FR-OWN] Create or refresh the sibling clone on
-      `codex/[IMPLEMENTATION]`.
-- [ ] T002 [FR-OWN] Create `.codex/tmp/active-implementation`,
-      `.codex/tmp/implementation-plan.yaml`,
-      `.codex/tmp/implementation-owner-attestation.yaml`, and matching
-      delegation token evidence.
-- [ ] T003 [FR-OWN] Run the three owner workflow validators and record outcomes
-      in `specs/[IMPLEMENTATION]/evidence.md`.
-
-## Phase 2: Spec And Plan
-
-- [ ] T004 [FR-SPEC] Write or update `specs/[IMPLEMENTATION]/spec.md`.
-- [ ] T005 [FR-PLAN] Write or update `specs/[IMPLEMENTATION]/plan.md`,
+- [ ] T001 [FR-SPEC] Create or update `specs/[IMPLEMENTATION]/spec.md`.
+- [ ] T002 [FR-PLAN] Create or update `specs/[IMPLEMENTATION]/plan.md`,
       including tiered TDD and development validation expectations.
-- [ ] T006 [FR-DOCS] Confirm documentation impact and generated architecture
+- [ ] T003 [FR-DOCS] Confirm documentation impact and generated architecture
       expectations.
 
-## Phase 3: Implementation
+## Phase 2: Implementation
 
-- [ ] T007 [P] [FR-IMPL] Edit [path].
-- [ ] T008 [P] [FR-IMPL] Edit [path].
-- [ ] T009 [FR-IMPL] Re-check constitution gates after implementation edits.
+- [ ] T004 [P] [FR-IMPL] Edit [path].
+- [ ] T005 [P] [FR-IMPL] Edit [path].
+- [ ] T006 [FR-IMPL] Re-check constitution gates after implementation edits.
 
-## Phase 4: Verification
+## Phase 3: Verification
 
-- [ ] T010 [FR-TEST] Run [focused local command].
-- [ ] T011 [FR-TEST] Run [broader local command].
-- [ ] T012 [FR-SMOKE] Run development smoke validation or record why the tier
+- [ ] T007 [FR-TEST] Run [focused local command].
+- [ ] T008 [FR-TEST] Run [broader local command].
+- [ ] T009 [FR-SMOKE] Run development smoke validation or record why the tier
       does not require it.
-- [ ] T013 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
+- [ ] T010 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
       and final `HEAD` in `specs/[IMPLEMENTATION]/evidence.md`.
 
-## Phase 5: Commit And Handoff
+## Phase 4: Commit And PR
 
-- [ ] T014 [FR-PR] Write `.codex/tmp/pr-summary.md` from the plan and final
-      evidence.
-- [ ] T015 [FR-PR] Commit with a conventional commit message.
-- [ ] T016 [FR-PR] Report exact `HEAD` and do not create verifier approval.
+- [ ] T011 [FR-PR] Commit with a conventional commit message.
+- [ ] T012 [FR-PR] Push branch `codex/[IMPLEMENTATION]` and open a PR.
 
 ## Tier Guidance
 
@@ -79,7 +66,6 @@ and delegation token under `.codex/tmp/`
 
 **High**
 
-- Prefer helper lanes where available.
 - Include broad local checks and development validation for affected apps or
   shared base paths.
 - Use `--include-cluster-base` when shared development base resources must

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,10 @@ Synology NFS, Grafana/Loki/Mimir/Alloy.
 
 ## Start Here
 
-- Use Spec-Driven Development for repository changes. Start with
-  `docs/runbooks/spec-driven-development.md`, then keep implementation artifacts
+- Use Spec Kit for repository changes. Start with
+  `docs/runbooks/spec-driven-development.md`, follow
+  `docs/runbooks/implementation-workflow.md`, and keep implementation artifacts
   in `specs/<implementation>/`.
-- Use the mandatory implementation workflow in
-  `docs/runbooks/implementation-workflow.md`, accepted by
-  `docs/decisions/codex-implementation-workflow.md`.
 - Binding architecture and operating decisions live in `docs/decisions/`.
   SDD artifacts summarize and trace to them; they do not replace them.
 - General operational procedures live in `docs/runbooks/`; Codex-local notes live
@@ -41,27 +39,25 @@ Synology NFS, Grafana/Loki/Mimir/Alloy.
 - Preserve other people's work. Check the working tree before editing and avoid
   unrelated rewrites.
 
-## Implementation Ownership
+## Implementation Workflow
 
 - Break work into named implementations. One implementation maps to one branch,
   one `specs/<implementation>/` directory, and one PR.
-- Plan in `/workspaces/homelab`, but make tracked implementation edits only in
-  `/workspaces/homelab-ideas/<implementation>` on branch
-  `codex/<implementation>`.
-- Before tracked edits, create and validate `.codex/tmp/active-implementation`,
-  `.codex/tmp/implementation-plan.yaml`,
-  `.codex/tmp/implementation-owner-attestation.yaml`, and matching delegation
-  token evidence under `.codex/tmp/delegation-tokens/`.
-- Before cloning, stage required ignored local secret/config files under
+- Default tracked repository changes to a dedicated worktree:
+  `/workspaces/homelab-worktrees/<implementation>` on branch
+  `codex/<implementation>`. Use the current checkout only when explicitly
+  requested; sibling clones are an allowed fallback.
+- Run the Spec Kit cycle: specify, plan, tasks, then implement.
+- Before worktree or clone commands that need ignored local secret/config files,
+  stage them under
   `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout
   without logging secret contents; install staged files into the same
-  repo-relative paths in implementation and verifier clones before commands that
-  need them.
+  repo-relative paths in worktrees or clones before commands that need them.
 - Runtime scratch files stay under `.codex/tmp/` and are not committed. Durable
   requirements, plans, tasks, and evidence stay under `specs/<implementation>/`.
-- Do not create verifier approval for your own implementation. A separate
-  verifier records `.codex/tmp/verifier-approved` and verifier attestation for
-  the exact `HEAD` before PR creation.
+- Push and PR automation require matching non-empty Spec Kit artifacts,
+  including `evidence.md`; normal GitHub PR review and status checks provide
+  review gating.
 
 ## Tool Routing
 

--- a/docs/decisions/codex-implementation-workflow.md
+++ b/docs/decisions/codex-implementation-workflow.md
@@ -7,7 +7,7 @@ scope:
   - agent-operations
 authority: binding
 created: 2026-05-10
-last_verified: 2026-05-16
+last_verified: 2026-07-03
 supersedes: []
 superseded_by:
 ---
@@ -16,41 +16,49 @@ superseded_by:
 
 ## Decision
 
-All repository code changes must use the mandatory implementation workflow in `docs/runbooks/implementation-workflow.md`.
+All repository code changes must use the Spec Kit implementation workflow in
+`docs/runbooks/implementation-workflow.md`.
 
-Implementation work must happen in a sibling clone under `/workspaces/homelab-ideas/<implementation>` on branch `codex/<implementation>`. Before tracked files change, the clone must contain a valid `.codex/tmp/active-implementation` marker, a valid `.codex/tmp/implementation-plan.yaml` plan, and a valid `.codex/tmp/implementation-owner-attestation.yaml` with matching delegation token evidence.
+Implementation work is isolated by branch and durable Spec Kit artifacts. Each
+implementation uses branch `codex/<implementation>`, directory
+`specs/<implementation>/`, and one PR. Tracked edits on `main` or on non-Codex
+implementation branches are rejected by local guards.
 
-When runtime tooling permits delegation, tracked implementation work must be owned by an implementation owner subagent, and verification must be owned by a separate verifier subagent. The main agent remains planner and orchestrator only: it may inspect, stage required ignored local config, and coordinate, but it does not own tracked implementation work or verifier sign-off.
+The default local execution mode is a dedicated worktree under
+`/workspaces/homelab-worktrees/<implementation>`. Users may explicitly request
+the current checkout or a sibling clone when appropriate.
 
-Runtime and developer policy outrank this repository documentation. If runtime tooling is unavailable or higher-priority policy blocks delegation, that blockage is not automatic permission for main-agent self-work. Self-implementation or self-verification requires explicit user consent for the specific task, and the approved fallback must be recorded in `.codex/tmp/pr-summary.md`.
+Before push or automatic PR creation, `specs/<implementation>/spec.md`,
+`plan.md`, `tasks.md`, and `evidence.md` must be present and non-empty. If
+`evidence.md` records an explicit final, verified, approved, branch, or current
+`HEAD`, that SHA must match the current branch `HEAD`.
 
-Pushes to `origin` and automatic PR creation require verifier approval for the exact `HEAD` in `.codex/tmp/verifier-approved` plus a valid `.codex/tmp/verifier-attestation.yaml` with `approved_head` equal to that same SHA and separate verifier delegation token evidence. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
-
-Approved memory may point to this workflow or summarize it at a high level, but it must not restate the binding workflow policy in full and is not the canonical authority for the policy.
+Local owner attestations, verifier attestations, delegation tokens, and
+exact-`HEAD` verifier approval files are no longer required. Review gating is
+provided by normal GitHub PR review and status checks.
 
 ## Rationale
 
-- Binding workflow policy belongs in decision records and runbooks, not only in approved memory.
-- Delegated implementation and verification keeps planner coordination separate from tracked edits and review approval.
-- A local implementation plan makes scope, documentation impact, tests, verification, and risks explicit before edits begin.
-- Deterministic local attestations and delegation token files make the implementation owner and verifier roles machine-checkable without relying on conversational context.
-- Hook enforcement catches accidental edits in the planner checkout or on non-implementation branches.
-- Exact-`HEAD` verifier approval before push and PR creation keeps review tied to the actual branch state.
+- Spec Kit now provides the standard implementation lifecycle and artifact
+  structure.
+- Worktrees keep concurrent efforts isolated without requiring local
+  attestation files.
+- Branch and SDD artifact guards catch accidental tracked edits on `main` or on
+  mismatched branches.
+- PR review and status checks are the durable review mechanism.
 
 ## Consequences
 
-- Code-change requests begin with planning in the main checkout and move to a sibling implementation clone for edits.
-- The implementation owner owns tracked edits, commits, `.codex/tmp/active-implementation`, `.codex/tmp/implementation-plan.yaml`, `.codex/tmp/implementation-owner-attestation.yaml`, `.codex/tmp/pr-summary.md`, and final branch state.
-- A separate verifier owns exact-`HEAD` verifier approval and verifier attestation.
-- The main agent plans and coordinates; it may perform self-work only with explicit task-specific user consent when delegation is unavailable or blocked by higher-priority policy.
-- Helper agents may research, test, smoke check, or prepare patch recommendations, but only the implementation owner mutates tracked files.
-- Generic identities such as `codex`, `assistant`, `planner`, `parent`, `main`, `self`, and `orchestrator` are not valid implementation owner or verifier identities. Owner identities must use the `implementation-agent-` prefix, and verifier identities must use the `verifier-agent-` prefix.
-- Hook enforcement happens at mutating tool or tracked-file-change boundaries; natural-language request detection remains advisory.
-- The approved memory entry for this workflow must remain an advisory pointer to this decision and the runbook.
+- Repo-changing prompts default to worktree setup guidance.
+- Sibling clones remain allowed, but are no longer required.
+- `.codex/tmp/` stays local scratch and must not contain durable requirements or
+  evidence.
+- Existing historical validators for old attestation files are not part of the
+  current workflow contract.
 
 ## Operational Notes
 
-- Validate the active marker with `tools/codex-harness/validate_active_implementation.py`.
-- Validate the local plan with `tools/codex-harness/validate_implementation_plan.py`.
-- Validate implementation owner and verifier attestations with `tools/codex-harness/validate_workflow_attestations.py`.
 - Use `docs/runbooks/implementation-workflow.md` as the step-by-step procedure.
+- Validate durable Spec Kit context with
+  `tools/codex-harness/validate_sdd_context.py`.
+- Keep useful evidence in `specs/<implementation>/evidence.md`.

--- a/docs/decisions/tdd-and-development-smoke-evidence.md
+++ b/docs/decisions/tdd-and-development-smoke-evidence.md
@@ -17,13 +17,26 @@ superseded_by:
 
 ## Decision
 
-Implementation plans, PR summaries, and verifier review must use risk-tiered TDD and development validation evidence for repository changes.
+Spec Kit plans, evidence files, PR summaries, and PR review must use
+risk-tiered TDD and development validation evidence for repository changes.
 
-Development-cluster validation is required before production-oriented PR completion for covered cluster-affecting changes: Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, branch overlays, and app behavior. TDD evidence remains risk-tiered and documented. The harness must not add hard gates for TDD or smoke testing until the practice proves stable across routine work; owners and verifiers enforce the requirement through plan, PR, and review evidence.
+Development-cluster validation is required before production-oriented PR
+completion for covered cluster-affecting changes: Kubernetes manifests,
+Terraform, Flux wiring, Gateway routes, storage, secrets references, branch
+overlays, and app behavior. TDD evidence remains risk-tiered and documented.
+The harness must not add hard gates for TDD or smoke testing until the practice
+proves stable across routine work; implementation evidence and PR review enforce
+the requirement.
 
-If the development cluster, kubeconfig, required staged development secrets, or required credentials are unavailable, owners may record a documented exception with substitute checks. Actual development validation failures are not exceptions; the change should be fixed and rerun before production-oriented completion.
+If the development cluster, kubeconfig, required staged development secrets, or
+required credentials are unavailable, record a documented exception with
+substitute checks. Actual development validation failures are not exceptions;
+the change should be fixed and rerun before production-oriented completion.
 
-The existing single-owner implementation model remains binding. Test-helper and smoke-helper lanes may research, run commands, prepare recommendations, and report evidence, but the implementation owner remains responsible for tracked edits, commits, local workflow files, `.codex/tmp/pr-summary.md`, and final branch state.
+Each implementation remains branch-scoped on `codex/<implementation>` with
+durable evidence under `specs/<implementation>/`. Helper lanes may research, run
+commands, prepare recommendations, and report evidence, but final evidence and
+branch state must remain coherent for the PR.
 
 ## Rationale
 
@@ -31,13 +44,17 @@ The existing single-owner implementation model remains binding. Test-helper and 
 - Development smoke tests are valuable only when their evidence identifies the app, branch, exact `HEAD`, profile, result, and cleanup state.
 - The current branch deployment verifier is intentionally narrow, with automated support for `whoami` only while a config-driven app profile model is developed.
 - Hard harness gates would be brittle before the team has enough examples of useful tests, smoke profiles, and valid exceptions.
-- Preserving the single-owner model keeps responsibility clear even when helper lanes contribute evidence.
+- Branch-scoped Spec Kit evidence keeps responsibility clear even when helper
+  lanes contribute evidence.
 
 ## Consequences
 
-- Implementation plans must describe TDD, development validation expectations, and known exceptions in the tests, verification, and risks sections.
+- Spec Kit plans must describe TDD, development validation expectations, and
+  known exceptions.
 - PR summaries must include commands run, development smoke reports or exceptions, documentation impact, and whether generated architecture changed.
-- Verifiers must audit declared tests and development validation evidence against the risk tier, spot-check stale or incomplete evidence, and confirm documented exceptions when live validation is unavailable.
+- PR reviewers must audit declared tests and development validation evidence
+  against the risk tier, spot-check stale or incomplete evidence, and confirm
+  documented exceptions when live validation is unavailable.
 - New app work must add or select a smoke profile when practical, or document why development smoke coverage is deferred.
 - Hard harness gates, automated profile enforcement, and non-`whoami` deployment verifier behavior are deferred to future implementations.
 

--- a/docs/runbooks/codex-workflow-protocol.md
+++ b/docs/runbooks/codex-workflow-protocol.md
@@ -5,29 +5,38 @@ scope:
   - implementation-workflow
 authority: reference
 created: 2026-05-12
-last_verified: 2026-05-12
+last_verified: 2026-07-03
 ---
 
 # Codex Workflow Protocol Reference
 
-This reference records the machine-readable evidence used by `docs/runbooks/implementation-workflow.md`.
-
-## Delegation Tokens
-
-Implementation and verifier attestations must include `delegation_token` and `delegation_token_path`. Token paths must be relative paths under `.codex/tmp/delegation-tokens/`; absolute paths and paths outside that directory are invalid.
-
-Each token file contains:
-
-```yaml
-delegation_token: <role-specific-token>
-implementation: <implementation>
-role: implementation-agent|verifier-agent
-agent_id: <role-prefixed-agent-id>
-created_at: <UTC timestamp>
-```
-
-The token fields must match the corresponding attestation. Verifier token values and paths must be distinct from the implementation owner evidence.
+This reference records local machine-readable signals used by
+`docs/runbooks/implementation-workflow.md`.
 
 ## Prompt Intent Marker
 
-The `UserPromptSubmit` hook may write `.codex/tmp/repo-change-intent` when a prompt appears to request repository changes. This marker is advisory and exists to surface workflow reminders before tracked files change; mutation, push, and PR guards remain the authoritative enforcement points.
+The `UserPromptSubmit` hook may write `.codex/tmp/repo-change-intent` when a
+prompt appears to request repository changes. This marker is advisory and exists
+to surface workflow reminders before tracked files change.
+
+The reminder tells agents that the default execution mode is a worktree:
+
+```bash
+git fetch origin
+git worktree add /workspaces/homelab-worktrees/<implementation> \
+  -b codex/<implementation> origin/main
+```
+
+Mutation, push, and PR guards remain the authoritative enforcement points.
+
+## Durable Spec Kit Evidence
+
+Durable workflow state lives under `specs/<implementation>/`:
+
+- `spec.md`
+- `plan.md`
+- `tasks.md`
+- `evidence.md`
+
+Push and PR automation require these files to be present and non-empty on the
+matching branch `codex/<implementation>`.

--- a/docs/runbooks/development-cluster.md
+++ b/docs/runbooks/development-cluster.md
@@ -152,7 +152,7 @@ Prerequisites:
 - Ignored development Terraform vars are staged into the clone that runs smoke
   when Terraform preflight may run:
   `.codex/scripts/prepare_development_smoke_secrets.sh <implementation>
-  [/workspaces/homelab-ideas/<implementation> ...]`.
+  [/workspaces/homelab-worktrees/<implementation> ...]`.
 - The branch named by `--branch` is available on origin. Use `--push` to push the current HEAD to origin as that branch before activation.
 - `--slug` is deterministic and DNS-safe: lowercase letters, numbers, and hyphens; starts and ends with an alphanumeric character; and is short enough for the selected app's `${app}-${branch_slug}` Kubernetes names.
 

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -5,263 +5,136 @@ scope:
   - implementation-workflow
 authority: binding
 created: 2026-05-10
-last_verified: 2026-05-16
+last_verified: 2026-07-03
 ---
 
 # Implementation Workflow
 
-Use this runbook for every repository code change. The binding decision is `docs/decisions/codex-implementation-workflow.md`.
+Use this runbook for every repository code change. The binding decision is
+`docs/decisions/codex-implementation-workflow.md`.
 
 ## Procedure
 
-1. Plan in the main checkout at `/workspaces/homelab`; do not edit tracked files there.
-2. Choose a single implementation name. One implementation maps to one pull request and branch `codex/<implementation>`.
-3. If ignored local secrets or configs are required, stage them under `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout, preserving repo-relative paths and never logging contents. For development branch smoke that needs Terraform preflight, run `.codex/scripts/prepare_development_smoke_secrets.sh <implementation> [/workspaces/homelab-ideas/<implementation> ...]` from the main checkout before the implementation or verifier clone runs `tools/development/verify_branch_deploy.py`.
-4. Clone the repo into `/workspaces/homelab-ideas/<implementation>` and create `codex/<implementation>` from `origin/main`.
-5. Before tracked edits, create `.codex/tmp/active-implementation` with `implementation`, `branch`, `base`, `role`, `clone_path`, `owner_role`, and `owner_agent`.
-6. Before tracked edits, create `.codex/tmp/implementation-plan.yaml` with implementation identity, summary, scope, out-of-scope items, planned changes, documentation impact, tests, verification, and risks. Tests, verification, and risks must declare the risk-tiered TDD and development validation expectations for the implementation, or explain why they do not apply.
-7. Before tracked edits, create `.codex/tmp/implementation-owner-attestation.yaml` with implementation identity, role, concrete `agent_id`, clone path, `created_at`, and matching delegation token evidence under `.codex/tmp/delegation-tokens/`.
-8. Validate the marker, plan, and owner attestation.
-9. Create durable SDD artifacts under `specs/<implementation>/`: `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
-10. Make tracked-file changes only in the sibling clone.
-11. Update docs, generated docs, decision records, runbooks, or agent guidance when behavior changes. If no docs change, record why in `.codex/tmp/pr-summary.md`.
-12. Commit with conventional commits.
-13. Run relevant checks, collect TDD evidence, and collect required development-cluster validation evidence for covered cluster-affecting changes before requesting verifier review.
-14. Record command outcomes, development validation evidence or exceptions, final `HEAD`, and documentation impact in `specs/<implementation>/evidence.md`.
-15. Record verifier approval for the exact `HEAD` SHA in `.codex/tmp/verifier-approved`.
-16. Record `.codex/tmp/verifier-attestation.yaml` with verifier identity, separate delegation token evidence, and `approved_head` equal to the exact `HEAD` SHA. The verifier `agent_id`, `delegation_token`, and `delegation_token_path` must differ from the implementation owner evidence.
-17. Write `.codex/tmp/pr-summary.md` from the plan and final result.
-18. Create the pull request against `main`; delete the sibling clone only after PR creation succeeds.
+1. Choose a single implementation name. One implementation maps to branch
+   `codex/<implementation>`, directory `specs/<implementation>/`, and one PR.
+2. Default to a dedicated worktree for tracked repository changes:
 
-## Active Marker
+   ```bash
+   git fetch origin
+   git worktree add /workspaces/homelab-worktrees/<implementation> \
+     -b codex/<implementation> origin/main
+   ```
 
-```text
-implementation=<implementation>
-branch=codex/<implementation>
-base=origin/main
-role=implementation
-clone_path=/workspaces/homelab-ideas/<implementation>
-owner_role=implementation-agent
-owner_agent=implementation-agent-<implementation>
-```
+   Use the current checkout only when explicitly requested. Sibling clones are
+   allowed as a fallback when a worktree is impractical.
+3. If ignored local secrets or configs are required, stage them under
+   `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout,
+   preserving repo-relative paths and never logging contents. Install staged
+   files into the worktree or clone before commands that need them.
+4. Run the Spec Kit cycle in the implementation worktree or checkout:
+   `specify -> plan -> tasks -> implement`.
+5. Keep durable implementation context in `specs/<implementation>/`:
+   `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
+6. Make tracked-file changes only on `codex/<implementation>`, never on `main`.
+7. Run relevant checks, collect TDD evidence, and collect required development
+   validation evidence for covered cluster-affecting changes.
+8. Record command outcomes, development validation evidence or exceptions,
+   final branch state, and documentation impact in
+   `specs/<implementation>/evidence.md`.
+9. Commit with a conventional commit message.
+10. Create the pull request against `main`. Review gating happens through
+    normal GitHub PR review and status checks.
 
-`owner_agent` must be a concrete implementation owner identity with the `implementation-agent-` prefix. Generic role labels such as `codex`, `assistant`, `planner`, `parent`, `main`, `self`, and `orchestrator` are rejected.
+## Guard Gates
 
-## Implementation Plan
+The local workflow guard enforces the branch and artifact contract:
 
-```yaml
-implementation: <implementation>
-branch: codex/<implementation>
-base: origin/main
-clone_path: /workspaces/homelab-ideas/<implementation>
-owner_agent: implementation-agent-<implementation>
-summary: <one sentence>
-scope:
-  - <included work>
-out_of_scope:
-  - <excluded work>
-planned_changes:
-  - <change>
-docs_impact: <docs updated or why none are needed>
-tests:
-  - <command or scenario>
-verification:
-  - <review or acceptance check>
-risks:
-  - <known risk or none>
-```
+- tracked edits on `main` are rejected;
+- tracked edits outside `codex/<implementation>` branches are rejected;
+- initial bootstrap of `specs/<implementation>/{spec,plan,tasks,evidence}.md`
+  is allowed on a new implementation branch;
+- after bootstrap, non-bootstrap tracked edits require non-empty `spec.md`,
+  `plan.md`, and `tasks.md`;
+- push and automatic PR creation require non-empty `evidence.md` as well.
 
-## Owner Attestation
+Local owner attestations, verifier attestations, delegation token files, and
+exact-`HEAD` verifier approval files are no longer part of the workflow.
 
-```yaml
-implementation: <implementation>
-branch: codex/<implementation>
-base: origin/main
-role: implementation-agent
-agent_id: implementation-agent-<implementation>
-clone_path: /workspaces/homelab-ideas/<implementation>
-created_at: <UTC timestamp>
-delegation_token: implementation-delegation-<implementation>
-delegation_token_path: .codex/tmp/delegation-tokens/implementation-agent-<implementation>.token
-```
+## Prompt Catch
 
-`agent_id` must match the active marker `owner_agent` and the implementation plan `owner_agent`.
-
-The referenced delegation token file must be repo-relative, live under `.codex/tmp/delegation-tokens/`, and contain matching `delegation_token`, `implementation`, `role`, `agent_id`, and `created_at` fields.
-
-## Verifier Approval And Attestation
-
-```text
-<exact HEAD SHA>
-```
-
-Write the exact `HEAD` SHA to `.codex/tmp/verifier-approved`.
-
-```yaml
-implementation: <implementation>
-branch: codex/<implementation>
-base: origin/main
-role: verifier-agent
-agent_id: verifier-agent-<implementation>
-clone_path: /workspaces/homelab-ideas/<implementation>
-created_at: <UTC timestamp>
-approved_head: <exact HEAD SHA>
-delegation_token: verifier-delegation-<implementation>
-delegation_token_path: .codex/tmp/delegation-tokens/verifier-agent-<implementation>.token
-```
-
-The verifier `agent_id` must be concrete, must use the `verifier-agent-` prefix, must not use a generic role label, and must differ from the implementation owner `agent_id`. The verifier delegation token and token path must also differ from the implementation owner evidence.
-
-## Validation
+When a prompt appears to request tracked repository changes, the prompt-intent
+hook reminds agents that the default execution mode is a worktree:
 
 ```bash
-python3 tools/codex-harness/validate_active_implementation.py \
-  --marker .codex/tmp/active-implementation \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)"
-
-python3 tools/codex-harness/validate_implementation_plan.py \
-  --plan .codex/tmp/implementation-plan.yaml \
-  --marker .codex/tmp/active-implementation \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)"
-
-python3 tools/codex-harness/validate_workflow_attestations.py \
-  --kind owner \
-  --attestation .codex/tmp/implementation-owner-attestation.yaml \
-  --marker .codex/tmp/active-implementation \
-  --plan .codex/tmp/implementation-plan.yaml \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)"
-
-python3 tools/codex-harness/validate_sdd_context.py \
-  --marker .codex/tmp/active-implementation \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)" \
-  --require-plan-artifacts
-
-python3 tools/codex-harness/validate_workflow_attestations.py \
-  --kind verifier \
-  --attestation .codex/tmp/verifier-attestation.yaml \
-  --marker .codex/tmp/active-implementation \
-  --owner-attestation .codex/tmp/implementation-owner-attestation.yaml \
-  --head "$(git rev-parse HEAD)" \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)"
-
-python3 tools/codex-harness/validate_sdd_context.py \
-  --marker .codex/tmp/active-implementation \
-  --root "$(pwd)" \
-  --branch "$(git branch --show-current)" \
-  --require-plan-artifacts \
-  --require-evidence \
-  --head "$(git rev-parse HEAD)"
+git fetch origin
+git worktree add /workspaces/homelab-worktrees/<implementation> \
+  -b codex/<implementation> origin/main
 ```
 
-## SDD Guard Gates
-
-For non-bootstrap tracked edits, the workflow guard requires valid branch,
-clone, marker, implementation plan, owner attestation, delegation token, and
-non-empty `specs/<implementation>/spec.md`, `plan.md`, and `tasks.md`.
-Bootstrap edits that create the initial SDD artifact files are allowed only when
-the branch `HEAD` does not already contain SDD artifacts for the implementation.
-
-Verifier approval, verifier attestation, automatic PR creation, final handoff,
-and non-smoke pushes require `specs/<implementation>/evidence.md` to exist and
-be non-empty. When `evidence.md` records an explicit final, verified, approved,
-branch, or current `HEAD`, that SHA must match the current branch `HEAD`.
-
-`.codex/scripts/create_implementation_pr.sh --auto` performs its own marker,
-plan, owner attestation, SDD evidence, verifier approval, and verifier
-attestation gates before pushing or creating a PR. Do not rely on Stop-hook
-ordering as the PR creation safety boundary.
-
-Development validation may push `origin HEAD:refs/heads/codex/<implementation>`
-before verifier approval only from the active implementation branch, only when
-the implementation clone has valid runtime workflow context and non-empty
-`spec.md`, `plan.md`, and `tasks.md`. PR creation, final handoff, and all other
-origin pushes still require exact-HEAD verifier approval and verifier
-attestation.
-
-## Ownership
-
-The main agent remains planner and orchestrator only. It may inspect repository state, stage required ignored local config for delegation, and coordinate agents, but it does not own tracked-file edits, commits, verifier approval, or final branch state.
-
-One implementation owner subagent owns tracked-file edits, commits, `.codex/tmp/active-implementation`, `.codex/tmp/implementation-plan.yaml`, `.codex/tmp/implementation-owner-attestation.yaml`, `.codex/tmp/pr-summary.md`, and final branch state for the implementation clone.
-
-One separate verifier subagent reviews the exact `HEAD` and owns `.codex/tmp/verifier-approved` plus `.codex/tmp/verifier-attestation.yaml`. The verifier identity and delegation token evidence must differ from the implementation owner evidence.
-
-Helper subagents may research, test, run smoke checks, or recommend patches through the single integrator model. Helpers must not make tracked-file edits; the implementation owner applies any accepted recommendations.
-
-If subagent tooling is unavailable or higher-priority runtime policy blocks delegation, blocked delegation is not automatic permission for main-agent self-work. The user must explicitly consent to self-implementation or self-verification for that task, and the approved fallback must be recorded in `.codex/tmp/pr-summary.md`.
+If `/workspaces/homelab-worktrees` is unavailable in a local environment, use a
+writable sibling location and record the exception in `evidence.md`.
 
 ## Risk-Tiered TDD And Development Validation
 
-TDD evidence remains risk-tiered and documented. Development-cluster validation is required for covered cluster-affecting changes before production-oriented PR completion, but it is enforced by implementation and verifier review rather than hard harness gates. See `docs/decisions/tdd-and-development-smoke-evidence.md`.
+TDD evidence remains risk-tiered and documented. Development-cluster validation
+is required for covered cluster-affecting changes before production-oriented PR
+completion, but it is enforced by implementation evidence and PR review rather
+than local attestation files. See
+`docs/decisions/tdd-and-development-smoke-evidence.md`.
 
-Declare a risk tier in the plan:
+Declare a risk tier in `plan.md`:
 
-- `docs-only`: documentation, generated docs, decisions, runbooks, or agent guidance only.
-- `low`: narrow code or manifest changes with local-only behavior and low operational blast radius.
-- `medium`: app behavior, Kubernetes manifests, Flux wiring, Terraform module logic, storage, secrets references, or Gateway routes.
-- `high`: cluster-scoped controllers, CRDs, networking, storage classes, authentication, production traffic paths, secret handling, or changes that can affect multiple apps.
-
-TDD expectations by tier:
-
-- `docs-only`: no code TDD required; run relevant doc, harness, or repo tests that guard the edited guidance when available.
-- `low`: add or update the smallest unit test that fails before the fix when the codebase has a reasonable test seam; otherwise document the exception.
-- `medium`: prefer a red-green flow for behavior changes, including local render tests or focused unit tests for Kubernetes/Terraform tooling where applicable.
-- `high`: use a test-helper lane by default to identify or prepare failing tests before implementation, plus broader verification after the change. If no useful failing test can be made, record why.
+- `docs-only`: documentation, generated docs, decisions, runbooks, or agent
+  guidance only.
+- `low`: narrow code or manifest changes with local-only behavior and low
+  operational blast radius.
+- `medium`: app behavior, Kubernetes manifests, Flux wiring, Terraform module
+  logic, storage, secrets references, or Gateway routes.
+- `high`: cluster-scoped controllers, CRDs, networking, storage classes,
+  authentication, production traffic paths, secret handling, or changes that can
+  affect multiple apps.
 
 Development validation expectations by tier:
 
 - `docs-only`: no live development smoke required.
-- `low`: run development validation when the changed path affects live app rendering or operator commands.
-- `medium`: run development validation for Kubernetes manifests, Terraform, Flux wiring, Gateway routes, storage, secrets references, and app behavior changes. Use a smoke-helper lane by default for touched apps when delegation is available.
-- `high`: run development validation for the affected app or base path. For shared cluster base changes, include a sequential development base reconcile before app acceptance.
+- `low`: run development validation when the changed path affects live app
+  rendering or operator commands.
+- `medium`: run development validation for Kubernetes manifests, Terraform,
+  Flux wiring, Gateway routes, storage, secrets references, and app behavior
+  changes.
+- `high`: run development validation for the affected app or base path. For
+  shared cluster base changes, include a sequential development base reconcile
+  before app acceptance.
 
-If the development cluster, kubeconfig, required staged development secrets, or required credentials are unavailable, record a documented exception with the blocker and safest substitute checks. A real development validation failure is not an exception; fix the change, rerun validation, or leave the PR incomplete.
-
-Before smoke commands that may run development Terraform preflight, prepare the
-required ignored development tfvars from the main checkout:
-
-```bash
-.codex/scripts/prepare_development_smoke_secrets.sh <implementation>
-```
-
-Pass both implementation and verifier clone paths when a verifier will rerun the
-same smoke:
-
-```bash
-.codex/scripts/prepare_development_smoke_secrets.sh <implementation> \
-  /workspaces/homelab-ideas/<implementation> \
-  /workspaces/homelab-ideas/<verification-clone>
-```
+If the development cluster, kubeconfig, required staged development secrets, or
+required credentials are unavailable, record a documented exception with the
+blocker and safest substitute checks. A real development validation failure is
+not an exception; fix the change, rerun validation, or leave the PR incomplete.
 
 Default development validation paths:
 
-- `smoke_profile: whoami`: run `python3 tools/development/verify_branch_deploy.py --app whoami --branch <branch> --slug <slug> --push` when the `whoami` branch profile fits the touched app or acceptance path.
-- `--include-cluster-base`: add this flag when the implementation changes resources under `kubernetes/clusters/development`, shared CRDs, controller installs, Gateway base objects, Cilium, cert-manager, NFS CSI, Flux dependency ordering, or app dependencies that must reconcile before branch app validation.
-- `smoke_profile: manual`: for apps without automated profiles, run manual development smoke checks that prove the relevant workload, Service, route, storage, secret reference, and app-specific behavior. Record exact commands and observations.
-- `smoke_profile: none`: use only for docs-only or local-only changes, unavailable development infrastructure or credentials, missing development branch coverage that cannot be safely emulated manually, or production-only integrations that development cannot represent. Include substitute checks and a follow-up when coverage should be added.
-
-## Helper Lanes
-
-Use helper lanes without breaking the single-owner model:
-
-- `test-helper`: researches risk, proposes or runs failing tests, and reports command output or patch recommendations. The implementation owner remains the only role that applies tracked-file edits.
-- `smoke-helper`: prepares or runs development cluster validation, captures exact branch and `HEAD` evidence, and recommends cleanup. The implementation owner remains responsible for final branch state and PR notes.
-
-Helper output belongs in `.codex/tmp/pr-summary.md` or an equivalent local note when it affects verifier review. Include commands, outcomes, skipped checks, and exceptions. Do not create verifier approval files from helper lanes.
+- `smoke_profile: whoami`: run
+  `python3 tools/development/verify_branch_deploy.py --app whoami --branch <branch> --slug <slug> --push`
+  when the `whoami` branch profile fits the touched app or acceptance path.
+- `--include-cluster-base`: add this flag when shared development base resources
+  must reconcile before branch app validation.
+- `smoke_profile: manual`: for apps without automated profiles, run manual
+  development smoke checks that prove the relevant workload, Service, route,
+  storage, secret reference, and app-specific behavior.
+- `smoke_profile: none`: use only for docs-only or local-only changes,
+  unavailable development infrastructure or credentials, missing development
+  branch coverage that cannot be safely emulated manually, or production-only
+  integrations that development cannot represent.
 
 ## Evidence Audit
 
-Before requesting verifier review, the implementation owner must audit:
+Before requesting PR review, audit:
 
-- The plan declares the intended TDD and development validation expectations for the risk tier.
-- Any skipped failing test, missing smoke profile, unavailable development cluster, unavailable credentials, or other exception is recorded with a reason and substitute checks.
-- Test evidence includes the exact commands run and pass/fail result.
-- Development validation evidence includes app name, branch, branch slug, exact `HEAD`, smoke profile or documented exception, report path if one was produced, cleanup status, and whether stale reports were ignored or removed.
-- Parent/process evidence is internally consistent: active marker, plan, owner attestation, delegation token, branch, clone path, and PR summary all point at the same implementation.
-
-Verifier review must audit the same evidence. If required development validation is stale, missing, or inconsistent with the risk tier, the verifier must request a rerun, run a spot check, or confirm a documented exception before sign-off.
+- The plan declares the intended TDD and development validation expectations for
+  the risk tier.
+- Skipped tests, missing smoke profiles, unavailable infrastructure, or other
+  exceptions are recorded with substitute checks.
+- Test evidence includes exact commands and pass/fail result.
+- Development validation evidence includes app name, branch, branch slug, exact
+  `HEAD`, smoke profile or documented exception, report path if one was
+  produced, and cleanup status.

--- a/docs/runbooks/spec-driven-development.md
+++ b/docs/runbooks/spec-driven-development.md
@@ -11,8 +11,8 @@ last_verified: 2026-07-03
 
 # Spec-Driven Development
 
-Use this runbook to plan Homelab changes with Spec Kit while preserving the
-mandatory implementation workflow and binding ADRs.
+Use this runbook to plan Homelab changes with Spec Kit while preserving binding
+ADRs and local branch/artifact guards.
 
 ## Authority
 
@@ -67,44 +67,32 @@ Each implementation owns:
 - `specs/<implementation>/tasks.md`
 - `specs/<implementation>/evidence.md`
 
-The implementation owner also owns local runtime files under `.codex/tmp/` in
-the sibling clone. These files are ignored and are not durable documentation.
-
-Verifier files under `.codex/tmp/` are owned by a separate verifier and are not
-created by the implementation owner.
+Runtime files under `.codex/tmp/` are ignored and are not durable
+documentation. Durable implementation context belongs in `specs/<implementation>/`.
 
 ## Enforced Guard Behavior
 
 The harness treats `specs/<implementation>/` as durable implementation context.
-After the initial SDD artifact bootstrap, non-bootstrap tracked edits require a
-valid implementation marker, implementation plan, owner attestation, delegation
-token, and non-empty:
+After the initial SDD artifact bootstrap, non-bootstrap tracked edits require
+branch `codex/<implementation>` and non-empty:
 
 - `specs/<implementation>/spec.md`
 - `specs/<implementation>/plan.md`
 - `specs/<implementation>/tasks.md`
 
-`specs/<implementation>/evidence.md` is required before verifier approval,
-automatic PR creation, final handoff, and non-smoke pushes. If evidence records
-an explicit final, verified, approved, branch, or current `HEAD`, the recorded
-SHA must match the current branch `HEAD`.
+`specs/<implementation>/evidence.md` is required before push and automatic PR
+creation. If evidence records an explicit final, verified, approved, branch, or
+current `HEAD`, the recorded SHA must match the current branch `HEAD`.
 
 Automatic PR creation runs these gates itself through
 `.codex/scripts/create_implementation_pr.sh --auto`; Stop-hook ordering is not
 the enforcement boundary.
 
-Development smoke validation may push the active implementation branch to
-`origin codex/<implementation>` before verifier approval only from a valid
-implementation clone with non-empty `spec.md`, `plan.md`, and `tasks.md`.
-Verifier approval for the exact `HEAD` remains mandatory for PR creation, final
-handoff, and non-smoke pushes.
-
 ## Spec Persistence
 
 Keep useful decisions, assumptions, acceptance criteria, test outcomes, smoke
 evidence, and exceptions in `specs/<implementation>/`. Use `.codex/tmp/` only
-for active workflow state such as markers, attestations, delegation tokens,
-verifier approval, and draft PR summaries.
+for local scratch state such as prompt-intent markers and draft PR summaries.
 
 If future operators need the information after the branch is merged, it belongs
 in a committed spec, runbook, ADR, or generated documentation.
@@ -112,7 +100,7 @@ in a committed spec, runbook, ADR, or generated documentation.
 ## Tiered Workflow
 
 Use the SDD tier in the spec and plan, and map it to the implementation workflow
-risk tier when writing `.codex/tmp/implementation-plan.yaml`.
+risk tier in `plan.md` when needed.
 
 | SDD tier | Use for | Expected evidence |
 | -------- | ------- | ----------------- |
@@ -126,26 +114,21 @@ risk tier when writing `.codex/tmp/implementation-plan.yaml`.
 
 ## Procedure
 
-1. Create a named implementation and branch plan in the main checkout.
-2. Create or reuse the sibling clone required by
-   `docs/runbooks/implementation-workflow.md`.
-3. Before tracked edits, create and validate `.codex/tmp/active-implementation`,
-   `.codex/tmp/implementation-plan.yaml`,
-   `.codex/tmp/implementation-owner-attestation.yaml`, and delegation token
-   evidence.
-4. Create `specs/<implementation>/spec.md` from
+1. Create a named implementation.
+2. Create or reuse the default worktree:
+   `/workspaces/homelab-worktrees/<implementation>` on branch
+   `codex/<implementation>`.
+3. Create `specs/<implementation>/spec.md` from
    `.specify/templates/spec-template.md`.
-5. Create `specs/<implementation>/plan.md` from
+4. Create `specs/<implementation>/plan.md` from
    `.specify/templates/plan-template.md`.
-6. Create `specs/<implementation>/tasks.md` from
+5. Create `specs/<implementation>/tasks.md` from
    `.specify/templates/tasks-template.md`.
-7. Create `specs/<implementation>/evidence.md` from
+6. Create `specs/<implementation>/evidence.md` from
    `.specify/templates/evidence-template.md`.
-8. Implement the change in the sibling clone only.
-9. Record command outcomes, development validation, exceptions, final `HEAD`,
+7. Implement the change in the worktree or explicitly selected checkout.
+8. Record command outcomes, development validation, exceptions, final `HEAD`,
    and documentation impact in `evidence.md`.
-10. Write `.codex/tmp/pr-summary.md` from the plan and evidence before verifier
-    handoff.
 
 ## Development Validation
 
@@ -155,7 +138,7 @@ Development-cluster validation follows
 
 Use `smoke_profile: none` only for docs-only/local-only work or when required
 development infrastructure or credentials are unavailable. Record the reason and
-substitute checks in both `evidence.md` and `.codex/tmp/pr-summary.md`.
+substitute checks in `evidence.md`.
 
 Use `--include-cluster-base` when shared development base resources must
 reconcile before app acceptance.
@@ -167,5 +150,5 @@ reconcile before app acceptance.
   expectations, docs impact, and risks.
 - Tasks are concrete enough for an implementation owner to execute.
 - Evidence includes exact command outcomes and exceptions.
-- `.codex/tmp` files are consistent with the implementation identity and branch.
-- The implementation owner did not create verifier approval.
+- The branch is `codex/<implementation>` and artifacts live under matching
+  `specs/<implementation>/`.

--- a/specs/adopt-speckit-worktree-flow/evidence.md
+++ b/specs/adopt-speckit-worktree-flow/evidence.md
@@ -1,0 +1,36 @@
+# Evidence: adopt-speckit-worktree-flow
+
+**Branch**: `codex/adopt-speckit-worktree-flow`
+**Risk Tier**: medium
+**Started**: 2026-07-03
+
+## Workflow Bootstrap
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py ...` | PASS | Ran before tracked edits under the old workflow. |
+| `python3 tools/codex-harness/validate_implementation_plan.py ...` | PASS | Ran before tracked edits under the old workflow. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner ...` | PASS | Ran before tracked edits under the old workflow. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Branch-derived SDD validation succeeds after the workflow migration. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m pytest tools/codex-harness/tests/test_implementation_workflow_guard.py tools/codex-harness/tests/test_verifier_push_guard.py tools/codex-harness/tests/test_create_implementation_pr.py tools/codex-harness/tests/test_validate_sdd_context.py` | FAIL/SKIP | `pytest` is not installed in this environment. |
+| `python3 -m unittest tools.codex-harness.tests.test_implementation_workflow_guard tools.codex-harness.tests.test_verifier_push_guard tools.codex-harness.tests.test_create_implementation_pr tools.codex-harness.tests.test_validate_sdd_context` | PASS | 30 tests passed. |
+| `python3 -m unittest discover -s tools/codex-harness/tests` | PASS | 73 tests passed after implementation and after executable-bit restoration. |
+| `python3 tools/architecture/render.py --check` | PASS | No output. |
+| `pre-commit run --all-files` | FAIL/BLOCKED | All hooks before `agent-memory-lint` passed. `agent-memory-lint` failed because `.codex/memory` does not exist in this worktree. |
+
+## Development Validation
+
+- Profile: none
+- Reason: local workflow tooling and documentation only; no cluster-affecting
+  manifests or runtime app behavior changed.
+
+## Final State
+
+- Final branch: `codex/adopt-speckit-worktree-flow`
+- Final HEAD: reported in final handoff after commit.
+- Commit: reported in final handoff after commit.

--- a/specs/adopt-speckit-worktree-flow/plan.md
+++ b/specs/adopt-speckit-worktree-flow/plan.md
@@ -1,0 +1,49 @@
+# Implementation Plan: adopt-speckit-worktree-flow
+
+**Branch**: `codex/adopt-speckit-worktree-flow` | **Date**: 2026-07-03 |
+**Spec**: `specs/adopt-speckit-worktree-flow/spec.md`
+
+## Summary
+
+Make Spec Kit the canonical implementation workflow and use worktrees as the
+default concurrency model. Remove local attestation requirements from hooks,
+push guards, PR automation, templates, and binding guidance.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: docs/tooling
+**Primary Files**: `.codex/hooks/implementation_workflow_guard.sh`,
+`.codex/hooks/user_prompt_submit.sh`, `.codex/hooks/verifier_push_guard.sh`,
+`.codex/scripts/create_implementation_pr.sh`, `.specify/templates/*`, docs,
+and Codex harness tests.
+**Development Validation**: not required; this changes local workflow tooling
+and documentation only.
+
+## Constitution Check
+
+- Git remains the source of truth; no live cluster mutation.
+- Spec Kit artifacts remain durable implementation evidence.
+- Runtime scratch under `.codex/tmp/` remains ignored and non-durable.
+- Branch isolation remains mandatory through `codex/<implementation>`.
+
+## Approach
+
+1. Update repo guidance and templates to describe Spec Kit plus default
+   worktree mode.
+2. Simplify workflow guards to enforce branch and SDD artifact invariants.
+3. Simplify push and PR automation to require evidence but not verifier files.
+4. Update harness tests to cover the new guard contract.
+5. Record command results and exceptions in evidence.
+
+## Validation
+
+- `python3 -m pytest tools/codex-harness/tests`
+- `python3 tools/architecture/render.py --check`
+- `pre-commit run --all-files` if practical
+
+## Risks
+
+- Guard changes could become too permissive around tracked edits.
+- Existing docs may retain stale attestation language.
+- PR automation still depends on `gh` in environments that use it.

--- a/specs/adopt-speckit-worktree-flow/spec.md
+++ b/specs/adopt-speckit-worktree-flow/spec.md
@@ -1,0 +1,71 @@
+# Feature Specification: adopt-speckit-worktree-flow
+
+**Feature Branch**: `codex/adopt-speckit-worktree-flow`
+**Created**: 2026-07-03
+**Status**: Draft
+**Input**: Replace the custom attested implementation workflow with standard
+Spec Kit workflow and default worktree isolation.
+
+## Binding Context
+
+- `AGENTS.md`
+- `.specify/workflows/speckit/workflow.yml`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/decisions/codex-implementation-workflow.md`
+
+## User Stories
+
+### User Story 1 - Start Concurrent Work In Worktrees
+
+As an operator, I want repository-changing requests to default to a dedicated
+worktree so multiple implementations can run concurrently without colliding.
+
+**Acceptance Scenarios**
+
+1. **Given** a repo-changing prompt without an explicit execution mode,
+   **When** Codex displays workflow guidance, **Then** the guidance says the
+   default is a worktree under `/workspaces/homelab-worktrees/<implementation>`.
+2. **Given** a tracked edit is attempted on `main`, **When** the guard runs,
+   **Then** the edit is rejected.
+3. **Given** a tracked edit is attempted on `codex/<implementation>` with
+   matching Spec Kit artifacts, **When** the guard runs, **Then** the edit is
+   allowed.
+
+### User Story 2 - Use Standard Spec Kit Implementation
+
+As an implementation agent, I want the repo guidance and templates to route me
+through `specify -> plan -> tasks -> implement` without local owner/verifier
+attestation boilerplate.
+
+**Acceptance Scenarios**
+
+1. **Given** a new implementation, **When** the agent reads AGENTS and SDD docs,
+   **Then** Spec Kit is the canonical implementation flow.
+2. **Given** push or PR automation runs from a valid `codex/<implementation>`
+   branch, **When** `specs/<implementation>/evidence.md` is present, **Then**
+   local verifier attestation files are not required.
+
+## Requirements
+
+- **FR-001**: The workflow MUST use Spec Kit artifacts as the durable
+  implementation context.
+- **FR-002**: The workflow MUST default tracked repo changes to a dedicated
+  worktree unless the user explicitly requests current-checkout or clone mode.
+- **FR-003**: The guard MUST reject tracked edits on `main`.
+- **FR-004**: The guard MUST reject tracked edits on branches not matching
+  `codex/<implementation>`.
+- **FR-005**: The guard MUST require matching non-empty `spec.md`, `plan.md`,
+  and `tasks.md` after initial Spec Kit artifact bootstrap.
+- **FR-006**: Push and PR automation MUST require non-empty matching
+  `evidence.md` and MUST NOT require local verifier approval or attestation.
+- **FR-007**: Guidance and templates MUST stop requiring active implementation
+  markers, implementation plans, owner attestations, verifier attestations, or
+  delegation tokens.
+
+## Out Of Scope
+
+- Kubernetes, Terraform, Flux, Gateway, or application manifest changes.
+- Changing Spec Kit upstream behavior.
+- Requiring GitHub branch protection configuration in this repository change.

--- a/specs/adopt-speckit-worktree-flow/tasks.md
+++ b/specs/adopt-speckit-worktree-flow/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: adopt-speckit-worktree-flow
+
+**Input**: `specs/adopt-speckit-worktree-flow/spec.md` and
+`specs/adopt-speckit-worktree-flow/plan.md`
+**Risk Tier**: medium
+
+## Phase 1: Guidance And Templates
+
+- [x] T001 [FR-001] Update `AGENTS.md` to name Spec Kit plus default worktree
+      isolation as the repository implementation flow.
+- [x] T002 [FR-001] Update `.specify/memory/constitution.md` to remove local
+      attestation requirements.
+- [x] T003 [FR-007] Update `.specify/templates/spec-template.md`,
+      `.specify/templates/plan-template.md`,
+      `.specify/templates/tasks-template.md`, and
+      `.specify/templates/evidence-template.md`.
+- [x] T004 [FR-001] Update `docs/runbooks/spec-driven-development.md`,
+      `docs/runbooks/implementation-workflow.md`, and
+      `docs/runbooks/codex-workflow-protocol.md`.
+- [x] T005 [FR-001] Update
+      `docs/decisions/codex-implementation-workflow.md` and
+      `docs/decisions/tdd-and-development-smoke-evidence.md`.
+
+## Phase 2: Guards And Automation
+
+- [x] T006 [FR-002] Update `.codex/hooks/user_prompt_submit.sh` to recommend
+      default worktree mode.
+- [x] T007 [FR-003] [FR-004] [FR-005] Simplify
+      `.codex/hooks/implementation_workflow_guard.sh` to enforce branch and SDD
+      artifact invariants.
+- [x] T008 [FR-006] Simplify `.codex/hooks/verifier_push_guard.sh` into a
+      branch/evidence push guard.
+- [x] T009 [FR-006] Simplify `.codex/scripts/create_implementation_pr.sh` to
+      require valid SDD evidence instead of verifier files.
+
+## Phase 3: Tests
+
+- [x] T010 [FR-002] Update user prompt hook tests for default worktree guidance.
+- [x] T011 [FR-003] [FR-004] [FR-005] Update workflow guard tests for branch and
+      artifact enforcement.
+- [x] T012 [FR-006] Update push and PR automation tests to remove verifier file
+      requirements.
+
+## Phase 4: Verification
+
+- [x] T013 [FR-TEST] Run focused Codex harness tests.
+- [x] T014 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T015 [FR-TEST] Run `pre-commit run --all-files` if practical.
+- [x] T016 [FR-EVIDENCE] Record outcomes and final state in
+      `specs/adopt-speckit-worktree-flow/evidence.md`.

--- a/tools/codex-harness/tests/test_create_implementation_pr.py
+++ b/tools/codex-harness/tests/test_create_implementation_pr.py
@@ -9,9 +9,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPT_SOURCE = REPO_ROOT / ".codex" / "scripts" / "create_implementation_pr.sh"
-ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
-PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
-ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
 SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
 VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
@@ -19,69 +16,49 @@ TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 class CreateImplementationPrTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.temp_parent = tempfile.TemporaryDirectory(prefix="pr-root-")
-        self.sibling_root = Path(self.temp_parent.name) / "homelab-ideas"
-        self.sibling_root.mkdir()
-        self.tmpdir = tempfile.TemporaryDirectory(dir=self.sibling_root, prefix="pr-test-")
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="pr-test-")
         self.root = Path(self.tmpdir.name)
-        self.implementation = self.root.name
+        self.implementation = "pr-test"
         self.branch = f"codex/{self.implementation}"
         _init_repo(self.root)
-        _install_harness_files(self.root, self.sibling_root)
+        _install_harness_files(self.root)
         subprocess.run(["git", "switch", "-c", self.branch], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
-        _write_marker(self.root, self.implementation)
-        _write_plan(self.root, self.implementation)
-        _write_owner_attestation(self.root, self.implementation)
         self.head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.root, text=True).strip()
         _write_sdd_artifacts(self.root, self.implementation, final_head=self.head)
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()
-        self.temp_parent.cleanup()
-
-    def test_blocks_without_verifier_attestation(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-
-        result = _run_script(self.root)
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("verifier attestation is missing", result.stderr)
-
-    def test_auto_blocks_without_exact_head_verifier_approval(self) -> None:
-        result = _run_script(self.root, "--auto")
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("verifier approval is missing for exact HEAD", result.stderr)
-
-    def test_blocks_with_wrong_head_verifier_attestation(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-        _write_verifier_attestation(self.root, self.implementation, "0" * 40)
-
-        result = _run_script(self.root)
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("verifier attestation validation failed", result.stderr)
 
     def test_blocks_without_evidence_md(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-        _write_verifier_attestation(self.root, self.implementation, self.head)
         (self.root / "specs" / self.implementation / "evidence.md").unlink()
 
         result = _run_script(self.root)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("SDD evidence validation failed", result.stderr)
-        self.assertIn("Missing required SDD artifact", result.stderr)
+        self.assertIn("evidence.md", result.stderr)
 
-    def test_blocks_stale_evidence_head(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-        _write_verifier_attestation(self.root, self.implementation, self.head)
+    def test_blocks_stale_evidence_head_without_verifier_files(self) -> None:
         _write_sdd_artifacts(self.root, self.implementation, final_head="0" * 40)
 
         result = _run_script(self.root)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("records HEAD", result.stderr)
+
+    def test_blocks_dirty_tree_after_valid_sdd_evidence(self) -> None:
+        (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
+
+        result = _run_script(self.root)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("working tree must be clean", result.stderr)
+
+    def test_auto_exits_on_non_codex_branch(self) -> None:
+        subprocess.run(["git", "switch", "main"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
+
+        result = _run_script(self.root, "--auto")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 def _init_repo(root: Path) -> None:
@@ -94,117 +71,16 @@ def _init_repo(root: Path) -> None:
     subprocess.run(["git", "commit", "-m", "test: initialize"], cwd=root, check=True, stdout=subprocess.DEVNULL)
 
 
-def _install_harness_files(root: Path, sibling_root: Path) -> None:
+def _install_harness_files(root: Path) -> None:
     script_path = root / ".codex" / "scripts" / "create_implementation_pr.sh"
     tool_dir = root / "tools" / "codex-harness"
     script_path.parent.mkdir(parents=True, exist_ok=True)
     tool_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(SCRIPT_SOURCE, script_path)
-    shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
-    shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
-    shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
     shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
     shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
-    _patch_sibling_root(
-        sibling_root,
-        script_path,
-        tool_dir / "validate_active_implementation.py",
-        tool_dir / "validate_implementation_plan.py",
-    )
     script_path.chmod(0o755)
-
-
-def _patch_sibling_root(sibling_root: Path, *paths: Path) -> None:
-    for path in paths:
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                "/workspaces/homelab-ideas",
-                str(sibling_root),
-            ),
-            encoding="utf-8",
-        )
-
-
-def _write_marker(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "active-implementation").write_text(
-        "\n".join(
-            [
-                f"implementation={implementation}",
-                f"branch=codex/{implementation}",
-                "base=origin/main",
-                "role=implementation",
-                f"clone_path={root}",
-                "owner_role=implementation-agent",
-                "owner_agent=implementation-agent-deterministic-role-enforcement",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_owner_attestation(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    _write_delegation_token(
-        root,
-        token_name="implementation-token-deterministic-role-enforcement",
-        implementation=implementation,
-        role="implementation-agent",
-        agent_id="implementation-agent-deterministic-role-enforcement",
-    )
-    (tmp / "implementation-owner-attestation.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                "role: implementation-agent",
-                "agent_id: implementation-agent-deterministic-role-enforcement",
-                f"clone_path: {root}",
-                "created_at: 2026-05-11T00:00:00Z",
-                "delegation_token: implementation-token-deterministic-role-enforcement",
-                "delegation_token_path: .codex/tmp/delegation-tokens/implementation-agent-deterministic-role-enforcement.token",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_plan(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "implementation-plan.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                f"clone_path: {root}",
-                "owner_agent: implementation-agent-deterministic-role-enforcement",
-                "summary: Harden implementation workflow enforcement.",
-                "scope:",
-                "  - Add plan validation.",
-                "out_of_scope:",
-                "  - Live cluster changes.",
-                "planned_changes:",
-                "  - Add validator and hook checks.",
-                "docs_impact: Update workflow runbooks.",
-                "tests:",
-                "  - python3 -m unittest discover -s tools/codex-harness/tests",
-                "verification:",
-                "  - Harness tests pass.",
-                "risks:",
-                "  - Conservative guard behavior.",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 def _write_sdd_artifacts(root: Path, implementation: str, *, final_head: str | None = None) -> None:
@@ -217,67 +93,6 @@ def _write_sdd_artifacts(root: Path, implementation: str, *, final_head: str | N
     if final_head is not None:
         lines.append(f"- Final HEAD: {final_head}")
     (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def _write_verifier_approval(root: Path, head: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "verifier-approved").write_text(head + "\n", encoding="utf-8")
-
-
-def _write_verifier_attestation(root: Path, implementation: str, head: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    _write_delegation_token(
-        root,
-        token_name="verifier-token-deterministic-role-enforcement",
-        implementation=implementation,
-        role="verifier-agent",
-        agent_id="verifier-agent-deterministic-role-enforcement",
-    )
-    (tmp / "verifier-attestation.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                "role: verifier-agent",
-                "agent_id: verifier-agent-deterministic-role-enforcement",
-                f"clone_path: {root}",
-                "created_at: 2026-05-11T00:00:00Z",
-                f"approved_head: {head}",
-                "delegation_token: verifier-token-deterministic-role-enforcement",
-                "delegation_token_path: .codex/tmp/delegation-tokens/verifier-agent-deterministic-role-enforcement.token",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_delegation_token(
-    root: Path,
-    *,
-    token_name: str,
-    implementation: str,
-    role: str,
-    agent_id: str,
-) -> None:
-    token_path = root / ".codex" / "tmp" / "delegation-tokens" / f"{agent_id}.token"
-    token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(
-        "\n".join(
-            [
-                f"delegation_token: {token_name}",
-                f"implementation: {implementation}",
-                f"role: {role}",
-                f"agent_id: {agent_id}",
-                "created_at: 2026-05-11T00:00:00Z",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 def _run_script(root: Path, *args: str) -> subprocess.CompletedProcess[str]:

--- a/tools/codex-harness/tests/test_implementation_workflow_guard.py
+++ b/tools/codex-harness/tests/test_implementation_workflow_guard.py
@@ -12,80 +12,39 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "implementation_workflow_guard.sh"
 USER_PROMPT_HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "user_prompt_submit.sh"
-ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
-PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
-ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
-SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
-VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
-TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 
 class ImplementationWorkflowGuardTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.temp_parent = tempfile.TemporaryDirectory(prefix="guard-root-")
-        self.sibling_root = Path(self.temp_parent.name) / "homelab-ideas"
-        self.sibling_root.mkdir()
-        self.tmpdir = tempfile.TemporaryDirectory(dir=self.sibling_root, prefix="guard-test-")
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="guard-test-")
         self.root = Path(self.tmpdir.name)
-        self.implementation = self.root.name
+        self.implementation = "guard-test"
         self.branch = f"codex/{self.implementation}"
         self._init_repo()
         self._install_harness_files()
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()
-        self.temp_parent.cleanup()
 
-    def test_post_change_blocks_without_plan(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
+    def test_post_change_blocks_on_main(self) -> None:
         (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
 
         result = self._run_hook()
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Missing .codex/tmp/implementation-plan.yaml", result.stderr)
+        self.assertIn("Current branch is main", result.stderr)
 
-    def test_post_change_blocks_without_owner_attestation(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
+    def test_post_change_blocks_on_non_codex_branch(self) -> None:
+        subprocess.run(["git", "switch", "-c", "feature/test"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
         (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
 
         result = self._run_hook()
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Missing .codex/tmp/implementation-owner-attestation.yaml", result.stderr)
-
-    def test_post_change_allows_matching_marker_plan_and_owner_attestation(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
-        self._write_sdd_artifacts()
-        (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
-
-        result = self._run_hook()
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-
-    def test_post_change_blocks_without_sdd_context(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
-        (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
-
-        result = self._run_hook()
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Missing required SDD artifact", result.stderr)
+        self.assertIn("does not match codex/<implementation>", result.stderr)
 
     def test_post_change_allows_sdd_artifact_bootstrap(self) -> None:
         self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
         specs = self.root / "specs" / self.implementation
         specs.mkdir(parents=True, exist_ok=True)
         (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
@@ -94,71 +53,57 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_post_change_blocks_after_repo_change_intent_without_workflow(self) -> None:
-        (self.root / ".codex" / "tmp").mkdir(parents=True, exist_ok=True)
-        (self.root / ".codex" / "tmp" / "repo-change-intent").write_text(
-            "repo_change_intent=true\nhook=UserPromptSubmit\n",
-            encoding="utf-8",
-        )
+    def test_post_change_allows_matching_branch_and_sdd_context(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_sdd_artifacts()
+        (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
+
+        result = self._run_hook()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_post_change_blocks_without_sdd_context_after_bootstrap(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_sdd_artifacts()
+        subprocess.run(["git", "add", "specs"], cwd=self.root, check=True)
+        subprocess.run(["git", "commit", "-m", "test: add specs"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
+        (self.root / "specs" / self.implementation / "tasks.md").unlink()
         (self.root / "README.md").write_text("# changed\n", encoding="utf-8")
 
         result = self._run_hook()
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Current branch is main", result.stderr)
+        self.assertIn("Missing required SDD artifact", result.stderr)
 
-    def test_preflight_bash_blocks_mutating_command_without_plan(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-
-        result = self._run_hook("--preflight-bash", {"command": "git add README.md"})
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Missing .codex/tmp/implementation-plan.yaml", result.stderr)
-
-    def test_preflight_bash_allows_read_only_command_without_plan(self) -> None:
+    def test_preflight_bash_allows_read_only_command_on_main(self) -> None:
         result = self._run_hook("--preflight-bash", {"command": "git status --short"})
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_preflight_bash_allows_workflow_bootstrap_commands_without_plan(self) -> None:
-        clone = self._run_hook(
+    def test_preflight_bash_allows_default_worktree_setup_on_main(self) -> None:
+        result = self._run_hook(
             "--preflight-bash",
             {
                 "command": (
-                    "git clone https://github.com/petebeegle/homelab.git "
-                    f"{self.sibling_root}/bootstrap-test"
+                    "git worktree add /workspaces/homelab-worktrees/example "
+                    "-b codex/example origin/main"
                 )
             },
         )
-        branch = self._run_hook(
-            "--preflight-bash",
-            {"command": "git switch -c codex/bootstrap-test origin/main"},
-        )
 
-        self.assertEqual(clone.returncode, 0, clone.stderr)
-        self.assertEqual(branch.returncode, 0, branch.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_preflight_bash_blocks_branch_bootstrap_outside_sibling_clone(self) -> None:
-        with tempfile.TemporaryDirectory(prefix="planner-test-") as directory:
-            root = Path(directory)
-            self._init_external_repo(root)
-            self._install_harness_files(root)
-
-            result = self._run_hook(
-                "--preflight-bash",
-                {"command": "git switch -c codex/bootstrap-test origin/main"},
-                cwd=root,
-            )
+    def test_preflight_bash_blocks_mutating_command_on_main(self) -> None:
+        result = self._run_hook("--preflight-bash", {"command": "git add README.md"})
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Current branch is main", result.stderr)
 
-    def test_preflight_mutation_allows_workflow_bootstrap_paths(self) -> None:
-        result = self._run_hook(
-            "--preflight-mutation",
-            {"tool_input": {"path": ".codex/tmp/implementation-owner-attestation.yaml"}},
-        )
+    def test_preflight_bash_allows_mutating_command_with_sdd_context(self) -> None:
+        self._switch_to_implementation_branch()
+        self._write_sdd_artifacts()
+
+        result = self._run_hook("--preflight-bash", {"command": "git add README.md"})
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
@@ -170,11 +115,8 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_preflight_mutation_allows_sdd_artifact_bootstrap_after_workflow_validation(self) -> None:
+    def test_preflight_mutation_allows_sdd_artifact_bootstrap_on_codex_branch(self) -> None:
         self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
 
         result = self._run_hook(
             "--preflight-mutation",
@@ -183,69 +125,24 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_preflight_mutation_blocks_non_sdd_change_without_sdd_artifacts(self) -> None:
+    def test_preflight_mutation_blocks_non_sdd_change_without_artifacts(self) -> None:
         self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
 
         result = self._run_hook("--preflight-mutation", {"tool_input": {"path": "README.md"}})
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Missing required SDD artifact", result.stderr)
 
-    def test_preflight_mutation_blocks_verifier_approval_without_evidence(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
-        self._write_sdd_artifacts(include_evidence=False)
-
-        result = self._run_hook(
-            "--preflight-mutation",
-            {"tool_input": {"path": ".codex/tmp/verifier-approved"}},
-        )
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("SDD evidence validation failed", result.stderr)
-
-    def test_preflight_bash_allows_verifier_approval_with_evidence(self) -> None:
-        self._switch_to_implementation_branch()
-        self._write_marker()
-        self._write_plan()
-        self._write_owner_attestation()
-        self._write_sdd_artifacts()
-
-        result = self._run_hook(
-            "--preflight-bash",
-            {"command": "touch .codex/tmp/verifier-approved"},
-        )
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-
-    def test_user_prompt_submit_marks_repo_change_intent_and_reminds(self) -> None:
+    def test_user_prompt_submit_marks_repo_change_intent_and_recommends_worktree(self) -> None:
         result = self._run_prompt_hook({"prompt": "Please update the workflow harness tests."})
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("implementation-agent-*", result.stdout)
+        self.assertIn("dedicated worktree", result.stdout)
+        self.assertIn("/workspaces/homelab-worktrees/<implementation>", result.stdout)
         self.assertTrue((self.root / ".codex" / "tmp" / "repo-change-intent").is_file())
 
     def test_user_prompt_submit_ignores_read_only_prompt(self) -> None:
         result = self._run_prompt_hook({"prompt": "Please explain the workflow harness tests."})
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual("", result.stdout)
-        self.assertFalse((self.root / ".codex" / "tmp" / "repo-change-intent").exists())
-
-    def test_user_prompt_submit_ignores_explicit_no_edit_review_prompt(self) -> None:
-        result = self._run_prompt_hook({"prompt": "Final verifier pass, review only; do not edit files."})
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual("", result.stdout)
-        self.assertFalse((self.root / ".codex" / "tmp" / "repo-change-intent").exists())
-
-    def test_user_prompt_submit_ignores_pr_review_prompt(self) -> None:
-        result = self._run_prompt_hook({"prompt": "Please review the PR code before approval."})
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual("", result.stdout)
@@ -266,57 +163,23 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
                 self.assertEqual("", result.stdout)
                 self.assertFalse((self.root / ".codex" / "tmp" / "repo-change-intent").exists())
 
-    def test_user_prompt_submit_marks_review_then_change_prompt(self) -> None:
-        result = self._run_prompt_hook({"prompt": "Please review the workflow tests and update them."})
-
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("implementation-agent-*", result.stdout)
-        self.assertTrue((self.root / ".codex" / "tmp" / "repo-change-intent").is_file())
-
     def _init_repo(self) -> None:
-        self._init_external_repo(self.root)
+        subprocess.run(["git", "init", "-b", "main"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "config", "user.email", "codex@example.invalid"], cwd=self.root, check=True)
+        subprocess.run(["git", "config", "user.name", "Codex"], cwd=self.root, check=True)
+        subprocess.run(["git", "remote", "add", "origin", "https://github.com/petebeegle/homelab.git"], cwd=self.root, check=True)
+        (self.root / "README.md").write_text("# test\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=self.root, check=True)
+        subprocess.run(["git", "commit", "-m", "test: initialize"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
 
-    def _init_external_repo(self, root: Path) -> None:
-        subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, stdout=subprocess.DEVNULL)
-        subprocess.run(["git", "config", "user.email", "codex@example.invalid"], cwd=root, check=True)
-        subprocess.run(["git", "config", "user.name", "Codex"], cwd=root, check=True)
-        subprocess.run(["git", "remote", "add", "origin", "https://github.com/petebeegle/homelab.git"], cwd=root, check=True)
-        (root / "README.md").write_text("# test\n", encoding="utf-8")
-        subprocess.run(["git", "add", "README.md"], cwd=root, check=True)
-        subprocess.run(["git", "commit", "-m", "test: initialize"], cwd=root, check=True, stdout=subprocess.DEVNULL)
-
-    def _install_harness_files(self, root: Path | None = None) -> None:
-        target_root = root or self.root
-        hook_path = target_root / ".codex" / "hooks" / "implementation_workflow_guard.sh"
-        prompt_hook_path = target_root / ".codex" / "hooks" / "user_prompt_submit.sh"
-        tool_dir = target_root / "tools" / "codex-harness"
+    def _install_harness_files(self) -> None:
+        hook_path = self.root / ".codex" / "hooks" / "implementation_workflow_guard.sh"
+        prompt_hook_path = self.root / ".codex" / "hooks" / "user_prompt_submit.sh"
         hook_path.parent.mkdir(parents=True, exist_ok=True)
-        tool_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(HOOK_SOURCE, hook_path)
         shutil.copy2(USER_PROMPT_HOOK_SOURCE, prompt_hook_path)
-        shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
-        shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
-        shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
-        shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
-        shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
-        shutil.copytree(TOOLS_LIB_SOURCE, target_root / "tools" / "lib")
-        self._patch_sibling_root(
-            hook_path,
-            tool_dir / "validate_active_implementation.py",
-            tool_dir / "validate_implementation_plan.py",
-        )
         hook_path.chmod(0o755)
         prompt_hook_path.chmod(0o755)
-
-    def _patch_sibling_root(self, *paths: Path) -> None:
-        for path in paths:
-            path.write_text(
-                path.read_text(encoding="utf-8").replace(
-                    "/workspaces/homelab-ideas",
-                    str(self.sibling_root),
-                ),
-                encoding="utf-8",
-            )
 
     def _switch_to_implementation_branch(self) -> None:
         subprocess.run(
@@ -327,109 +190,18 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
             stderr=subprocess.DEVNULL,
         )
 
-    def _write_marker(self) -> None:
-        tmp = self.root / ".codex" / "tmp"
-        tmp.mkdir(parents=True, exist_ok=True)
-        (tmp / "active-implementation").write_text(
-            "\n".join(
-                [
-                    f"implementation={self.implementation}",
-                    f"branch={self.branch}",
-                    "base=origin/main",
-                    "role=implementation",
-                    f"clone_path={self.root}",
-                    "owner_role=implementation-agent",
-                    "owner_agent=implementation-agent-deterministic-role-enforcement",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-
-    def _write_plan(self) -> None:
-        tmp = self.root / ".codex" / "tmp"
-        tmp.mkdir(parents=True, exist_ok=True)
-        (tmp / "implementation-plan.yaml").write_text(
-            "\n".join(
-                [
-                    f"implementation: {self.implementation}",
-                    f"branch: {self.branch}",
-                    "base: origin/main",
-                    f"clone_path: {self.root}",
-                    "owner_agent: implementation-agent-deterministic-role-enforcement",
-                    "summary: Harden implementation workflow enforcement.",
-                    "scope:",
-                    "  - Add plan validation.",
-                    "out_of_scope:",
-                    "  - Live cluster changes.",
-                    "planned_changes:",
-                    "  - Add validator and hook checks.",
-                    "docs_impact: Update ADR and runbook authority.",
-                    "tests:",
-                    "  - python3 -m unittest discover -s tools/codex-harness/tests",
-                    "verification:",
-                    "  - Harness tests pass.",
-                    "risks:",
-                    "  - Conservative command classification.",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-
-    def _write_owner_attestation(self) -> None:
-        tmp = self.root / ".codex" / "tmp"
-        tmp.mkdir(parents=True, exist_ok=True)
-        token_path = tmp / "delegation-tokens" / "implementation-agent-deterministic-role-enforcement.token"
-        token_path.parent.mkdir(parents=True, exist_ok=True)
-        token_path.write_text(
-            "\n".join(
-                [
-                    "delegation_token: implementation-token-deterministic-role-enforcement",
-                    f"implementation: {self.implementation}",
-                    "role: implementation-agent",
-                    "agent_id: implementation-agent-deterministic-role-enforcement",
-                    "created_at: 2026-05-11T00:00:00Z",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-        (tmp / "implementation-owner-attestation.yaml").write_text(
-            "\n".join(
-                [
-                    f"implementation: {self.implementation}",
-                    f"branch: {self.branch}",
-                    "base: origin/main",
-                    "role: implementation-agent",
-                    "agent_id: implementation-agent-deterministic-role-enforcement",
-                    f"clone_path: {self.root}",
-                    "created_at: 2026-05-11T00:00:00Z",
-                    "delegation_token: implementation-token-deterministic-role-enforcement",
-                    "delegation_token_path: .codex/tmp/delegation-tokens/implementation-agent-deterministic-role-enforcement.token",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-
-    def _write_sdd_artifacts(self, *, include_evidence: bool = True, final_head: str | None = None) -> None:
+    def _write_sdd_artifacts(self) -> None:
         specs = self.root / "specs" / self.implementation
         specs.mkdir(parents=True, exist_ok=True)
         (specs / "spec.md").write_text("# Spec\n", encoding="utf-8")
         (specs / "plan.md").write_text("# Plan\n", encoding="utf-8")
         (specs / "tasks.md").write_text("# Tasks\n", encoding="utf-8")
-        if include_evidence:
-            lines = ["# Evidence"]
-            if final_head is not None:
-                lines.append(f"- Final HEAD: {final_head}")
-            (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        (specs / "evidence.md").write_text("# Evidence\n", encoding="utf-8")
 
     def _run_hook(
         self,
         arg: str | None = None,
         payload: dict[str, object] | None = None,
-        cwd: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         command = ["bash", ".codex/hooks/implementation_workflow_guard.sh"]
         if arg is not None:
@@ -437,7 +209,7 @@ class ImplementationWorkflowGuardTest(unittest.TestCase):
         env = os.environ.copy()
         return subprocess.run(
             command,
-            cwd=cwd or self.root,
+            cwd=self.root,
             input=json.dumps(payload or {}),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/tools/codex-harness/tests/test_validate_sdd_context.py
+++ b/tools/codex-harness/tests/test_validate_sdd_context.py
@@ -11,26 +11,18 @@ HARNESS_ROOT = REPO_ROOT / "tools" / "codex-harness"
 if str(HARNESS_ROOT) not in sys.path:
     sys.path.insert(0, str(HARNESS_ROOT))
 
-import validate_active_implementation
-from validate_active_implementation import parse_marker
 from validate_sdd_context import validate_sdd_context
 
 
 class ValidateSddContextTest(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_parent = tempfile.TemporaryDirectory(prefix="sdd-root-")
-        self.sibling_root = Path(self.temp_parent.name) / "homelab-ideas"
-        self.sibling_root.mkdir()
-        self.root = self.sibling_root / "sdd-context-test"
+        self.root = Path(self.temp_parent.name) / "sdd-context-test"
         self.root.mkdir()
         self.implementation = "sdd-context-test"
         self.branch = f"codex/{self.implementation}"
-        self.original_sibling_root = validate_active_implementation.SIBLING_CLONE_ROOT
-        validate_active_implementation.SIBLING_CLONE_ROOT = self.sibling_root
-        self._write_marker()
 
     def tearDown(self) -> None:
-        validate_active_implementation.SIBLING_CLONE_ROOT = self.original_sibling_root
         self.temp_parent.cleanup()
 
     def test_allows_valid_plan_artifacts_and_evidence(self) -> None:
@@ -39,6 +31,22 @@ class ValidateSddContextTest(unittest.TestCase):
         result = self._validate(require_evidence=True, current_head="1" * 40)
 
         self.assertTrue(result.ok, result.errors)
+
+    def test_infers_implementation_from_branch(self) -> None:
+        self._write_sdd_artifacts()
+
+        result = validate_sdd_context(root=self.root, current_branch=self.branch)
+
+        self.assertTrue(result.ok, result.errors)
+        self.assertEqual(result.values["implementation"], self.implementation)
+
+    def test_blocks_without_branch_or_implementation(self) -> None:
+        self._write_sdd_artifacts()
+
+        result = validate_sdd_context(root=self.root, current_branch="main")
+
+        self.assertFalse(result.ok)
+        self.assertTrue(any("Unable to determine implementation" in error for error in result.errors))
 
     def test_blocks_missing_plan_artifact(self) -> None:
         self._write_sdd_artifacts()
@@ -74,25 +82,6 @@ class ValidateSddContextTest(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertTrue(any("records HEAD" in error for error in result.errors))
 
-    def _write_marker(self) -> None:
-        tmp = self.root / ".codex" / "tmp"
-        tmp.mkdir(parents=True, exist_ok=True)
-        (tmp / "active-implementation").write_text(
-            "\n".join(
-                [
-                    f"implementation={self.implementation}",
-                    f"branch={self.branch}",
-                    "base=origin/main",
-                    "role=implementation",
-                    f"clone_path={self.root}",
-                    "owner_role=implementation-agent",
-                    "owner_agent=implementation-agent-sdd-context-test",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
-        )
-
     def _write_sdd_artifacts(self, *, include_evidence: bool = True, final_head: str | None = None) -> None:
         specs = self.root / "specs" / self.implementation
         specs.mkdir(parents=True, exist_ok=True)
@@ -106,10 +95,8 @@ class ValidateSddContextTest(unittest.TestCase):
             (specs / "evidence.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     def _validate(self, *, require_evidence: bool = False, current_head: str | None = None):
-        marker = parse_marker(self.root / ".codex" / "tmp" / "active-implementation")
         return validate_sdd_context(
             root=self.root,
-            marker=marker,
             current_branch=self.branch,
             require_evidence=require_evidence,
             current_head=current_head,

--- a/tools/codex-harness/tests/test_verifier_push_guard.py
+++ b/tools/codex-harness/tests/test_verifier_push_guard.py
@@ -9,79 +9,53 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 HOOK_SOURCE = REPO_ROOT / ".codex" / "hooks" / "verifier_push_guard.sh"
-ACTIVE_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_active_implementation.py"
-PLAN_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_implementation_plan.py"
-ATTESTATION_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_workflow_attestations.py"
 SDD_VALIDATOR = REPO_ROOT / "tools" / "codex-harness" / "validate_sdd_context.py"
 VALIDATION_COMMON = REPO_ROOT / "tools" / "codex-harness" / "validation_common.py"
 TOOLS_LIB_SOURCE = REPO_ROOT / "tools" / "lib"
 
 
-class VerifierPushGuardTest(unittest.TestCase):
+class SpecKitPushGuardTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.temp_parent = tempfile.TemporaryDirectory(prefix="push-root-")
-        self.sibling_root = Path(self.temp_parent.name) / "homelab-ideas"
-        self.sibling_root.mkdir()
-        self.tmpdir = tempfile.TemporaryDirectory(dir=self.sibling_root, prefix="push-test-")
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="push-test-")
         self.root = Path(self.tmpdir.name)
-        self.implementation = self.root.name
+        self.implementation = "push-test"
         self.branch = f"codex/{self.implementation}"
         _init_repo(self.root)
-        _install_harness_files(self.root, self.sibling_root)
+        _install_harness_files(self.root)
         subprocess.run(["git", "switch", "-c", self.branch], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
-        _write_marker(self.root, self.implementation)
-        _write_plan(self.root, self.implementation)
-        _write_owner_attestation(self.root, self.implementation)
-        self.head = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=self.root, text=True).strip()
         _write_sdd_artifacts(self.root, self.implementation)
 
     def tearDown(self) -> None:
         self.tmpdir.cleanup()
-        self.temp_parent.cleanup()
 
-    def test_blocks_without_verifier_attestation(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-
-        result = _run_hook(self.root)
-
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("Expected .codex/tmp/verifier-attestation.yaml", result.stderr)
-
-    def test_allows_with_verifier_approval_and_attestation(self) -> None:
-        _write_verifier_approval(self.root, self.head)
-        _write_verifier_attestation(self.root, self.implementation, self.head)
-
+    def test_allows_valid_spec_kit_branch_without_verifier_files(self) -> None:
         result = _run_hook(self.root)
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_allows_smoke_push_to_active_implementation_branch_without_verifier_approval(self) -> None:
-        result = _run_hook(
-            self.root,
-            stdin=f"HEAD {self.head} refs/heads/{self.branch} {'0' * 40}\n",
-        )
+    def test_blocks_main_branch(self) -> None:
+        subprocess.run(["git", "switch", "main"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-
-    def test_blocks_smoke_push_to_non_active_branch_without_verifier_approval(self) -> None:
-        result = _run_hook(
-            self.root,
-            stdin=f"HEAD {self.head} refs/heads/codex/other-implementation {'0' * 40}\n",
-        )
+        result = _run_hook(self.root)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("refusing to push to origin", result.stderr)
+        self.assertIn("Current branch is main", result.stderr)
 
-    def test_blocks_smoke_push_without_sdd_context(self) -> None:
-        (self.root / "specs" / self.implementation / "tasks.md").unlink()
+    def test_blocks_non_codex_branch(self) -> None:
+        subprocess.run(["git", "switch", "-c", "feature/test"], cwd=self.root, check=True, stdout=subprocess.DEVNULL)
 
-        result = _run_hook(
-            self.root,
-            stdin=f"HEAD {self.head} refs/heads/{self.branch} {'0' * 40}\n",
-        )
+        result = _run_hook(self.root)
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("refusing to push to origin", result.stderr)
+        self.assertIn("does not match codex/<implementation>", result.stderr)
+
+    def test_blocks_without_evidence(self) -> None:
+        (self.root / "specs" / self.implementation / "evidence.md").unlink()
+
+        result = _run_hook(self.root)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("evidence.md", result.stderr)
 
 
 def _init_repo(root: Path) -> None:
@@ -94,116 +68,16 @@ def _init_repo(root: Path) -> None:
     subprocess.run(["git", "commit", "-m", "test: initialize"], cwd=root, check=True, stdout=subprocess.DEVNULL)
 
 
-def _install_harness_files(root: Path, sibling_root: Path) -> None:
+def _install_harness_files(root: Path) -> None:
     hook_path = root / ".codex" / "hooks" / "verifier_push_guard.sh"
     tool_dir = root / "tools" / "codex-harness"
     hook_path.parent.mkdir(parents=True, exist_ok=True)
     tool_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy2(HOOK_SOURCE, hook_path)
-    shutil.copy2(ACTIVE_VALIDATOR, tool_dir / "validate_active_implementation.py")
-    shutil.copy2(PLAN_VALIDATOR, tool_dir / "validate_implementation_plan.py")
-    shutil.copy2(ATTESTATION_VALIDATOR, tool_dir / "validate_workflow_attestations.py")
     shutil.copy2(SDD_VALIDATOR, tool_dir / "validate_sdd_context.py")
     shutil.copy2(VALIDATION_COMMON, tool_dir / "validation_common.py")
     shutil.copytree(TOOLS_LIB_SOURCE, root / "tools" / "lib")
-    _patch_sibling_root(
-        sibling_root,
-        tool_dir / "validate_active_implementation.py",
-        tool_dir / "validate_implementation_plan.py",
-    )
     hook_path.chmod(0o755)
-
-
-def _patch_sibling_root(sibling_root: Path, *paths: Path) -> None:
-    for path in paths:
-        path.write_text(
-            path.read_text(encoding="utf-8").replace(
-                "/workspaces/homelab-ideas",
-                str(sibling_root),
-            ),
-            encoding="utf-8",
-        )
-
-
-def _write_marker(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "active-implementation").write_text(
-        "\n".join(
-            [
-                f"implementation={implementation}",
-                f"branch=codex/{implementation}",
-                "base=origin/main",
-                "role=implementation",
-                f"clone_path={root}",
-                "owner_role=implementation-agent",
-                "owner_agent=implementation-agent-deterministic-role-enforcement",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_owner_attestation(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    _write_delegation_token(
-        root,
-        token_name="implementation-token-deterministic-role-enforcement",
-        implementation=implementation,
-        role="implementation-agent",
-        agent_id="implementation-agent-deterministic-role-enforcement",
-    )
-    (tmp / "implementation-owner-attestation.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                "role: implementation-agent",
-                "agent_id: implementation-agent-deterministic-role-enforcement",
-                f"clone_path: {root}",
-                "created_at: 2026-05-11T00:00:00Z",
-                "delegation_token: implementation-token-deterministic-role-enforcement",
-                "delegation_token_path: .codex/tmp/delegation-tokens/implementation-agent-deterministic-role-enforcement.token",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_plan(root: Path, implementation: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "implementation-plan.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                f"clone_path: {root}",
-                "owner_agent: implementation-agent-deterministic-role-enforcement",
-                "summary: Harden implementation workflow enforcement.",
-                "scope:",
-                "  - Add plan validation.",
-                "out_of_scope:",
-                "  - Live cluster changes.",
-                "planned_changes:",
-                "  - Add validator and hook checks.",
-                "docs_impact: Update workflow runbooks.",
-                "tests:",
-                "  - python3 -m unittest discover -s tools/codex-harness/tests",
-                "verification:",
-                "  - Harness tests pass.",
-                "risks:",
-                "  - Conservative guard behavior.",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
 
 
 def _write_sdd_artifacts(root: Path, implementation: str) -> None:
@@ -215,72 +89,10 @@ def _write_sdd_artifacts(root: Path, implementation: str) -> None:
     (specs / "evidence.md").write_text("# Evidence\n", encoding="utf-8")
 
 
-def _write_verifier_approval(root: Path, head: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    (tmp / "verifier-approved").write_text(head + "\n", encoding="utf-8")
-
-
-def _write_verifier_attestation(root: Path, implementation: str, head: str) -> None:
-    tmp = root / ".codex" / "tmp"
-    tmp.mkdir(parents=True, exist_ok=True)
-    _write_delegation_token(
-        root,
-        token_name="verifier-token-deterministic-role-enforcement",
-        implementation=implementation,
-        role="verifier-agent",
-        agent_id="verifier-agent-deterministic-role-enforcement",
-    )
-    (tmp / "verifier-attestation.yaml").write_text(
-        "\n".join(
-            [
-                f"implementation: {implementation}",
-                f"branch: codex/{implementation}",
-                "base: origin/main",
-                "role: verifier-agent",
-                "agent_id: verifier-agent-deterministic-role-enforcement",
-                f"clone_path: {root}",
-                "created_at: 2026-05-11T00:00:00Z",
-                f"approved_head: {head}",
-                "delegation_token: verifier-token-deterministic-role-enforcement",
-                "delegation_token_path: .codex/tmp/delegation-tokens/verifier-agent-deterministic-role-enforcement.token",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_delegation_token(
-    root: Path,
-    *,
-    token_name: str,
-    implementation: str,
-    role: str,
-    agent_id: str,
-) -> None:
-    token_path = root / ".codex" / "tmp" / "delegation-tokens" / f"{agent_id}.token"
-    token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(
-        "\n".join(
-            [
-                f"delegation_token: {token_name}",
-                f"implementation: {implementation}",
-                f"role: {role}",
-                f"agent_id: {agent_id}",
-                "created_at: 2026-05-11T00:00:00Z",
-            ]
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def _run_hook(root: Path, *, stdin: str = "") -> subprocess.CompletedProcess[str]:
+def _run_hook(root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", ".codex/hooks/verifier_push_guard.sh", "origin", "https://github.com/petebeegle/homelab.git"],
         cwd=root,
-        input=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,

--- a/tools/codex-harness/validate_sdd_context.py
+++ b/tools/codex-harness/validate_sdd_context.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate durable Spec Kit context for an active implementation."""
+"""Validate durable Spec Kit context for a branch-scoped implementation."""
 
 from __future__ import annotations
 
@@ -19,9 +19,6 @@ if str(TOOLS_LIB) not in sys.path:
 
 from homelab_tools.git import discover_git_branch, discover_git_head, discover_git_root
 from validation_common import ValidationResult, path_from_cwd
-from validate_active_implementation import parse_marker, validate_marker
-
-
 REQUIRED_PLAN_ARTIFACTS = ("spec.md", "plan.md", "tasks.md")
 EVIDENCE_ARTIFACT = "evidence.md"
 EXPLICIT_HEAD_RE = re.compile(
@@ -38,8 +35,9 @@ SddContextValidationResult = ValidationResult
 def validate_sdd_context(
     *,
     root: Path | str,
-    marker: Mapping[str, str],
+    marker: Mapping[str, str] | None = None,
     current_branch: str | None = None,
+    implementation: str | None = None,
     require_plan_artifacts: bool = True,
     require_evidence: bool = False,
     current_head: str | None = None,
@@ -47,10 +45,19 @@ def validate_sdd_context(
     errors: list[str] = []
     root_path = Path(root)
 
-    marker_result = validate_marker(marker, current_root=root_path, current_branch=current_branch)
-    errors.extend(f"Active implementation marker: {error}" for error in marker_result.errors)
+    if marker is not None:
+        from validate_active_implementation import validate_marker
 
-    implementation = marker.get("implementation", "")
+        marker_result = validate_marker(marker, current_root=root_path, current_branch=current_branch)
+        errors.extend(f"Active implementation marker: {error}" for error in marker_result.errors)
+        implementation = marker.get("implementation", implementation or "")
+
+    if not implementation and current_branch and current_branch.startswith("codex/"):
+        implementation = current_branch.split("/", 1)[1]
+
+    if not implementation:
+        errors.append("Unable to determine implementation from --implementation, marker, or codex/<implementation> branch.")
+
     specs_dir = root_path / "specs" / implementation if implementation else root_path / "specs" / "<implementation>"
 
     if require_plan_artifacts:
@@ -69,12 +76,17 @@ def validate_sdd_context(
                 f"but current HEAD is {current_head}."
             )
 
-    return SddContextValidationResult({"implementation": implementation}, tuple(errors))
+    return SddContextValidationResult({"implementation": implementation or ""}, tuple(errors))
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate specs/<implementation>/ durable SDD context.")
-    parser.add_argument("--marker", default=".codex/tmp/active-implementation")
+    parser.add_argument(
+        "--marker",
+        default=None,
+        help="Optional old workflow marker. If omitted, infer implementation from codex/<implementation> branch.",
+    )
+    parser.add_argument("--implementation", help="Implementation slug. Defaults to codex/<implementation> branch suffix.")
     parser.add_argument("--root", help="Current repository root. Defaults to git rev-parse --show-toplevel.")
     parser.add_argument("--branch", help="Current branch. Defaults to git branch --show-current.")
     parser.add_argument(
@@ -98,22 +110,25 @@ def main(argv: Sequence[str] | None = None) -> int:
     root = Path(args.root) if args.root is not None else discover_git_root(Path.cwd())
     branch = args.branch if args.branch is not None else discover_git_branch(Path.cwd())
     head = args.head if args.head is not None else discover_git_head(Path.cwd())
-    marker_path = path_from_cwd(args.marker)
+    marker = None
+    if args.marker is not None:
+        marker_path = path_from_cwd(args.marker)
+        if not marker_path.is_file():
+            print(f"Active implementation marker not found: {marker_path}", file=sys.stderr)
+            return 1
+        try:
+            from validate_active_implementation import parse_marker
 
-    if not marker_path.is_file():
-        print(f"Active implementation marker not found: {marker_path}", file=sys.stderr)
-        return 1
-
-    try:
-        marker = parse_marker(marker_path)
-    except (OSError, ValueError) as exc:
-        print(f"Active implementation marker is invalid: {exc}", file=sys.stderr)
-        return 1
+            marker = parse_marker(marker_path)
+        except (OSError, ValueError) as exc:
+            print(f"Active implementation marker is invalid: {exc}", file=sys.stderr)
+            return 1
 
     result = validate_sdd_context(
         root=root,
         marker=marker,
         current_branch=branch,
+        implementation=args.implementation,
         require_plan_artifacts=args.require_plan_artifacts,
         require_evidence=args.require_evidence,
         current_head=head,


### PR DESCRIPTION
## Summary

Adopts the standard Spec Kit workflow as the repository implementation flow while preserving concurrent work through default worktree isolation.

## Changes

- Updates AGENTS, ADRs, runbooks, constitution, and Spec Kit templates to remove local owner/verifier attestation requirements.
- Changes workflow guards to enforce `codex/<implementation>` branches plus matching `specs/<implementation>/` artifacts.
- Changes push/PR automation to require SDD evidence instead of verifier approval files.
- Adds SDD artifacts for `adopt-speckit-worktree-flow`.

## Validation

- `python3 -m unittest discover -s tools/codex-harness/tests` passed.
- `python3 tools/architecture/render.py --check` passed.
- `pre-commit run --all-files` was attempted; all hooks passed until `agent-memory-lint`, which failed because `.codex/memory` is absent in this worktree.
