### PR TITLE
fix(homepage): serve dashboard on homepage host

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,7 +173,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `home-assistant-${branch_slug}/home-assistant-${branch_slug}` | `homeassistant-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `home-assistant-${branch_slug}:80` |
 | `HTTPRoute` | `home-assistant/home-assistant` | `homeassistant.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `home-assistant:80` |
 | `HTTPRoute` | `homepage-${branch_slug}/homepage-${branch_slug}` | `homepage-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `homepage-${branch_slug}:80` |
-| `HTTPRoute` | `homepage/homepage` | `${cluster_domain}` | `gateway/internal/https-domain-gateway, gateway/external/https-domain-gateway` | `homepage:80` |
+| `HTTPRoute` | `homepage/homepage` | `homepage.${cluster_domain}` | `gateway/internal/https-domain-gateway, gateway/external/https-domain-gateway` | `homepage:80` |
 | `HTTPRoute` | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `jellyfin-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `jellyfin-${branch_slug}-metrics-deny:8096` |
 | `HTTPRoute` | `jellyfin/jellyfin` | `jellyfin.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `jellyfin-metrics-deny:8096` |
 | `HTTPRoute` | `otel-collector/otel-collector` | `otel.${cluster_domain}` | `gateway/internal/https-gateway` | `otel-collector-opentelemetry-collector:4318` |

--- a/kubernetes/apps/homepage/base/configmap.yaml
+++ b/kubernetes/apps/homepage/base/configmap.yaml
@@ -31,7 +31,7 @@ data:
     - Core:
         - Homepage:
             icon: homepage.png
-            href: https://${homepage_target_domain}
+            href: https://homepage.${homepage_target_domain}
             description: Homelab dashboard
             namespace: homepage
             app: homepage

--- a/kubernetes/apps/homepage/base/deployment.yaml
+++ b/kubernetes/apps/homepage/base/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           imagePullPolicy: IfNotPresent
           env:
             - name: HOMEPAGE_ALLOWED_HOSTS
-              value: ${cluster_domain}
+              value: homepage.${cluster_domain}
             - name: LOG_TARGETS
               value: stdout
           ports:

--- a/kubernetes/apps/homepage/base/httproute.yaml
+++ b/kubernetes/apps/homepage/base/httproute.yaml
@@ -15,7 +15,7 @@ spec:
       namespace: gateway
       sectionName: https-domain-gateway
   hostnames:
-    - ${cluster_domain}
+    - homepage.${cluster_domain}
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/homepage/development/kustomization.yaml
+++ b/kubernetes/apps/homepage/development/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
           - Core:
               - Homepage:
                   icon: homepage.png
-                  href: https://lab.petebeegle.com
+                  href: https://homepage.lab.petebeegle.com
                   description: Homelab dashboard
               - Authentik:
                   icon: authentik.png


### PR DESCRIPTION
## Summary
- serve production Homepage at homepage.${cluster_domain} instead of the apex domain
- set HOMEPAGE_ALLOWED_HOSTS to the same hostname
- update the Homepage self-card to https://homepage.lab.petebeegle.com while leaving other service cards on production targets

## Validation
- kubectl kustomize kubernetes/clusters/production
- kubectl kustomize kubernetes/clusters/development
- strict prod/dev Homepage renders with flux envsubst --strict
- python3 tools/architecture/render.py --check
- python3 -m unittest tools.development.tests.test_verify_branch_deploy
- git diff --check