### PR TITLE
Implementation: home-assistant-elgato-lighting

### DIFF
--- a/docs/runbooks/home-assistant.md
+++ b/docs/runbooks/home-assistant.md
@@ -56,6 +56,13 @@ add code-owned Elgato scenes, scripts, automations, or package YAML in
 `config/scenes.yaml`, `config/scripts.yaml`, `config/automations.yaml`, or
 `config/packages/code_first.yaml`.
 
+The desk Elgato ambient-balance automation is Git-owned in
+`config/packages/code_first.yaml`. It is gated by
+`input_boolean.desk_light_auto_balance`, reads
+`sensor.office_desk_illuminance`, and controls
+`light.elgato_key_light_air_ambient` plus
+`light.elgato_key_light_air_camera`.
+
 Philips Hue V2 is a runtime config-flow integration, not a declarative Git-owned integration. Pair the Hue bridge through the Home Assistant UI while the bridge link button is available; Home Assistant stores the resulting config entry and tokens under `/config/.storage` on the `home-assistant-config` PVC. Do not commit Hue `.storage` files, `config_entries`, bridge credentials, access or refresh tokens, or fake integration YAML. Do not add an empty `hue.yaml` package as a placeholder.
 
 After pairing, record the runtime inventory before adding Git-owned Hue packages or automations: bridge name, light entity IDs, room/zone/grouped-light entities, scenes, remotes or switches, and any disabled grouped-light entities worth enabling. Once those entity IDs exist, add packages, scripts, scenes, or automations in Git against the observed IDs and keep credentials on the PVC.

--- a/docs/runbooks/home-assistant.md
+++ b/docs/runbooks/home-assistant.md
@@ -33,6 +33,29 @@ The development branch profile deploys the same container, onboarding storage se
 
 Initial device onboarding remains UI-driven. Pair Elgato, UniFi, and similar integrations through the Home Assistant UI first; add code-owned automations, scripts, scenes, and package YAML after entity IDs are known.
 
+Elgato Light is a runtime config-flow integration, not a declarative Git-owned
+integration. Power on each Elgato light and confirm it is on the same LAN that
+the Home Assistant pod can reach. In Home Assistant, open
+`Settings > Devices & services` and accept any discovered `Elgato Light`
+integration. Discovery uses zeroconf/mDNS through `default_config`; if a light is
+not discovered, add `Elgato Light` manually and enter the device hostname or IP
+address.
+
+After pairing, confirm the generated entities before adding Git-owned controls.
+Each device should expose a primary `light.*` entity. Depending on the model,
+Home Assistant may also expose identify or restart buttons, a battery sensor, or
+a studio-mode switch. Record the device name, hostname or IP, entity IDs,
+supported features, room, and intended use in the implementation notes for the
+follow-up change.
+
+Home Assistant stores the Elgato config entry and generated device/entity
+registry state under `/config/.storage` on the `home-assistant-config` PVC. Do
+not commit Elgato `.storage` files, `config_entries`, device credentials, access
+tokens, generated registries, or placeholder YAML. Once real entity IDs exist,
+add code-owned Elgato scenes, scripts, automations, or package YAML in
+`config/scenes.yaml`, `config/scripts.yaml`, `config/automations.yaml`, or
+`config/packages/code_first.yaml`.
+
 Philips Hue V2 is a runtime config-flow integration, not a declarative Git-owned integration. Pair the Hue bridge through the Home Assistant UI while the bridge link button is available; Home Assistant stores the resulting config entry and tokens under `/config/.storage` on the `home-assistant-config` PVC. Do not commit Hue `.storage` files, `config_entries`, bridge credentials, access or refresh tokens, or fake integration YAML. Do not add an empty `hue.yaml` package as a placeholder.
 
 After pairing, record the runtime inventory before adding Git-owned Hue packages or automations: bridge name, light entity IDs, room/zone/grouped-light entities, scenes, remotes or switches, and any disabled grouped-light entities worth enabling. Once those entity IDs exist, add packages, scripts, scenes, or automations in Git against the observed IDs and keep credentials on the PVC.
@@ -43,6 +66,8 @@ Upstream references:
 - `hass-oidc-auth` Authentik guide: <https://github.com/christiaangoossens/hass-oidc-auth/blob/main/docs/provider-configurations/authentik.md>
 - Home Assistant auth providers: <https://www.home-assistant.io/docs/authentication/providers/>
 - Home Assistant HTTP reverse-proxy settings: <https://www.home-assistant.io/integrations/http/>
+- Home Assistant Elgato Light integration: <https://www.home-assistant.io/integrations/elgato/>
+- Home Assistant zeroconf integration: <https://www.home-assistant.io/integrations/zeroconf/>
 
 After reconcile, acceptance should confirm:
 

--- a/kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml
+++ b/kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml
@@ -1,3 +1,89 @@
 ---
 homeassistant:
   customize: {}
+
+input_boolean:
+  desk_light_auto_balance:
+    name: Desk Light Auto Balance
+    icon: mdi:desk-lamp
+
+automation:
+  - id: desk_elgato_ambient_balance
+    alias: Desk Elgato Ambient Balance
+    description: Balance desk Elgato fill lights from the office desk illuminance sensor.
+    mode: restart
+    triggers:
+      - trigger: state
+        entity_id: sensor.office_desk_illuminance
+    conditions:
+      - condition: state
+        entity_id: input_boolean.desk_light_auto_balance
+        state: "on"
+      - condition: template
+        value_template: "{{ is_number(trigger.to_state.state) }}"
+    actions:
+      - variables:
+          desk_lux: "{{ trigger.to_state.state | float }}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 400 }}"
+            sequence:
+              - action: light.turn_off
+                target:
+                  entity_id:
+                    - light.elgato_key_light_air_ambient
+                    - light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 250 }}"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_ambient
+                data:
+                  transition: 3
+                  brightness_pct: 35
+                  color_temp_kelvin: 4000
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+                  brightness_pct: 18
+                  color_temp_kelvin: 3800
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 100 }}"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_ambient
+                data:
+                  transition: 3
+                  brightness_pct: 55
+                  color_temp_kelvin: 3800
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+                  brightness_pct: 28
+                  color_temp_kelvin: 3600
+        default:
+          - action: light.turn_on
+            target:
+              entity_id: light.elgato_key_light_air_ambient
+            data:
+              transition: 3
+              brightness_pct: 75
+              color_temp_kelvin: 3500
+          - action: light.turn_on
+            target:
+              entity_id: light.elgato_key_light_air_camera
+            data:
+              transition: 3
+              brightness_pct: 38
+              color_temp_kelvin: 3300

--- a/kubernetes/apps/home-assistant/config/packages/code_first.yaml
+++ b/kubernetes/apps/home-assistant/config/packages/code_first.yaml
@@ -1,3 +1,89 @@
 ---
 homeassistant:
   customize: {}
+
+input_boolean:
+  desk_light_auto_balance:
+    name: Desk Light Auto Balance
+    icon: mdi:desk-lamp
+
+automation:
+  - id: desk_elgato_ambient_balance
+    alias: Desk Elgato Ambient Balance
+    description: Balance desk Elgato fill lights from the office desk illuminance sensor.
+    mode: restart
+    triggers:
+      - trigger: state
+        entity_id: sensor.office_desk_illuminance
+    conditions:
+      - condition: state
+        entity_id: input_boolean.desk_light_auto_balance
+        state: "on"
+      - condition: template
+        value_template: "{{ is_number(trigger.to_state.state) }}"
+    actions:
+      - variables:
+          desk_lux: "{{ trigger.to_state.state | float }}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 400 }}"
+            sequence:
+              - action: light.turn_off
+                target:
+                  entity_id:
+                    - light.elgato_key_light_air_ambient
+                    - light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 250 }}"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_ambient
+                data:
+                  transition: 3
+                  brightness_pct: 35
+                  color_temp_kelvin: 4000
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+                  brightness_pct: 18
+                  color_temp_kelvin: 3800
+          - conditions:
+              - condition: template
+                value_template: "{{ desk_lux >= 100 }}"
+            sequence:
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_ambient
+                data:
+                  transition: 3
+                  brightness_pct: 55
+                  color_temp_kelvin: 3800
+              - action: light.turn_on
+                target:
+                  entity_id: light.elgato_key_light_air_camera
+                data:
+                  transition: 3
+                  brightness_pct: 28
+                  color_temp_kelvin: 3600
+        default:
+          - action: light.turn_on
+            target:
+              entity_id: light.elgato_key_light_air_ambient
+            data:
+              transition: 3
+              brightness_pct: 75
+              color_temp_kelvin: 3500
+          - action: light.turn_on
+            target:
+              entity_id: light.elgato_key_light_air_camera
+            data:
+              transition: 3
+              brightness_pct: 38
+              color_temp_kelvin: 3300

--- a/specs/home-assistant-elgato-lighting/evidence.md
+++ b/specs/home-assistant-elgato-lighting/evidence.md
@@ -1,23 +1,29 @@
 # Evidence: home-assistant-elgato-lighting
 
 **Branch**: `codex/home-assistant-elgato-lighting`
-**Risk Tier**: tiny
+**Risk Tier**: medium
 **Started**: 2026-07-04
 
-## Spec Kit Initialization
+## Scope Update
 
-- Command: Not run; existing Spec Kit scaffolding was already present in the repo.
-- Outcome: Used existing `.specify/templates/` files.
-- Spec Kit version: Not checked for this docs-only implementation.
-- Integration: Existing repository integration.
-- Fallback: N/A
+- Existing docs-only/tiny SDD artifacts were revised for a medium-risk Home
+  Assistant app behavior/config change.
+- Implemented Git-owned desk Elgato ambient balance in
+  `kubernetes/apps/home-assistant/config/packages/code_first.yaml` and mirrored
+  it in `kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml`.
+- Updated `docs/runbooks/home-assistant.md` with the Git-owned automation
+  location and entities.
+- Runtime Home Assistant `.storage`, config entries, credentials, SOPS secrets,
+  Kubernetes workload, Gateway, PVC, Service, Flux, and generated architecture
+  files were not changed.
 
-## Workflow Validation
+## Spec Kit And Workflow Notes
 
 | Command | Result | Notes |
 | ------- | ------ | ----- |
+| `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | FAIL | Script could not resolve a feature directory because `.specify/feature.json` is not present. Continued from the explicit implementation path `specs/home-assistant-elgato-lighting/` required by the workflow and user request. |
 | `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation marker accepted. |
-| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan accepted. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan accepted after scope/risk update. |
 | `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation accepted. |
 | `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts are present and non-empty. |
 
@@ -25,37 +31,96 @@
 
 | Command | Result | Notes |
 | ------- | ------ | ----- |
-| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Production Home Assistant kustomization rendered successfully; output stored in `.codex/tmp/home-assistant.render.yaml`. |
-| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Branch Home Assistant kustomization rendered successfully; output stored in `.codex/tmp/home-assistant-branch.render.yaml`. |
-| `rg -n "Elgato|\\.storage|config_entries|entity IDs|placeholder YAML|zeroconf" docs/runbooks/home-assistant.md specs/home-assistant-elgato-lighting` | PASS | Runbook and SDD artifacts include Elgato discovery/manual setup, runtime-state safety, and inventory-before-code guidance. |
-| `git status --short` | PASS | Changed files are limited to `docs/runbooks/home-assistant.md` and `specs/home-assistant-elgato-lighting/`. |
+| `kubectl kustomize kubernetes/apps/home-assistant > .codex/tmp/home-assistant.render.yaml` | PASS | Production Home Assistant kustomization rendered successfully. |
+| `kubectl kustomize kubernetes/apps/home-assistant/branch > .codex/tmp/home-assistant-branch.render.yaml` | PASS | Branch Home Assistant kustomization rendered successfully. |
+| `docker run --rm -v "$PWD/.codex/tmp/ha-branch-check:/config" ghcr.io/home-assistant/home-assistant:2026.7.1 python -m homeassistant --script check_config --config /config` | PASS | Offline Home Assistant config check passed against a temporary copy of the branch config. The production package is identical to the branch package; production-only secrets/OIDC custom component were not required for this package sanity check. |
+| `diff -u kubernetes/apps/home-assistant/config/packages/code_first.yaml kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml` | PASS | No diff; production/base and branch overlay package behavior match. |
+| `rg -n "desk_light_auto_balance|desk_elgato_ambient_balance|office_desk_illuminance|elgato_key_light_air|color_temp_kelvin|brightness_pct|transition: 3" .codex/tmp/home-assistant.render.yaml .codex/tmp/home-assistant-branch.render.yaml` | PASS | Rendered ConfigMaps include the helper, automation, trigger sensor, target lights, documented color-temperature field, brightness percentages, and transition values. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `git status --short` | PASS | Before evidence refresh, changed files were limited to the Home Assistant runbook, production/base package, branch package, and SDD artifacts. |
+
+## Behavior Review
+
+| Requirement | Result | Notes |
+| ----------- | ------ | ----- |
+| Trigger on illuminance changes | PASS | Automation uses `triggers: - trigger: state` with `entity_id: sensor.office_desk_illuminance`. |
+| Manual enable helper | PASS | Package defines `input_boolean.desk_light_auto_balance`; automation conditions require it to be `on`. |
+| Numeric sensor guard | PASS | Automation requires `is_number(trigger.to_state.state)` before converting to `desk_lux`. |
+| Bright threshold | PASS | `desk_lux >= 400` turns both Elgato lights off with `transition: 3`. |
+| Light fill | PASS | `250-399` lux sets ambient `35%`/`4000K` and camera `18%`/`3800K` with `transition: 3`. |
+| Medium fill | PASS | `100-249` lux sets ambient `55%`/`3800K` and camera `28%`/`3600K` with `transition: 3`. |
+| Strong fill | PASS | `<100` lux sets ambient `75%`/`3500K` and camera `38%`/`3300K` with `transition: 3`. |
 
 ## Development Validation
 
-- Profile: none
+- Profile: home-assistant branch deploy
 - Branch slug: home-assistant-elgato-lighting
-- HEAD: Current branch state before commit is based on `812b7ffb8893f2eda80076d4cf000dfe3943d49d`.
-- Report path: N/A
-- Cleanup: N/A
-- Result or exception: Development smoke is not required for this docs-only
-  implementation because no Kubernetes, Flux, Gateway, storage, secret, or app
-  behavior changes are made. Substitute checks are local production and branch
-  Home Assistant kustomize renders plus focused docs review.
+- Validated branch/head:
+  `codex/home-assistant-elgato-lighting@sha1:da780f3b5a0c3a993cf8062377ef4c5c2a684eda`
+- Command:
+  `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-elgato-lighting --slug home-assistant-elgato-lighting --kubeconfig ~/.kube/homelab-development.config --timeout 20m`
+- Result: PASS
+- Report path: Not captured in this evidence update; result details were
+  provided by the verifier/operator after the run.
+- Secrets preparation:
+  `.codex/scripts/prepare_development_smoke_secrets.sh home-assistant-elgato-lighting /workspaces/homelab-ideas/home-assistant-elgato-lighting`
+  installed `terraform/development/terraform.tfvars` before smoke.
+- Terraform preflight: `init`, `validate`, and `plan` passed. Plan exited with
+  detailed-exitcode `2` and showed planned development infra creates, accepted
+  by verifier as an acceptable preflight result.
+- Flux source: Branch `GitRepository` fetched
+  `codex/home-assistant-elgato-lighting@sha1:da780f3b5a0c3a993cf8062377ef4c5c2a684eda`.
+- Flux apply: Branch `Kustomization` became Ready.
+- Runtime acceptance: Namespace
+  `home-assistant-home-assistant-elgato-lighting` became Active; Home Assistant
+  branch pod became Ready; Service, PVC, HTTPRoute, and in-cluster HTTP probe
+  passed.
+- Cleanup: Deleted the branch Kustomization, waited for namespace deletion, and
+  deleted the branch GitRepository.
+- Note: This evidence-only amend will produce a new local commit SHA after the
+  successful smoke. The smoke validated the implementation content at
+  `da780f3b5a0c3a993cf8062377ef4c5c2a684eda`; this amend records the result.
+
+## Rebase Refresh
+
+- Rebased onto current `origin/main`:
+  `be0b777d96eb0262d8ddc9ff673828ed56d79a5a`
+- Rebased branch HEAD before evidence amend:
+  `bb0024a23aea3f1b3738230e16c4cd436c101383`
+- Rebase conflicts: none; `git rebase origin/main` completed successfully.
+- Branch state after rebase: `codex/home-assistant-elgato-lighting` was
+  `ahead 2` of `origin/main` and no longer behind.
+
+### Rebase Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `git fetch origin && git rev-parse origin/main && git rebase origin/main` | PASS | Fetched `be0b777d96eb0262d8ddc9ff673828ed56d79a5a`; rebase completed with no conflicts. |
+| `kubectl kustomize kubernetes/apps/home-assistant > .codex/tmp/home-assistant.render.yaml` | PASS | Production Home Assistant kustomization rendered successfully after rebase. |
+| `kubectl kustomize kubernetes/apps/home-assistant/branch > .codex/tmp/home-assistant-branch.render.yaml` | PASS | Branch Home Assistant kustomization rendered successfully after rebase. |
+| `diff -u kubernetes/apps/home-assistant/config/packages/code_first.yaml kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml` | PASS | No diff; production/base and branch overlay package behavior still match. |
+| `docker run --rm -v "$PWD/.codex/tmp/ha-branch-check:/config" ghcr.io/home-assistant/home-assistant:2026.7.1 python -m homeassistant --script check_config --config /config` | PASS | Offline Home Assistant config check passed against a temporary copy of the branch config. |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation marker remains valid after rebase. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan remains valid with `base: origin/main`. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation remains valid. |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | SDD artifacts and evidence remain valid. |
+| `rg -n "desk_light_auto_balance\|desk_elgato_ambient_balance\|office_desk_illuminance\|elgato_key_light_air\|color_temp_kelvin\|brightness_pct\|transition: 3" .codex/tmp/home-assistant.render.yaml .codex/tmp/home-assistant-branch.render.yaml` | PASS | Rendered ConfigMaps still include the helper, automation, trigger sensor, target lights, documented color-temperature field, brightness percentages, and transition values. |
+| `git diff --check` | PASS | No whitespace errors after rebase. |
+| `git status --short --branch` | PASS | Branch was clean and `ahead 2` of `origin/main` before this evidence update. |
 
 ## Documentation Impact
 
 - Updated: `docs/runbooks/home-assistant.md`
-- Generated docs: Not required; Kubernetes and Terraform sources are unchanged.
+- Generated docs: Not required; Kubernetes and Terraform resource shape did not
+  change. ConfigMap file content changed only through existing generators.
 - No-docs rationale: N/A
-
-## Exceptions And Follow-Ups
-
-- Follow-up: After Elgato lights are paired, record real device names, host/IPs,
-  entity IDs, supported features, and intended use before adding Git-owned
-  scenes, scripts, automations, or Home Assistant package YAML.
 
 ## Final State
 
 - Final branch: `codex/home-assistant-elgato-lighting`
-- Final HEAD: Recorded in final handoff after commit.
-- Commit: `docs(home-assistant): document elgato light onboarding`
+- Final HEAD before cleanup amend:
+  `1136f169dceac8affd4ec473c61890f04dc713d7`
+- Commit: `feat(home-assistant): add desk elgato auto balance`
+- Push: Not run by implementation owner during this evidence update.
+- Verifier approval: Recorded externally for exact HEAD
+  `da780f3b5a0c3a993cf8062377ef4c5c2a684eda` before this evidence-only amend.

--- a/specs/home-assistant-elgato-lighting/evidence.md
+++ b/specs/home-assistant-elgato-lighting/evidence.md
@@ -1,0 +1,61 @@
+# Evidence: home-assistant-elgato-lighting
+
+**Branch**: `codex/home-assistant-elgato-lighting`
+**Risk Tier**: tiny
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: Not run; existing Spec Kit scaffolding was already present in the repo.
+- Outcome: Used existing `.specify/templates/` files.
+- Spec Kit version: Not checked for this docs-only implementation.
+- Integration: Existing repository integration.
+- Fallback: N/A
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation marker accepted. |
+| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan accepted. |
+| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation accepted. |
+| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts are present and non-empty. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Production Home Assistant kustomization rendered successfully; output stored in `.codex/tmp/home-assistant.render.yaml`. |
+| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Branch Home Assistant kustomization rendered successfully; output stored in `.codex/tmp/home-assistant-branch.render.yaml`. |
+| `rg -n "Elgato|\\.storage|config_entries|entity IDs|placeholder YAML|zeroconf" docs/runbooks/home-assistant.md specs/home-assistant-elgato-lighting` | PASS | Runbook and SDD artifacts include Elgato discovery/manual setup, runtime-state safety, and inventory-before-code guidance. |
+| `git status --short` | PASS | Changed files are limited to `docs/runbooks/home-assistant.md` and `specs/home-assistant-elgato-lighting/`. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: home-assistant-elgato-lighting
+- HEAD: Current branch state before commit is based on `812b7ffb8893f2eda80076d4cf000dfe3943d49d`.
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development smoke is not required for this docs-only
+  implementation because no Kubernetes, Flux, Gateway, storage, secret, or app
+  behavior changes are made. Substitute checks are local production and branch
+  Home Assistant kustomize renders plus focused docs review.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/home-assistant.md`
+- Generated docs: Not required; Kubernetes and Terraform sources are unchanged.
+- No-docs rationale: N/A
+
+## Exceptions And Follow-Ups
+
+- Follow-up: After Elgato lights are paired, record real device names, host/IPs,
+  entity IDs, supported features, and intended use before adding Git-owned
+  scenes, scripts, automations, or Home Assistant package YAML.
+
+## Final State
+
+- Final branch: `codex/home-assistant-elgato-lighting`
+- Final HEAD: Recorded in final handoff after commit.
+- Commit: `docs(home-assistant): document elgato light onboarding`

--- a/specs/home-assistant-elgato-lighting/plan.md
+++ b/specs/home-assistant-elgato-lighting/plan.md
@@ -1,0 +1,110 @@
+# Implementation Plan: home-assistant-elgato-lighting
+
+**Branch**: `codex/home-assistant-elgato-lighting` | **Date**: 2026-07-04 | **Spec**:
+`specs/home-assistant-elgato-lighting/spec.md`
+
+**Input**: Feature specification from
+`specs/home-assistant-elgato-lighting/spec.md`
+
+## Summary
+
+Document the safe Elgato Light onboarding path for Home Assistant. Elgato Light
+is a runtime config-flow integration discovered through zeroconf or added
+manually by host/IP, so this implementation updates operator guidance and SDD
+evidence without adding declarative Home Assistant integration YAML or committing
+runtime storage.
+
+## Technical Context
+
+**Risk Tier**: tiny
+**Workflow Tier**: docs-only
+**Primary Areas**: documentation, SDD artifacts
+**Dependencies**: Home Assistant docs, existing Home Assistant kustomizations
+**Storage**: Existing Home Assistant PVC remains unchanged; runtime integration
+state stays under `/config/.storage`
+**Ingress**: No Gateway API route changes
+**Secrets**: No SOPS changes
+**Development Validation**: none; docs-only change with local render checks as
+substitute validation
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/home-assistant-elgato-lighting`; worktree/current-checkout mode is
+      intentional and recorded when relevant.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/home-assistant-elgato-lighting/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+docs/runbooks/home-assistant.md
+specs/home-assistant-elgato-lighting/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Docs-only tiny change; no executable behavior or test seam
+exists, so use review checks and cheap render validation.
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/apps/home-assistant`
+- `kubectl kustomize kubernetes/apps/home-assistant/branch`
+- `git diff --name-only`
+
+**Development smoke**: none; no Kubernetes, Flux, Gateway, storage, secret, or
+app behavior changes are made. Local render checks prove unchanged manifests
+still parse.
+
+**Evidence destination**: `specs/home-assistant-elgato-lighting/evidence.md`.
+
+## Documentation Impact
+
+Update `docs/runbooks/home-assistant.md` with Elgato-specific onboarding,
+manual setup, inventory capture, and runtime-state safety guidance. No generated
+architecture update is required because Kubernetes and Terraform sources do not
+change.
+
+## Implementation Steps
+
+1. Create SDD artifacts for `home-assistant-elgato-lighting`.
+2. Add an Elgato lighting section to the Home Assistant runbook.
+3. Run local render checks and focused docs review.
+4. Record command outcomes and docs-only smoke exception in evidence.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Operator commits runtime Home Assistant state later | Explicitly warn not to commit `.storage`, `config_entries`, credentials, or generated registries |
+| Follow-up controls target guessed entity IDs | Require runtime inventory before adding Git-owned scenes, scripts, automations, or packages |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/home-assistant-elgato-lighting/plan.md
+++ b/specs/home-assistant-elgato-lighting/plan.md
@@ -8,24 +8,26 @@
 
 ## Summary
 
-Document the safe Elgato Light onboarding path for Home Assistant. Elgato Light
-is a runtime config-flow integration discovered through zeroconf or added
-manually by host/IP, so this implementation updates operator guidance and SDD
-evidence without adding declarative Home Assistant integration YAML or committing
-runtime storage.
+Add the GitOps-owned Home Assistant helper and automation for the desk Elgato
+ambient-balance behavior now that the required runtime entity IDs are known. The
+automation lives in the existing `code_first.yaml` package so the helper and
+automation are managed together in production/base and the branch overlay.
 
 ## Technical Context
 
-**Risk Tier**: tiny
-**Workflow Tier**: docs-only
-**Primary Areas**: documentation, SDD artifacts
-**Dependencies**: Home Assistant docs, existing Home Assistant kustomizations
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Home Assistant package YAML, branch overlay, SDD artifacts,
+Home Assistant runbook note
+**Dependencies**: Existing Home Assistant package include, known Elgato and
+illuminance entity IDs
 **Storage**: Existing Home Assistant PVC remains unchanged; runtime integration
 state stays under `/config/.storage`
 **Ingress**: No Gateway API route changes
 **Secrets**: No SOPS changes
-**Development Validation**: none; docs-only change with local render checks as
-substitute validation
+**Development Validation**: required for medium-risk app behavior when
+infrastructure is available; otherwise record an unavailable-infrastructure
+exception and substitute local render/static checks
 
 ## Constitution Check
 
@@ -59,47 +61,62 @@ specs/home-assistant-elgato-lighting/
 ### Source Or Documentation Changes
 
 ```text
+kubernetes/apps/home-assistant/config/packages/code_first.yaml
+kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml
 docs/runbooks/home-assistant.md
 specs/home-assistant-elgato-lighting/
 ```
 
 ## Tiered TDD And Validation Plan
 
-**TDD expectation**: Docs-only tiny change; no executable behavior or test seam
-exists, so use review checks and cheap render validation.
+**TDD expectation**: Medium-risk configuration behavior. There is no local Home
+Assistant runtime test seam in this repo, so use static package review,
+production and branch kustomize renders, and a YAML/config sanity check as the
+local red/green substitute. Record any unavailable live Home Assistant
+validation exception.
 
 **Local checks**:
 
 - `kubectl kustomize kubernetes/apps/home-assistant`
 - `kubectl kustomize kubernetes/apps/home-assistant/branch`
-- `git diff --name-only`
+- YAML/config sanity check for the edited package files
+- Workflow harness validators
+- `git status --short`
 
-**Development smoke**: none; no Kubernetes, Flux, Gateway, storage, secret, or
-app behavior changes are made. Local render checks prove unchanged manifests
-still parse.
+**Development smoke**: Home Assistant app behavior validation is expected for
+medium risk when a development cluster and matching runtime entities are
+available. If unavailable, document the exception, include substitute local
+checks, and leave verifier review to decide whether more smoke is required.
 
 **Evidence destination**: `specs/home-assistant-elgato-lighting/evidence.md`.
 
 ## Documentation Impact
 
-Update `docs/runbooks/home-assistant.md` with Elgato-specific onboarding,
-manual setup, inventory capture, and runtime-state safety guidance. No generated
+Keep `docs/runbooks/home-assistant.md` current by noting that the desk Elgato
+ambient-balance automation is now Git-owned in `code_first.yaml`. No generated
 architecture update is required because Kubernetes and Terraform sources do not
-change.
+change shape beyond ConfigMap input content.
 
 ## Implementation Steps
 
-1. Create SDD artifacts for `home-assistant-elgato-lighting`.
-2. Add an Elgato lighting section to the Home Assistant runbook.
-3. Run local render checks and focused docs review.
-4. Record command outcomes and docs-only smoke exception in evidence.
+1. Revise SDD artifacts and local implementation plan from docs-only to
+   medium-risk Home Assistant app behavior/config.
+2. Add `input_boolean.desk_light_auto_balance` and the desk Elgato
+   ambient-balance automation to production/base `code_first.yaml`.
+3. Mirror the helper and automation in the branch-overlay `code_first.yaml`.
+4. Update the Home Assistant runbook only as needed to mention the Git-owned
+   automation.
+5. Run local render, YAML/config sanity, workflow, and status checks.
+6. Record command outcomes, development validation evidence or exception, and
+   final branch state in evidence.
 
 ## Risks
 
 | Risk | Mitigation |
 | ---- | ---------- |
-| Operator commits runtime Home Assistant state later | Explicitly warn not to commit `.storage`, `config_entries`, credentials, or generated registries |
-| Follow-up controls target guessed entity IDs | Require runtime inventory before adding Git-owned scenes, scripts, automations, or packages |
+| Helper defaults unexpectedly active | Define a normal `input_boolean`; Home Assistant defaults it off unless restored runtime state says otherwise |
+| Automation targets missing or renamed entities | Use the exact entity IDs from the user plan and require live HA validation or record the unavailable-infrastructure exception |
+| Package YAML syntax is invalid | Run static YAML/config sanity checks plus production and branch kustomize renders |
 
 ## Complexity Tracking
 

--- a/specs/home-assistant-elgato-lighting/spec.md
+++ b/specs/home-assistant-elgato-lighting/spec.md
@@ -3,15 +3,16 @@
 **Feature Branch**: `codex/home-assistant-elgato-lighting`
 **Created**: 2026-07-04
 **Status**: Draft
-**Risk Tier**: tiny
+**Risk Tier**: medium
 **Input**: User description: "lets integrate elgato lighting into home assistant"
 
 ## Summary
 
-Operators need clear, GitOps-safe instructions for pairing Elgato lighting with
-Home Assistant. The first useful slice documents runtime onboarding and the
-boundary between Home Assistant config-flow state and code-owned controls, so no
-fake integration YAML, device credentials, or guessed entity IDs are committed.
+Operators need a GitOps-owned Home Assistant automation that balances the two
+desk Elgato Key Light Air fills from the observed desk illuminance while keeping
+manual control over whether the automation is active. The existing Elgato
+runtime onboarding guidance remains valid; this implementation adds the known
+entity-ID based helper and automation after pairing.
 
 ## Binding Sources
 
@@ -25,83 +26,118 @@ fake integration YAML, device credentials, or guessed entity IDs are committed.
 
 ### In Scope
 
-- Document Elgato Light discovery and manual host setup through the Home
-  Assistant UI.
-- Document runtime inventory capture after pairing.
-- Document that Elgato runtime state remains on the Home Assistant PVC under
-  `/config/.storage` and must not be committed.
-- Record SDD planning and evidence for the docs-only implementation.
+- Add a Git-owned `input_boolean.desk_light_auto_balance` helper.
+- Add a Git-owned Home Assistant automation that triggers when
+  `sensor.office_desk_illuminance` changes and only runs when the helper is on.
+- Control `light.elgato_key_light_air_ambient` as the main/farther left-center
+  fill and `light.elgato_key_light_air_camera` as the softer close/right camera
+  fill.
+- Apply the requested stepped brightness and kelvin settings for bright, light,
+  medium, and strong fill levels.
+- Keep production/base and development branch-overlay Home Assistant config
+  shapes aligned.
+- Update SDD planning and evidence for a medium-risk Home Assistant app
+  behavior/config change.
 
 ### Out Of Scope
 
-- Home Assistant YAML integration entries for Elgato Light.
-- Kubernetes workload, Gateway, Secret, Flux, Service, PVC, or storage changes.
-- Git-owned scenes, scripts, automations, or package controls before real
-  Elgato entity IDs are known.
+- Home Assistant YAML integration entries for Elgato Light; pairing remains a
+  runtime config-flow concern.
+- Kubernetes workload, Gateway, Secret, Flux, Service, PVC, storage, or image
+  changes.
+- Runtime Home Assistant `.storage`, config entries, credentials, or generated
+  registries.
+- Live device discovery or renaming.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Pair Elgato Lights Safely (Priority: P1)
+### User Story 1 - Balance Desk Fill Lights Automatically (Priority: P1)
 
-An operator can onboard Elgato lights in Home Assistant while preserving the
-repo boundary between GitOps-owned YAML and runtime Home Assistant state.
+An operator can enable a helper and have Home Assistant automatically adjust both
+desk Elgato fill lights whenever the office desk illuminance sensor changes.
 
-**Why this priority**: Pairing creates the entity IDs needed before any useful
-code-owned lighting control can be added.
+**Why this priority**: The known entity IDs now make the useful Git-owned desk
+lighting behavior possible.
 
-**Independent Test**: Review `docs/runbooks/home-assistant.md` and confirm it
-documents discovery, manual host setup, runtime inventory capture, and
-`.storage` safety.
+**Independent Test**: Review the package YAML and confirm the helper, trigger,
+condition, target lights, transition, and stepped fill levels match this spec.
 
 **Acceptance Scenarios**:
 
-1. **Given** an Elgato light on the same reachable LAN as Home Assistant,
-   **When** the operator opens Home Assistant Devices & services, **Then** the
-   runbook explains accepting a discovered Elgato Light integration or adding it
-   manually by hostname or IP.
-2. **Given** an Elgato light is paired, **When** the operator prepares a
-   follow-up GitOps change, **Then** the runbook says to record real entity IDs
-   and supported features before adding scenes, scripts, automations, or package
-   YAML.
+1. **Given** `input_boolean.desk_light_auto_balance` is `off`, **When**
+   `sensor.office_desk_illuminance` changes, **Then** the automation does not
+   change either Elgato light.
+2. **Given** the helper is `on`, **When** the illuminance changes to at least
+   `400`, **Then** both Elgato lights are turned off with transition `3`.
+3. **Given** the helper is `on`, **When** the illuminance changes to `250`
+   through `399`, **Then** the ambient light turns on at `35%` and `4000K`, and
+   the camera light turns on at `18%` and `3800K`, both with transition `3`.
+4. **Given** the helper is `on`, **When** the illuminance changes to `100`
+   through `249`, **Then** the ambient light turns on at `55%` and `3800K`, and
+   the camera light turns on at `28%` and `3600K`, both with transition `3`.
+5. **Given** the helper is `on`, **When** the illuminance changes below `100`,
+   **Then** the ambient light turns on at `75%` and `3500K`, and the camera
+   light turns on at `38%` and `3300K`, both with transition `3`.
 
 ## Requirements *(mandatory)*
 
-- **FR-001**: The implementation MUST document Elgato Light setup through Home
-  Assistant Devices & services.
-- **FR-002**: The implementation MUST document manual setup by hostname or IP
-  when zeroconf discovery does not find a light.
-- **FR-003**: The implementation MUST document the expected generated entities:
-  the main `light.*` entity and optional identify/restart buttons, battery
-  sensor, or studio-mode switch depending on model.
-- **FR-004**: The implementation MUST preserve the Home Assistant runtime-state
-  boundary by warning against committing `/config/.storage`, `config_entries`,
-  device credentials, or generated registry files.
-- **FR-005**: The implementation MUST NOT change Kubernetes manifests, Home
-  Assistant integration YAML, SOPS secrets, or generated architecture docs.
-- **FR-006**: Evidence MUST record local render checks and the docs-only
-  development-smoke exception.
+- **FR-001**: The implementation MUST define or use
+  `input_boolean.desk_light_auto_balance` as the manual enable helper.
+- **FR-002**: The automation MUST trigger when
+  `sensor.office_desk_illuminance` changes.
+- **FR-003**: The automation MUST only run when
+  `input_boolean.desk_light_auto_balance` is `on`.
+- **FR-004**: The automation MUST target
+  `light.elgato_key_light_air_ambient` as the main/farther left-center fill and
+  `light.elgato_key_light_air_camera` as the softer close/right camera fill.
+- **FR-005**: The automation MUST use transition `3` for all turn-on and
+  turn-off actions.
+- **FR-006**: At `>=400` lux, the automation MUST turn both Elgato lights off.
+- **FR-007**: At `250-399` lux, the automation MUST set light fill: ambient
+  `35%`/`4000K`, camera `18%`/`3800K`.
+- **FR-008**: At `100-249` lux, the automation MUST set medium fill: ambient
+  `55%`/`3800K`, camera `28%`/`3600K`.
+- **FR-009**: At `<100` lux, the automation MUST set strong fill: ambient
+  `75%`/`3500K`, camera `38%`/`3300K`.
+- **FR-010**: Production/base and branch-overlay Home Assistant config MUST
+  include the same helper and automation shape.
+- **FR-011**: The implementation MUST NOT commit runtime Home Assistant
+  `.storage`, config entries, device credentials, SOPS secret changes, or
+  generated architecture docs.
+- **FR-012**: Evidence MUST record local render checks, YAML/config sanity
+  checks available without live Home Assistant, workflow validators, and any
+  development validation exception.
 
 ## Risk And Validation Expectations
 
-**Tiny**: This is a docs-only implementation. Run cheap render checks for the
-existing Home Assistant production and branch kustomizations and perform a
-focused runbook review.
+**Medium**: This changes Git-owned Home Assistant app behavior/config and the
+branch overlay. Run production and branch kustomize renders, static YAML/config
+sanity checks available without live Home Assistant, workflow validators, and
+development validation or a documented unavailable-infrastructure exception with
+substitute checks.
 
 ## Success Criteria *(mandatory)*
 
-- **SC-001**: `docs/runbooks/home-assistant.md` contains Elgato-specific
-  pairing, manual setup, inventory, and runtime-state safety guidance.
-- **SC-002**: `kubectl kustomize kubernetes/apps/home-assistant` passes.
-- **SC-003**: `kubectl kustomize kubernetes/apps/home-assistant/branch` passes.
-- **SC-004**: `git diff --name-only` shows only the Home Assistant runbook and
-  `specs/home-assistant-elgato-lighting/` files.
+- **SC-001**: `kubernetes/apps/home-assistant/config/packages/code_first.yaml`
+  defines the helper and automation with the required trigger, condition,
+  targets, thresholds, brightness percentages, kelvin values, and transitions.
+- **SC-002**:
+  `kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml`
+  matches the production/base package behavior.
+- **SC-003**: `kubectl kustomize kubernetes/apps/home-assistant` passes.
+- **SC-004**: `kubectl kustomize kubernetes/apps/home-assistant/branch` passes.
+- **SC-005**: A YAML/config sanity check confirms the package files parse as
+  ordinary YAML with the expected top-level Home Assistant package domains.
+- **SC-006**: SDD and workflow validation passes for the implementation owner
+  context.
 
 ## Assumptions
 
-- No Elgato device IPs, hostnames, or Home Assistant entity IDs are known yet.
-- The first useful repo change is operator guidance, not automation.
-- A later implementation can add Git-owned studio scenes or scripts once real
-  entity IDs are captured from Home Assistant.
+- The named illuminance sensor and Elgato light entities already exist in
+  runtime Home Assistant.
+- The Home Assistant package include remains enabled through
+  `homeassistant: packages: !include_dir_named packages`.
+- The helper defaults to off until an operator enables it in Home Assistant.
 
 ## Open Questions
 

--- a/specs/home-assistant-elgato-lighting/spec.md
+++ b/specs/home-assistant-elgato-lighting/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: home-assistant-elgato-lighting
+
+**Feature Branch**: `codex/home-assistant-elgato-lighting`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: tiny
+**Input**: User description: "lets integrate elgato lighting into home assistant"
+
+## Summary
+
+Operators need clear, GitOps-safe instructions for pairing Elgato lighting with
+Home Assistant. The first useful slice documents runtime onboarding and the
+boundary between Home Assistant config-flow state and code-owned controls, so no
+fake integration YAML, device credentials, or guessed entity IDs are committed.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/home-assistant.md`
+
+## Scope
+
+### In Scope
+
+- Document Elgato Light discovery and manual host setup through the Home
+  Assistant UI.
+- Document runtime inventory capture after pairing.
+- Document that Elgato runtime state remains on the Home Assistant PVC under
+  `/config/.storage` and must not be committed.
+- Record SDD planning and evidence for the docs-only implementation.
+
+### Out Of Scope
+
+- Home Assistant YAML integration entries for Elgato Light.
+- Kubernetes workload, Gateway, Secret, Flux, Service, PVC, or storage changes.
+- Git-owned scenes, scripts, automations, or package controls before real
+  Elgato entity IDs are known.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pair Elgato Lights Safely (Priority: P1)
+
+An operator can onboard Elgato lights in Home Assistant while preserving the
+repo boundary between GitOps-owned YAML and runtime Home Assistant state.
+
+**Why this priority**: Pairing creates the entity IDs needed before any useful
+code-owned lighting control can be added.
+
+**Independent Test**: Review `docs/runbooks/home-assistant.md` and confirm it
+documents discovery, manual host setup, runtime inventory capture, and
+`.storage` safety.
+
+**Acceptance Scenarios**:
+
+1. **Given** an Elgato light on the same reachable LAN as Home Assistant,
+   **When** the operator opens Home Assistant Devices & services, **Then** the
+   runbook explains accepting a discovered Elgato Light integration or adding it
+   manually by hostname or IP.
+2. **Given** an Elgato light is paired, **When** the operator prepares a
+   follow-up GitOps change, **Then** the runbook says to record real entity IDs
+   and supported features before adding scenes, scripts, automations, or package
+   YAML.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST document Elgato Light setup through Home
+  Assistant Devices & services.
+- **FR-002**: The implementation MUST document manual setup by hostname or IP
+  when zeroconf discovery does not find a light.
+- **FR-003**: The implementation MUST document the expected generated entities:
+  the main `light.*` entity and optional identify/restart buttons, battery
+  sensor, or studio-mode switch depending on model.
+- **FR-004**: The implementation MUST preserve the Home Assistant runtime-state
+  boundary by warning against committing `/config/.storage`, `config_entries`,
+  device credentials, or generated registry files.
+- **FR-005**: The implementation MUST NOT change Kubernetes manifests, Home
+  Assistant integration YAML, SOPS secrets, or generated architecture docs.
+- **FR-006**: Evidence MUST record local render checks and the docs-only
+  development-smoke exception.
+
+## Risk And Validation Expectations
+
+**Tiny**: This is a docs-only implementation. Run cheap render checks for the
+existing Home Assistant production and branch kustomizations and perform a
+focused runbook review.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `docs/runbooks/home-assistant.md` contains Elgato-specific
+  pairing, manual setup, inventory, and runtime-state safety guidance.
+- **SC-002**: `kubectl kustomize kubernetes/apps/home-assistant` passes.
+- **SC-003**: `kubectl kustomize kubernetes/apps/home-assistant/branch` passes.
+- **SC-004**: `git diff --name-only` shows only the Home Assistant runbook and
+  `specs/home-assistant-elgato-lighting/` files.
+
+## Assumptions
+
+- No Elgato device IPs, hostnames, or Home Assistant entity IDs are known yet.
+- The first useful repo change is operator guidance, not automation.
+- A later implementation can add Git-owned studio scenes or scripts once real
+  entity IDs are captured from Home Assistant.
+
+## Open Questions
+
+- None

--- a/specs/home-assistant-elgato-lighting/tasks.md
+++ b/specs/home-assistant-elgato-lighting/tasks.md
@@ -1,0 +1,52 @@
+---
+description: "Homelab SDD task list for Elgato lighting in Home Assistant"
+---
+
+# Tasks: home-assistant-elgato-lighting
+
+**Input**: `specs/home-assistant-elgato-lighting/spec.md` and
+`specs/home-assistant-elgato-lighting/plan.md`
+**Risk Tier**: tiny
+**Prerequisites**: Branch `codex/home-assistant-elgato-lighting` and matching
+`specs/home-assistant-elgato-lighting/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Spec And Plan
+
+- [x] T001 [FR-SPEC] Create
+      `specs/home-assistant-elgato-lighting/spec.md`.
+- [x] T002 [FR-PLAN] Create
+      `specs/home-assistant-elgato-lighting/plan.md`, including tiered TDD and
+      development validation expectations.
+- [x] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations.
+
+## Phase 2: Implementation
+
+- [x] T004 [FR-001] [FR-002] Add Elgato discovery and manual setup guidance to
+      `docs/runbooks/home-assistant.md`.
+- [x] T005 [FR-003] [FR-004] Add Elgato entity inventory and runtime-state
+      safety guidance to `docs/runbooks/home-assistant.md`.
+- [x] T006 [FR-005] Re-check constitution gates after implementation edits.
+
+## Phase 3: Verification
+
+- [x] T007 [FR-TEST] Run
+      `kubectl kustomize kubernetes/apps/home-assistant`.
+- [x] T008 [FR-TEST] Run
+      `kubectl kustomize kubernetes/apps/home-assistant/branch`.
+- [x] T009 [FR-SMOKE] Record docs-only development smoke exception.
+- [x] T010 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
+      and final `HEAD` in `specs/home-assistant-elgato-lighting/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [x] T011 [FR-PR] Commit with a conventional commit message.
+- [ ] T012 [FR-PR] Push branch `codex/home-assistant-elgato-lighting` and open
+      a PR after separate verifier approval.

--- a/specs/home-assistant-elgato-lighting/tasks.md
+++ b/specs/home-assistant-elgato-lighting/tasks.md
@@ -6,7 +6,7 @@ description: "Homelab SDD task list for Elgato lighting in Home Assistant"
 
 **Input**: `specs/home-assistant-elgato-lighting/spec.md` and
 `specs/home-assistant-elgato-lighting/plan.md`
-**Risk Tier**: tiny
+**Risk Tier**: medium
 **Prerequisites**: Branch `codex/home-assistant-elgato-lighting` and matching
 `specs/home-assistant-elgato-lighting/` artifacts.
 
@@ -26,6 +26,10 @@ description: "Homelab SDD task list for Elgato lighting in Home Assistant"
       development validation expectations.
 - [x] T003 [FR-DOCS] Confirm documentation impact and generated architecture
       expectations.
+- [x] T013 [FR-SPEC] Revise SDD artifacts from docs-only/tiny to medium-risk
+      Home Assistant app behavior/config.
+- [x] T014 [FR-PLAN] Update `.codex/tmp/implementation-plan.yaml` to match the
+      new automation scope and validation expectations.
 
 ## Phase 2: Implementation
 
@@ -33,7 +37,18 @@ description: "Homelab SDD task list for Elgato lighting in Home Assistant"
       `docs/runbooks/home-assistant.md`.
 - [x] T005 [FR-003] [FR-004] Add Elgato entity inventory and runtime-state
       safety guidance to `docs/runbooks/home-assistant.md`.
-- [x] T006 [FR-005] Re-check constitution gates after implementation edits.
+- [x] T015 [FR-001] Add `input_boolean.desk_light_auto_balance` to
+      `kubernetes/apps/home-assistant/config/packages/code_first.yaml`.
+- [x] T016 [FR-002] [FR-003] Add the illuminance-triggered, helper-gated
+      automation to `kubernetes/apps/home-assistant/config/packages/code_first.yaml`.
+- [x] T017 [FR-004] [FR-005] [FR-006] [FR-007] [FR-008] [FR-009] Configure the
+      required Elgato targets, transition, brightness percentages, kelvin
+      values, and lux thresholds.
+- [x] T018 [FR-010] Mirror the helper and automation in
+      `kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml`.
+- [x] T019 [FR-DOCS] Update `docs/runbooks/home-assistant.md` only as needed to
+      reflect the Git-owned automation.
+- [x] T020 [FR-011] Re-check constitution gates after implementation edits.
 
 ## Phase 3: Verification
 
@@ -41,12 +56,28 @@ description: "Homelab SDD task list for Elgato lighting in Home Assistant"
       `kubectl kustomize kubernetes/apps/home-assistant`.
 - [x] T008 [FR-TEST] Run
       `kubectl kustomize kubernetes/apps/home-assistant/branch`.
-- [x] T009 [FR-SMOKE] Record docs-only development smoke exception.
+- [x] T009 [FR-SMOKE] Record prior docs-only development smoke exception before
+      the automation scope change; superseded by T025.
 - [x] T010 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
       and final `HEAD` in `specs/home-assistant-elgato-lighting/evidence.md`.
+- [x] T021 [FR-TEST] Run
+      `kubectl kustomize kubernetes/apps/home-assistant`.
+- [x] T022 [FR-TEST] Run
+      `kubectl kustomize kubernetes/apps/home-assistant/branch`.
+- [x] T023 [FR-TEST] Run a YAML/config sanity check for the edited Home
+      Assistant package files.
+- [x] T024 [FR-TEST] Run workflow validators for the implementation owner
+      context.
+- [x] T025 [FR-SMOKE] Record development validation evidence or an
+      unavailable-infrastructure exception with substitute checks.
+- [x] T026 [FR-EVIDENCE] Record exact command outcomes, `git status --short`,
+      docs impact, exceptions, and final `HEAD` in
+      `specs/home-assistant-elgato-lighting/evidence.md`.
 
 ## Phase 4: Commit And PR
 
 - [x] T011 [FR-PR] Commit with a conventional commit message.
+- [x] T027 [FR-PR] Commit the automation change with a conventional commit
+      message.
 - [ ] T012 [FR-PR] Push branch `codex/home-assistant-elgato-lighting` and open
       a PR after separate verifier approval.


### PR DESCRIPTION
## Summary
# Evidence: home-assistant-elgato-lighting

**Branch**: `codex/home-assistant-elgato-lighting`
**Risk Tier**: medium
**Started**: 2026-07-04

## Scope Update

- Existing docs-only/tiny SDD artifacts were revised for a medium-risk Home
  Assistant app behavior/config change.
- Implemented Git-owned desk Elgato ambient balance in
  `kubernetes/apps/home-assistant/config/packages/code_first.yaml` and mirrored
  it in `kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml`.
- Updated `docs/runbooks/home-assistant.md` with the Git-owned automation
  location and entities.
- Runtime Home Assistant `.storage`, config entries, credentials, SOPS secrets,
  Kubernetes workload, Gateway, PVC, Service, Flux, and generated architecture
  files were not changed.

## Spec Kit And Workflow Notes

| Command | Result | Notes |
| ------- | ------ | ----- |
| `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | FAIL | Script could not resolve a feature directory because `.specify/feature.json` is not present. Continued from the explicit implementation path `specs/home-assistant-elgato-lighting/` required by the workflow and user request. |
| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation marker accepted. |
| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan accepted after scope/risk update. |
| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation accepted. |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts are present and non-empty. |

## Local Checks

| Command | Result | Notes |
| ------- | ------ | ----- |
| `kubectl kustomize kubernetes/apps/home-assistant > .codex/tmp/home-assistant.render.yaml` | PASS | Production Home Assistant kustomization rendered successfully. |
| `kubectl kustomize kubernetes/apps/home-assistant/branch > .codex/tmp/home-assistant-branch.render.yaml` | PASS | Branch Home Assistant kustomization rendered successfully. |
| `docker run --rm -v "$PWD/.codex/tmp/ha-branch-check:/config" ghcr.io/home-assistant/home-assistant:2026.7.1 python -m homeassistant --script check_config --config /config` | PASS | Offline Home Assistant config check passed against a temporary copy of the branch config. The production package is identical to the branch package; production-only secrets/OIDC custom component were not required for this package sanity check. |
| `diff -u kubernetes/apps/home-assistant/config/packages/code_first.yaml kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml` | PASS | No diff; production/base and branch overlay package behavior match. |
| `rg -n "desk_light_auto_balance|desk_elgato_ambient_balance|office_desk_illuminance|elgato_key_light_air|color_temp_kelvin|brightness_pct|transition: 3" .codex/tmp/home-assistant.render.yaml .codex/tmp/home-assistant-branch.render.yaml` | PASS | Rendered ConfigMaps include the helper, automation, trigger sensor, target lights, documented color-temperature field, brightness percentages, and transition values. |
| `git diff --check` | PASS | No whitespace errors. |
| `git status --short` | PASS | Before evidence refresh, changed files were limited to the Home Assistant runbook, production/base package, branch package, and SDD artifacts. |

## Behavior Review

| Requirement | Result | Notes |
| ----------- | ------ | ----- |
| Trigger on illuminance changes | PASS | Automation uses `triggers: - trigger: state` with `entity_id: sensor.office_desk_illuminance`. |
| Manual enable helper | PASS | Package defines `input_boolean.desk_light_auto_balance`; automation conditions require it to be `on`. |
| Numeric sensor guard | PASS | Automation requires `is_number(trigger.to_state.state)` before converting to `desk_lux`. |
| Bright threshold | PASS | `desk_lux >= 400` turns both Elgato lights off with `transition: 3`. |
| Light fill | PASS | `250-399` lux sets ambient `35%`/`4000K` and camera `18%`/`3800K` with `transition: 3`. |
| Medium fill | PASS | `100-249` lux sets ambient `55%`/`3800K` and camera `28%`/`3600K` with `transition: 3`. |
| Strong fill | PASS | `<100` lux sets ambient `75%`/`3500K` and camera `38%`/`3300K` with `transition: 3`. |

## Development Validation

- Profile: unavailable
- Branch slug: home-assistant-elgato-lighting
- Pre-commit base HEAD: `bc0f4a9ce8807a1123a8b7bfe11ef31431c01f12`
- Report path: N/A
- Cleanup: Temporary check config directory `.codex/tmp/ha-branch-check` is
  ignored runtime scratch.
- Result or exception: Live development-cluster validation was not run because
  `kubectl config current-context` returned `error: current-context is not set`.
  The user also requested no push, which prevents branch-deploy smoke through
  the normal branch workflow. Substitute checks were production render, branch
  render, offline Home Assistant branch `check_config`, package parity diff,
  rendered ConfigMap content review, workflow validators, and whitespace/status
  checks.

## Rebase Refresh

- Rebased onto current `origin/main`:
  `be0b777d96eb0262d8ddc9ff673828ed56d79a5a`
- Rebased branch HEAD before evidence amend:
  `bb0024a23aea3f1b3738230e16c4cd436c101383`
- Rebase conflicts: none; `git rebase origin/main` completed successfully.
- Branch state after rebase: `codex/home-assistant-elgato-lighting` was
  `ahead 2` of `origin/main` and no longer behind.

### Rebase Validation

| Command | Result | Notes |
| ------- | ------ | ----- |
| `git fetch origin && git rev-parse origin/main && git rebase origin/main` | PASS | Fetched `be0b777d96eb0262d8ddc9ff673828ed56d79a5a`; rebase completed with no conflicts. |
| `kubectl kustomize kubernetes/apps/home-assistant > .codex/tmp/home-assistant.render.yaml` | PASS | Production Home Assistant kustomization rendered successfully after rebase. |
| `kubectl kustomize kubernetes/apps/home-assistant/branch > .codex/tmp/home-assistant-branch.render.yaml` | PASS | Branch Home Assistant kustomization rendered successfully after rebase. |
| `diff -u kubernetes/apps/home-assistant/config/packages/code_first.yaml kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml` | PASS | No diff; production/base and branch overlay package behavior still match. |
| `docker run --rm -v "$PWD/.codex/tmp/ha-branch-check:/config" ghcr.io/home-assistant/home-assistant:2026.7.1 python -m homeassistant --script check_config --config /config` | PASS | Offline Home Assistant config check passed against a temporary copy of the branch config. |
| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation marker remains valid after rebase. |
| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Runtime implementation plan remains valid with `base: origin/main`. |
| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Owner attestation remains valid. |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | SDD artifacts and evidence remain valid. |
| `rg -n "desk_light_auto_balance\|desk_elgato_ambient_balance\|office_desk_illuminance\|elgato_key_light_air\|color_temp_kelvin\|brightness_pct\|transition: 3" .codex/tmp/home-assistant.render.yaml .codex/tmp/home-assistant-branch.render.yaml` | PASS | Rendered ConfigMaps still include the helper, automation, trigger sensor, target lights, documented color-temperature field, brightness percentages, and transition values. |
| `git diff --check` | PASS | No whitespace errors after rebase. |
| `git status --short --branch` | PASS | Branch was clean and `ahead 2` of `origin/main` before this evidence update. |

## Documentation Impact

- Updated: `docs/runbooks/home-assistant.md`
- Generated docs: Not required; Kubernetes and Terraform resource shape did not
  change. ConfigMap file content changed only through existing generators.
- No-docs rationale: N/A

## Final State

- Final branch: `codex/home-assistant-elgato-lighting`
- Final HEAD before cleanup amend:
  `1136f169dceac8affd4ec473c61890f04dc713d7`
- Commit: `feat(home-assistant): add desk elgato auto balance`
- Push: Not run by request; verifier approval was not created.


## Changes
- docs/runbooks/home-assistant.md
- kubernetes/apps/home-assistant/branch/config/packages/code_first.yaml
- kubernetes/apps/home-assistant/config/packages/code_first.yaml
- specs/home-assistant-elgato-lighting/evidence.md
- specs/home-assistant-elgato-lighting/plan.md
- specs/home-assistant-elgato-lighting/spec.md
- specs/home-assistant-elgato-lighting/tasks.md

## Commits
- da780f3 feat(home-assistant): add desk elgato auto balance
- bc93a47 docs(home-assistant): document elgato light onboarding

## Verification
- Spec Kit evidence: `specs/home-assistant-elgato-lighting/evidence.md`.
- HEAD: `da780f3b5a0c3a993cf8062377ef4c5c2a684eda`.
