### PR TITLE
Implementation: home-assistant-dashboard-activity

### DIFF
--- a/kubernetes/apps/home-assistant/branch/config/configuration.yaml
+++ b/kubernetes/apps/home-assistant/branch/config/configuration.yaml
@@ -17,6 +17,24 @@ http:
   trusted_proxies:
     - 10.244.0.0/16
 
+prometheus:
+  namespace: homeassistant
+  requires_auth: false
+  filter:
+    include_domains:
+      - light
+      - switch
+      - binary_sensor
+      - sensor
+      - person
+      - device_tracker
+      - automation
+      - climate
+      - cover
+      - fan
+      - lock
+      - update
+
 automation: !include automations.yaml
 script: !include scripts.yaml
 scene: !include scenes.yaml

--- a/kubernetes/apps/home-assistant/branch/home-assistant.yaml
+++ b/kubernetes/apps/home-assistant/branch/home-assistant.yaml
@@ -141,6 +141,10 @@ metadata:
   labels:
     app.kubernetes.io/name: home-assistant
     homelab.petebeegle.com/branch-slug: ${branch_slug}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "80"
+    prometheus.io/path: /api/prometheus
 spec:
   selector:
     app.kubernetes.io/name: home-assistant

--- a/kubernetes/apps/home-assistant/config/configuration.yaml
+++ b/kubernetes/apps/home-assistant/config/configuration.yaml
@@ -22,6 +22,24 @@ http:
   trusted_proxies:
     - 10.244.0.0/16
 
+prometheus:
+  namespace: homeassistant
+  requires_auth: false
+  filter:
+    include_domains:
+      - light
+      - switch
+      - binary_sensor
+      - sensor
+      - person
+      - device_tracker
+      - automation
+      - climate
+      - cover
+      - fan
+      - lock
+      - update
+
 auth_oidc:
   client_id: home-assistant
   discovery_url: https://authentik.${cluster_domain}/application/o/home-assistant/.well-known/openid-configuration

--- a/kubernetes/apps/home-assistant/service.yaml
+++ b/kubernetes/apps/home-assistant/service.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: home-assistant
   labels:
     app.kubernetes.io/name: home-assistant
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "80"
+    prometheus.io/path: /api/prometheus
 spec:
   selector:
     app.kubernetes.io/name: home-assistant

--- a/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
@@ -319,72 +319,6 @@
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 1
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "editorMode": "code",
-          "expr": "sum(count_over_time({namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\" | logfmt | status=\"failed\" [30m])) OR vector(0)",
-          "legendFormat": "failed runs",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "Smoke Failures",
-      "type": "stat"
-    },
-    {
-      "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
@@ -414,7 +348,7 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
+        "x": 16,
         "y": 1
       },
       "id": 7,
@@ -452,6 +386,79 @@
       "type": "stat"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Activity",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (__name__) (changes({__name__=~\"homeassistant_(light|switch|binary_sensor|person|device_tracker|automation|climate|cover|fan|lock|update)_state|homeassistant_sensor_.+\"}[$__rate_interval])) OR vector(0)",
+          "legendFormat": "{{__name__}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Recent Entity Changes",
+      "type": "timeseries"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -480,12 +487,12 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 5
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
       },
-      "id": 8,
+      "id": 22,
       "options": {
         "cellHeight": "sm",
         "footer": {
@@ -505,15 +512,284 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "kube_pod_status_phase{exported_namespace=\"home-assistant\",pod=~\"home-assistant-.*\"}",
+          "expr": "(homeassistant_entity_available == 0) * on(entity) group_left(name, area) homeassistant_entity_info",
           "format": "table",
           "instant": true,
-          "legendFormat": "{{pod}} {{phase}}",
+          "legendFormat": "{{entity}}",
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Pod Phases",
+      "title": "Unavailable Entities",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum((homeassistant_light_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
+          "instant": true,
+          "legendFormat": "lights on",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Lights",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum((homeassistant_switch_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
+          "instant": true,
+          "legendFormat": "switches on",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Switches",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum((homeassistant_binary_sensor_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
+          "instant": true,
+          "legendFormat": "binary sensors on",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Binary Sensors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 26,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (area, domain) (homeassistant_entity_info{domain=~\"light|switch|binary_sensor|sensor|person|device_tracker|automation|climate|cover|fan|lock|update\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{entity}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Entities By Area",
       "type": "table"
     },
     {
@@ -522,7 +798,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 22
       },
       "id": 9,
       "panels": [],
@@ -556,7 +832,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 13
+        "y": 23
       },
       "id": 10,
       "options": {
@@ -616,7 +892,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 13
+        "y": 23
       },
       "id": 11,
       "options": {
@@ -655,7 +931,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 31
       },
       "id": 12,
       "panels": [],
@@ -671,7 +947,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 32
       },
       "id": 13,
       "options": {
@@ -708,7 +984,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 32
       },
       "id": 14,
       "options": {
@@ -745,7 +1021,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 40
       },
       "id": 15,
       "options": {
@@ -772,158 +1048,6 @@
       ],
       "title": "Observed Integration Activity",
       "type": "logs"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 38
-      },
-      "id": 16,
-      "panels": [],
-      "title": "Synthetic Smoke",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 39
-      },
-      "id": 17,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "kube_pod_status_phase{exported_namespace=\"synthetics\",pod=~\"synthetic-smoke-.*\"}",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "{{pod}} {{phase}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Synthetic Pod State",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 46
-      },
-      "id": 18,
-      "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "editorMode": "code",
-          "expr": "{namespace=\"synthetics\", app=\"synthetic-smoke\"} |= \"SMOKE_RUN_SUMMARY\"",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "Smoke Summary Logs",
-      "type": "logs"
-    },
-    {
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 46
-      },
-      "id": 19,
-      "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "editorMode": "code",
-          "expr": "{namespace=\"synthetics\", app=\"synthetic-smoke\"} |~ \"(?i)(home assistant|homeassistant|authentik|oidc|onboarding)\"",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "Home Assistant Route Smoke Logs",
-      "type": "logs"
     }
   ],
   "refresh": "1m",
@@ -945,6 +1069,6 @@
   "timezone": "browser",
   "title": "Home Assistant - Overview",
   "uid": "home-assistant-overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/specs/home-assistant-dashboard-activity/evidence.md
+++ b/specs/home-assistant-dashboard-activity/evidence.md
@@ -1,0 +1,97 @@
+# Evidence: home-assistant-dashboard-activity
+
+**Branch**: `codex/home-assistant-dashboard-activity`
+**Risk Tier**: medium
+**Started**: 2026-07-04
+**Owner**: implementation-agent-home-assistant-dashboard-activity
+
+## Spec Kit Initialization
+
+- Command: Not rerun; repository Spec Kit scaffolding already present on
+  `origin/main`.
+- Outcome: Used existing `.specify/` templates and constitution.
+- Spec Kit version: Not changed by this implementation.
+- Integration: Existing repository integration.
+- Fallback: None.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `git remote set-url origin https://github.com/petebeegle/homelab.git && git fetch origin && git checkout -B codex/home-assistant-dashboard-activity origin/main` | PASS | Corrected implementation clone from stale local remote base `1750d60847d94c62bf4d0b5bc89d30cfc4a74cce` to current `origin/main` `c3c4210e349f90b1027b9a21944119303329fe02` before tracked edits. |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed after SDD bootstrap artifacts were created. |
+| `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json` | PASS | Dashboard JSON is valid. |
+| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Production render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
+| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Branch render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
+| `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` | PASS | Dashboard ConfigMap render includes Activity panels and no removed Home Assistant dashboard panel titles. |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture document unchanged. |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Passed against final committed SDD evidence. |
+
+## Development Validation
+
+- Profile: manual
+- Branch slug: `home-assistant-dashboard-activity`
+- Validated commit: `f3259955819ede0664503a2733e63752bbd7c7e1` for the pushed
+  development validation commit.
+- Report path: N/A; helper output captured in command log.
+- Cleanup: PASS; helper deleted
+  `kustomization.kustomize.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`,
+  waited for namespace `home-assistant-home-assistant-dashboard-activity`
+  deletion, and deleted
+  `gitrepository.source.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`.
+- Prerequisite preparation:
+  `.codex/scripts/prepare_development_smoke_secrets.sh home-assistant-dashboard-activity /workspaces/homelab-ideas/home-assistant-dashboard-activity`
+  passed and installed the ignored development Terraform tfvars into the
+  implementation clone without logging secret contents.
+- Result or exception:
+  `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-dashboard-activity --slug home-assistant-dashboard-activity --push`
+  PASS. The helper pushed the branch, ran Terraform init/validate/plan,
+  applied the branch Flux activation, reconciled GitRepository and
+  Kustomization to
+  `codex/home-assistant-dashboard-activity@sha1:f3259955819ede0664503a2733e63752bbd7c7e1`,
+  confirmed namespace active, waited for the Home Assistant pod Ready
+  condition, checked PVC, Service, and HTTPRoute resources, ran the in-cluster
+  HTTP probe successfully, and cleaned up the branch Flux resources and
+  namespace.
+
+## Grafana/Mimir Query Smoke
+
+- Query target: native `homeassistant_*` metrics after exporter enablement.
+- Result or exception:
+  `mcp__grafana.list_prometheus_metric_names(datasourceUid="prometheus", regex="^homeassistant_.*", startRfc3339="now-6h", endRfc3339="now")`
+  returned `401 Unauthorized` while reading datasource UID `prometheus`.
+  Substitute checks are the dashboard JSON validation, dashboard kustomize
+  render, and rendered Home Assistant Service scrape annotations.
+
+## Documentation Impact
+
+- Updated: SDD artifacts under `specs/home-assistant-dashboard-activity/`.
+- Generated docs: `docs/architecture.md` unchanged;
+  `python3 tools/architecture/render.py --check` passed.
+- No-docs rationale: No runbook or ADR changes are expected because this change
+  follows existing Home Assistant, Grafana, Gateway, and monitoring patterns.
+
+## Exceptions And Follow-Ups
+
+- TDD exception: no practical red unit-test seam exists for this YAML and
+  Grafana JSON-only change; focused render/schema checks are the substitute.
+- Grafana/Mimir live query smoke is blocked by Grafana datasource authorization
+  in this session (`401 Unauthorized` for datasource UID `prometheus`).
+
+## Final State
+
+- Final branch: `codex/home-assistant-dashboard-activity`.
+- Final HEAD at verifier feedback:
+  `33a42d3c99d06cb0d4ed83b4c37e35d89dac9fc6`.
+- Evidence correction: this follow-up records the exact implementation-owner
+  handoff commit above durably in tracked evidence after verifier feedback.
+- Commit: `feat(home-assistant): add activity metrics dashboard`
+- Verifier approval: not created by implementation owner.

--- a/specs/home-assistant-dashboard-activity/plan.md
+++ b/specs/home-assistant-dashboard-activity/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: home-assistant-dashboard-activity
+
+**Branch**: `codex/home-assistant-dashboard-activity` | **Date**: 2026-07-04 | **Spec**:
+`specs/home-assistant-dashboard-activity/spec.md`
+
+**Input**: Feature specification from `specs/home-assistant-dashboard-activity/spec.md`
+
+## Summary
+
+Enable Home Assistant's native Prometheus exporter for the production and branch
+apps, annotate the Services for internal scraping, and update the Home
+Assistant Grafana dashboard to replace synthetic smoke-specific panels with a
+native Prometheus-backed Activity section while preserving operational health
+and log panels.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes app manifests, branch overlay, Grafana dashboard,
+SDD evidence
+**Dependencies**: kubectl kustomize, jq, Python architecture renderer, Codex
+harness validators, development branch deploy helper, Grafana/Mimir access if
+available
+**Storage**: Existing Home Assistant PVC remains on the configured storage;
+this change does not alter PVCs or StorageClasses.
+**Ingress**: Gateway API invariant preserved; no `Ingress`, HTTPRoute, TLSRoute,
+or external route changes.
+**Secrets**: SOPS invariant preserved; no secrets are read, created, or edited.
+**Development Validation**: attempt
+`python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-dashboard-activity --slug home-assistant-dashboard-activity --push`;
+record exact exception and substitute checks if prerequisites are unavailable.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/home-assistant-dashboard-activity`; sibling clone
+      ownership files were validated before tracked edits.
+- [x] Documentation impact identified; SDD artifacts document the behavior and
+      generated architecture is checked.
+- [x] PR review/status checks are the review gate; verifier approval is not
+      created by the implementation owner.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/home-assistant-dashboard-activity/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/home-assistant/config/configuration.yaml
+kubernetes/apps/home-assistant/branch/config/configuration.yaml
+kubernetes/apps/home-assistant/service.yaml
+kubernetes/apps/home-assistant/branch/home-assistant.yaml
+kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
+specs/home-assistant-dashboard-activity/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: There is no practical red unit-test seam for a Grafana JSON
+dashboard and Kubernetes YAML-only configuration change. Use focused render and
+schema checks as the medium-tier substitute, and document the exception in
+evidence.
+
+**Local checks**:
+
+- `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
+- `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"`
+- `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"`
+- `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+- `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
+- `kubectl kustomize kubernetes/apps/home-assistant`
+- `kubectl kustomize kubernetes/apps/home-assistant/branch`
+- `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"`
+
+**Development smoke**: Attempt the Home Assistant branch deployment helper with
+`--push` after local checks pass. If kubeconfig, cluster credentials, staged
+secrets, or network prerequisites are unavailable, record the exact blocker and
+substitute local kustomize/dashboard checks.
+
+**Evidence destination**: `specs/home-assistant-dashboard-activity/evidence.md`
+and `.codex/tmp/pr-summary.md`.
+
+## Documentation Impact
+
+- SDD artifacts document the accepted plan, source-doc rationale, validation,
+  and exceptions.
+- `docs/architecture.md` is expected to remain unchanged because the app,
+  route, and storage topology do not change; run
+  `python3 tools/architecture/render.py --check` and update generated
+  architecture only if it reports drift.
+
+## Implementation Steps
+
+1. Create workflow files and durable SDD artifacts from the corrected
+   `origin/main` base.
+2. Enable the Home Assistant Prometheus exporter in production and branch
+   configuration.
+3. Annotate production and branch Home Assistant Services for internal
+   Prometheus scraping.
+4. Update the Grafana dashboard JSON by removing the requested synthetic
+   smoke/pod phase panels and adding the Activity row and native
+   Home Assistant Prometheus panels.
+5. Run local validation, architecture check, SDD validators, development smoke
+   attempt, and live metric query smoke attempt.
+6. Record evidence, write `.codex/tmp/pr-summary.md`, and commit with a
+   conventional commit message.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Dashboard queries reference metrics before Home Assistant has restarted and Prometheus has scraped them. | Use `OR vector(0)` or table queries that tolerate absent series and record live query smoke availability. |
+| `requires_auth: false` exposes the exporter if routing changes later. | Keep exposure limited to internal Service scraping annotations; no external route changes are included. |
+| Development branch deploy requires unavailable cluster credentials or secret staging. | Attempt the helper and record the exact exception plus substitute local renders. |
+| Home Assistant exporter omits unavailable or unknown entities after startup. | Include `homeassistant_entity_available` and document that activity is Prometheus-derived rather than Logbook prose. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/home-assistant-dashboard-activity/spec.md
+++ b/specs/home-assistant-dashboard-activity/spec.md
@@ -1,0 +1,181 @@
+# Feature Specification: home-assistant-dashboard-activity
+
+**Feature Branch**: `codex/home-assistant-dashboard-activity`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: medium
+**Input**: User description: "Add native Home Assistant Prometheus activity metrics to the Home Assistant dashboard, replacing synthetic smoke-specific panels while preserving operational health coverage."
+
+## Summary
+
+Operators should be able to inspect Home Assistant activity from native Home
+Assistant Prometheus metrics in the existing Grafana dashboard. The dashboard
+should retain Kubernetes health, route, PVC, resource, and application log
+coverage, while synthetic smoke-specific panels move out of the Home Assistant
+overview.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/development-cluster.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/sops-age-secrets.md`
+- Home Assistant Prometheus integration docs: https://www.home-assistant.io/integrations/prometheus/
+
+## Scope
+
+### In Scope
+
+- Enable the native Home Assistant Prometheus exporter in production and branch
+  Home Assistant configuration.
+- Annotate production and branch Home Assistant Services for internal
+  Prometheus scraping of `/api/prometheus` on port 80.
+- Replace synthetic smoke-specific Home Assistant dashboard panels with an
+  Activity row backed by Prometheus queries for entity changes, unavailable
+  entities, active lights, active switches, active binary sensors, and
+  entity/area metadata.
+- Preserve dashboard coverage for Home Assistant Kubernetes health, route
+  status, PVC phase, CPU, memory, and Home Assistant logs.
+- Record workflow, local validation, development validation attempt, live query
+  smoke attempt, exceptions, and final branch state.
+
+### Out Of Scope
+
+- New secrets, external routes, internet-public exposure, or bearer token
+  management.
+- Changing the standalone synthetic smoke dashboard.
+- Exact Home Assistant Logbook prose reconstruction; dashboard activity is
+  Prometheus-derived.
+- Verifier approval artifacts or PR creation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Native Activity Metrics (Priority: P1)
+
+An operator can open the Home Assistant Grafana dashboard and see recent native
+Home Assistant entity activity and current entity state summaries.
+
+**Why this priority**: Native Home Assistant activity is the core user outcome
+and replaces lower-signal synthetic smoke-specific panels in this dashboard.
+
+**Independent Test**: `jq empty` validates the dashboard JSON and review of the
+dashboard panel titles and Prometheus expressions confirms the Activity row uses
+Home Assistant metrics with the `prometheus` datasource.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Home Assistant dashboard JSON, **When** an operator reviews the
+   panel list, **Then** it includes an Activity row with Prometheus panels for
+   recent entity changes, unavailable entities, active lights, active switches,
+   active binary sensors, and entity/area metadata.
+2. **Given** the Home Assistant dashboard JSON, **When** an operator reviews
+   removed panel titles, **Then** `Smoke Failures`, `Synthetic Smoke`,
+   `Synthetic Pod State`, `Smoke Summary Logs`, `Home Assistant Route Smoke
+   Logs`, and `Pod Phases` are absent.
+
+### User Story 2 - Scrapeable Home Assistant Exporter (Priority: P2)
+
+Prometheus can discover and scrape the Home Assistant native exporter from both
+production and branch app manifests without new credentials.
+
+**Why this priority**: Dashboard panels need native metrics to exist in Mimir,
+and branch validation should exercise the same exporter behavior.
+
+**Independent Test**: `kubectl kustomize kubernetes/apps/home-assistant` and
+`kubectl kustomize kubernetes/apps/home-assistant/branch` render configuration
+with the Prometheus exporter and Service scrape annotations.
+
+**Acceptance Scenarios**:
+
+1. **Given** production Home Assistant rendered manifests, **When** the
+   ConfigMap and Service are inspected, **Then** the Prometheus exporter is
+   enabled with namespace `homeassistant`, `requires_auth: false`, the approved
+   domain filter, and scrape annotations for `/api/prometheus`.
+2. **Given** branch Home Assistant rendered manifests, **When** the ConfigMap
+   and Service are inspected, **Then** they expose the same exporter behavior
+   using branch names and namespaces.
+
+### User Story 3 - Operational Coverage Preserved (Priority: P3)
+
+An operator keeps the existing Home Assistant operational view while activity
+metrics are added.
+
+**Why this priority**: The dashboard should become more app-relevant without
+losing health, route, storage, resource, or log signals.
+
+**Independent Test**: `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
+renders the dashboard ConfigMap and review confirms retained panels remain.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated dashboard JSON, **When** an operator reviews panel
+   titles, **Then** Kubernetes health, route acceptance, route refs, PVC phase,
+   CPU, memory, and Home Assistant log panels remain.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST enable Home Assistant `prometheus:` in
+  production and branch configuration with namespace `homeassistant`,
+  `requires_auth: false`, and `filter.include_domains` containing `light`,
+  `switch`, `binary_sensor`, `sensor`, `person`, `device_tracker`,
+  `automation`, `climate`, `cover`, `fan`, `lock`, and `update`.
+- **FR-002**: The implementation MUST annotate production and branch Home
+  Assistant Services with `prometheus.io/scrape: "true"`,
+  `prometheus.io/port: "80"`, and `prometheus.io/path: /api/prometheus`.
+- **FR-003**: The dashboard MUST remove panels titled `Smoke Failures`,
+  `Synthetic Smoke`, `Synthetic Pod State`, `Smoke Summary Logs`, `Home
+  Assistant Route Smoke Logs`, and `Pod Phases`.
+- **FR-004**: The dashboard MUST add an `Activity` row with Prometheus panels
+  for recent entity changes, currently unavailable entities, active lights,
+  active switches, active binary sensors, and entity/area metadata joined
+  through `homeassistant_entity_info` where useful.
+- **FR-005**: The dashboard MUST preserve Kubernetes health, route, PVC, CPU,
+  memory, and Home Assistant log coverage.
+- **FR-006**: The implementation MUST keep Grafana datasource UIDs
+  `prometheus` and `loki` and MUST NOT add new secrets or external routes.
+- **FR-007**: Evidence MUST record required local checks, SDD/workflow
+  validators, the development validation attempt or exact exception, the live
+  metric query smoke attempt or exact exception, final branch, final `HEAD`, and
+  that verifier approval was not created.
+
+## Risk And Validation Expectations
+
+**Medium**: Include local Kubernetes and Grafana render checks plus
+development-cluster validation for the Home Assistant branch app when
+prerequisites are available. If development infrastructure, credentials, or
+cluster access are unavailable, record the exact exception and substitute local
+checks. Attempt a live Grafana/Mimir query for new `homeassistant_*` metrics if
+credentials are available; otherwise record the exact unauthorized or
+unavailable exception.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Production and branch Home Assistant kustomize output includes
+  the approved Prometheus exporter configuration and Service annotations.
+- **SC-002**: The Home Assistant dashboard JSON is valid JSON and no longer
+  contains the removed synthetic smoke-specific panel titles.
+- **SC-003**: The Home Assistant dashboard contains an Activity row with
+  Prometheus datasource panels based on native Home Assistant metrics.
+- **SC-004**: Dashboard kustomize render and architecture check pass, or
+  generated architecture is updated if the check reports drift.
+- **SC-005**: Evidence and PR summary document all local checks, development
+  validation, live metric query smoke, exceptions, final branch state, and
+  verifier-approval absence.
+
+## Assumptions
+
+- Internal Service scraping makes `requires_auth: false` acceptable for the
+  Home Assistant Prometheus endpoint.
+- Prometheus metrics appear only after Home Assistant restarts with the updated
+  configuration and Prometheus scrapes `/api/prometheus`.
+- Home Assistant's documented `entity_info` metric is prefixed by the configured
+  namespace, so this implementation uses `homeassistant_entity_info`.
+
+## Open Questions
+
+- None.

--- a/specs/home-assistant-dashboard-activity/tasks.md
+++ b/specs/home-assistant-dashboard-activity/tasks.md
@@ -1,0 +1,112 @@
+# Tasks: home-assistant-dashboard-activity
+
+**Input**: `specs/home-assistant-dashboard-activity/spec.md` and
+`specs/home-assistant-dashboard-activity/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Valid workflow marker, implementation plan, owner
+attestation, and delegation token under `.codex/tmp/`
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Workflow Setup
+
+- [x] T001 [FR-OWN] Create or refresh the sibling clone at
+      `/workspaces/homelab-ideas/home-assistant-dashboard-activity` on
+      `codex/home-assistant-dashboard-activity`.
+- [x] T002 [FR-OWN] Correct the implementation clone remote and branch base to
+      current `origin/main` at `c3c4210e349f90b1027b9a21944119303329fe02`
+      before tracked edits.
+- [x] T003 [FR-OWN] Create `.codex/tmp/active-implementation`,
+      `.codex/tmp/implementation-plan.yaml`,
+      `.codex/tmp/implementation-owner-attestation.yaml`, and
+      `.codex/tmp/delegation-tokens/implementation-agent-home-assistant-dashboard-activity.token`.
+- [x] T004 [FR-OWN] Run the three owner workflow validators before tracked
+      edits.
+
+## Phase 2: Spec And Plan
+
+- [x] T005 [FR-SPEC] Write
+      `specs/home-assistant-dashboard-activity/spec.md`.
+- [x] T006 [FR-PLAN] Write
+      `specs/home-assistant-dashboard-activity/plan.md`, including tiered TDD
+      and development validation expectations.
+- [x] T007 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations in `specs/home-assistant-dashboard-activity/plan.md`.
+- [x] T008 [FR-EVIDENCE] Create initial
+      `specs/home-assistant-dashboard-activity/evidence.md`.
+
+## Phase 3: Implementation
+
+- [x] T009 [P] [FR-001] Add the native Prometheus exporter configuration to
+      `kubernetes/apps/home-assistant/config/configuration.yaml`.
+- [x] T010 [P] [FR-001] Add the native Prometheus exporter configuration to
+      `kubernetes/apps/home-assistant/branch/config/configuration.yaml`.
+- [x] T011 [P] [FR-002] Add Prometheus scrape annotations to
+      `kubernetes/apps/home-assistant/service.yaml`.
+- [x] T012 [P] [FR-002] Add Prometheus scrape annotations to the branch Service
+      in `kubernetes/apps/home-assistant/branch/home-assistant.yaml`.
+- [x] T013 [FR-003] [FR-004] [FR-005] [FR-006] Update
+      `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
+      with the Activity row and required panel removals.
+- [x] T014 [FR-PLAN] Re-check constitution gates after implementation edits in
+      `specs/home-assistant-dashboard-activity/plan.md`.
+
+## Phase 4: Verification
+
+- [x] T015 [FR-007] Run
+      `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
+- [x] T016 [FR-007] Run
+      `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`.
+- [x] T017 [FR-007] Run
+      `kubectl kustomize kubernetes/apps/home-assistant`.
+- [x] T018 [FR-007] Run
+      `kubectl kustomize kubernetes/apps/home-assistant/branch`.
+- [x] T019 [FR-007] Run
+      `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`.
+- [x] T020 [FR-007] Run `python3 tools/architecture/render.py --check` and
+      update generated architecture only if stale.
+- [x] T021 [FR-007] Attempt
+      `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-dashboard-activity --slug home-assistant-dashboard-activity --push`
+      or record exact exception.
+- [x] T022 [FR-007] Attempt Grafana/Mimir query smoke for new
+      `homeassistant_*` metrics or record exact exception.
+- [x] T023 [FR-007] Record command outcomes, exceptions, final `HEAD`, and
+      documentation impact in `specs/home-assistant-dashboard-activity/evidence.md`.
+
+## Phase 5: Commit And Handoff
+
+- [x] T024 [FR-007] Write `.codex/tmp/pr-summary.md` from the plan and final
+      evidence.
+- [x] T025 [FR-007] Commit with a conventional commit message.
+- [x] T026 [FR-007] Run the SDD context validator with `--require-evidence
+      --head` after commit.
+- [x] T027 [FR-007] Report exact `HEAD` and do not create verifier approval.
+
+## Dependencies
+
+- Phase 1 must complete before tracked edits.
+- Phase 2 bootstraps durable SDD context before implementation edits.
+- T009 through T012 can run in parallel because they touch separate manifest
+  files.
+- T013 should run after SDD bootstrap and before dashboard validation.
+- Verification tasks run after implementation edits.
+- Final evidence and PR summary are updated after validation and commit.
+
+## Parallel Execution Examples
+
+- T009, T010, T011, and T012 are independent YAML edits and can be reviewed in
+  parallel.
+- T016 through T020 are independent local checks once implementation files are
+  stable.
+
+## Implementation Strategy
+
+Deliver exporter configuration and Service scraping first so the metrics source
+is present, then update the dashboard to consume native Home Assistant metrics.
+Keep validation focused on local renders and schema checks, with best-effort
+development branch and live metric smoke attempts recorded for verifier review.


### PR DESCRIPTION
## Summary
# Evidence: home-assistant-dashboard-activity

**Branch**: `codex/home-assistant-dashboard-activity`
**Risk Tier**: medium
**Started**: 2026-07-04
**Owner**: implementation-agent-home-assistant-dashboard-activity

## Spec Kit Initialization

- Command: Not rerun; repository Spec Kit scaffolding already present on
  `origin/main`.
- Outcome: Used existing `.specify/` templates and constitution.
- Spec Kit version: Not changed by this implementation.
- Integration: Existing repository integration.
- Fallback: None.

## Workflow Validation

| Command | Result | Notes |
| ------- | ------ | ----- |
| `git remote set-url origin https://github.com/petebeegle/homelab.git && git fetch origin && git checkout -B codex/home-assistant-dashboard-activity origin/main` | PASS | Corrected implementation clone from stale local remote base `1750d60847d94c62bf4d0b5bc89d30cfc4a74cce` to current `origin/main` `c3c4210e349f90b1027b9a21944119303329fe02` before tracked edits. |
| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |

## Local Checks

| Command | Result | Notes |
| ------- | ------ | ----- |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed after SDD bootstrap artifacts were created. |
| `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json` | PASS | Dashboard JSON is valid. |
| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Production render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Branch render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
| `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` | PASS | Dashboard ConfigMap render includes Activity panels and no removed Home Assistant dashboard panel titles. |
| `python3 tools/architecture/render.py --check` | PASS | Generated architecture document unchanged. |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Passed against final committed SDD evidence. |

## Development Validation

- Profile: manual
- Branch slug: `home-assistant-dashboard-activity`
- Validated commit: `f3259955819ede0664503a2733e63752bbd7c7e1` for the pushed
  development validation commit.
- Report path: N/A; helper output captured in command log.
- Cleanup: PASS; helper deleted
  `kustomization.kustomize.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`,
  waited for namespace `home-assistant-home-assistant-dashboard-activity`
  deletion, and deleted
  `gitrepository.source.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`.
- Prerequisite preparation:
  `.codex/scripts/prepare_development_smoke_secrets.sh home-assistant-dashboard-activity /workspaces/homelab-ideas/home-assistant-dashboard-activity`
  passed and installed the ignored development Terraform tfvars into the
  implementation clone without logging secret contents.
- Result or exception:
  `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-dashboard-activity --slug home-assistant-dashboard-activity --push`
  PASS. The helper pushed the branch, ran Terraform init/validate/plan,
  applied the branch Flux activation, reconciled GitRepository and
  Kustomization to
  `codex/home-assistant-dashboard-activity@sha1:f3259955819ede0664503a2733e63752bbd7c7e1`,
  confirmed namespace active, waited for the Home Assistant pod Ready
  condition, checked PVC, Service, and HTTPRoute resources, ran the in-cluster
  HTTP probe successfully, and cleaned up the branch Flux resources and
  namespace.

## Grafana/Mimir Query Smoke

- Query target: native `homeassistant_*` metrics after exporter enablement.
- Result or exception:
  `mcp__grafana.list_prometheus_metric_names(datasourceUid="prometheus", regex="^homeassistant_.*", startRfc3339="now-6h", endRfc3339="now")`
  returned `401 Unauthorized` while reading datasource UID `prometheus`.
  Substitute checks are the dashboard JSON validation, dashboard kustomize
  render, and rendered Home Assistant Service scrape annotations.

## Documentation Impact

- Updated: SDD artifacts under `specs/home-assistant-dashboard-activity/`.
- Generated docs: `docs/architecture.md` unchanged;
  `python3 tools/architecture/render.py --check` passed.
- No-docs rationale: No runbook or ADR changes are expected because this change
  follows existing Home Assistant, Grafana, Gateway, and monitoring patterns.

## Exceptions And Follow-Ups

- TDD exception: no practical red unit-test seam exists for this YAML and
  Grafana JSON-only change; focused render/schema checks are the substitute.
- Grafana/Mimir live query smoke is blocked by Grafana datasource authorization
  in this session (`401 Unauthorized` for datasource UID `prometheus`).

## Final State

- Final branch: `codex/home-assistant-dashboard-activity`.
- Final HEAD at verifier feedback:
  `33a42d3c99d06cb0d4ed83b4c37e35d89dac9fc6`.
- Evidence correction: this follow-up records the exact implementation-owner
  handoff commit above durably in tracked evidence after verifier feedback.
- Commit: `feat(home-assistant): add activity metrics dashboard`
- Verifier approval: not created by implementation owner.


## Changes
- kubernetes/apps/home-assistant/branch/config/configuration.yaml
- kubernetes/apps/home-assistant/branch/home-assistant.yaml
- kubernetes/apps/home-assistant/config/configuration.yaml
- kubernetes/apps/home-assistant/service.yaml
- kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
- specs/home-assistant-dashboard-activity/evidence.md
- specs/home-assistant-dashboard-activity/plan.md
- specs/home-assistant-dashboard-activity/spec.md
- specs/home-assistant-dashboard-activity/tasks.md

## Commits
- 346273f feat(home-assistant): add activity metrics dashboard

## Verification
- Spec Kit evidence: `specs/home-assistant-dashboard-activity/evidence.md`.
- HEAD: `346273f113ba8475ed73cefa6416ffacf0018d4b`.
