### PR TITLE
[codex] Document smoke kube aliases

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -20,24 +20,43 @@ The checks are intentionally deeper than pod readiness and lighter than full aut
 
 ## Manual Run
 
-Create a one-off Job from the CronJob:
+Source the opt-in cluster aliases before running manual smoke commands. These
+helpers keep the kubeconfig selection scoped to each command process, which is
+useful when Codex or an operator needs an explicit cluster context:
 
 ```bash
-kubectl create job -n synthetics synthetic-smoke-manual-$(date +%Y%m%d%H%M%S) \
+. scripts/kube-aliases.sh
+kp config current-context
+```
+
+`kd` and `fd` target the development kubeconfig. `kp` and `fp` target the
+production kubeconfig. Use `kd config current-context` or
+`kp config current-context` before smoke work when the active cluster is
+ambiguous.
+
+Production is the default target for the scheduled `synthetic-smoke` CronJob.
+Create a one-off Job from the production CronJob:
+
+```bash
+kp create job -n synthetics synthetic-smoke-manual-$(date +%Y%m%d%H%M%S) \
   --from=cronjob/synthetic-smoke
 ```
 
 Watch it finish:
 
 ```bash
-kubectl get jobs,pods -n synthetics -l app.kubernetes.io/name=synthetic-smoke
+kp get jobs,pods -n synthetics -l app.kubernetes.io/name=synthetic-smoke
 ```
 
 Read the Playwright output:
 
 ```bash
-kubectl logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
+kp logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
 ```
+
+When running development-cluster smoke checks instead, use `kd` for Kubernetes
+commands and `fd` for Flux commands so the development kubeconfig is selected
+without changing the shell's active `KUBECONFIG`.
 
 Every completed run should emit exactly one bounded summary line:
 

--- a/specs/document-smoke-kube-aliases/evidence.md
+++ b/specs/document-smoke-kube-aliases/evidence.md
@@ -1,0 +1,60 @@
+# Evidence: document-smoke-kube-aliases
+
+**Branch**: `codex/document-smoke-kube-aliases`
+**Risk Tier**: tiny
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: manual SDD artifact creation from repository templates and approved
+  plan
+- Outcome: PASS
+- Spec Kit version: not reinitialized for this existing Spec Kit repository
+- Integration: existing repository integration
+- Fallback: default worktree parent
+  `/workspaces/homelab-worktrees/document-smoke-kube-aliases` was unavailable
+  because `/workspaces` is not writable by the container user; used
+  `/workspaces/homelab-ideas/document-smoke-kube-aliases` instead.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD context accepted branch `codex/document-smoke-kube-aliases` with non-empty spec, plan, and tasks artifacts. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `rg -n "kube-aliases|kd config current-context|kp create job|synthetic-smoke" docs/runbooks/synthetic-smoke-tests.md` | PASS | Found alias source, context confirmation, production `kp create job`, and synthetic smoke references in the runbook. |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture documentation remains current. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: document-smoke-kube-aliases
+- HEAD: final commit reported in handoff
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development smoke is not required because this is a
+  docs-only change that does not alter Kubernetes desired state, branch
+  overlays, app behavior, smoke code, Gateway routes, storage, or secret
+  references.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/synthetic-smoke-tests.md`
+- Generated docs: `python3 tools/architecture/render.py --check` passed; no
+  generated update needed.
+- No-docs rationale: N/A
+
+## Exceptions And Follow-Ups
+
+- Worktree path fallback from `/workspaces/homelab-worktrees/` to
+  `/workspaces/homelab-ideas/` due to filesystem permissions.
+
+## Final State
+
+- Final branch: `codex/document-smoke-kube-aliases`
+- Final HEAD: final commit reported in handoff
+- Commit: `docs(smoke): document kube aliases`

--- a/specs/document-smoke-kube-aliases/plan.md
+++ b/specs/document-smoke-kube-aliases/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: document-smoke-kube-aliases
+
+**Branch**: `codex/document-smoke-kube-aliases` | **Date**: 2026-07-04 |
+**Spec**: `specs/document-smoke-kube-aliases/spec.md`
+
+**Input**: Feature specification from
+`specs/document-smoke-kube-aliases/spec.md`
+
+## Summary
+
+Make a docs-only update to the synthetic smoke runbook so manual smoke commands
+use the existing kube aliases when an explicit development or production cluster
+context is needed. Keep alias behavior and cluster desired state unchanged.
+
+## Technical Context
+
+**Risk Tier**: tiny
+**Workflow Tier**: docs-only
+**Primary Areas**: documentation, SDD artifacts
+**Dependencies**: local Git, `rg`, Python architecture renderer, SDD context
+validator
+**Storage**: N/A
+**Ingress**: N/A
+**Secrets**: No secret manifests or local secret contents are changed
+**Development Validation**: none; docs-only change with no Kubernetes desired
+state or smoke behavior impact
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation exception is
+      recorded for this docs-only change.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; not applicable.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/document-smoke-kube-aliases`; fallback worktree location
+      is recorded because `/workspaces/homelab-worktrees` was not writable.
+- [x] Documentation impact identified; synthetic smoke runbook is updated.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/document-smoke-kube-aliases/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+docs/runbooks/synthetic-smoke-tests.md
+specs/document-smoke-kube-aliases/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No failing test is required for this docs-only wording
+change. The useful validation is focused review, targeted search, generated
+architecture check, and SDD context validation.
+
+**Local checks**:
+
+- `rg -n "kube-aliases|kd config current-context|kp create job|synthetic-smoke" docs/runbooks/synthetic-smoke-tests.md`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+
+**Development smoke**: none. This docs-only change does not affect Kubernetes
+desired state, branch overlays, app behavior, smoke code, Gateway routes,
+storage, or secret references.
+
+**Evidence destination**: `specs/document-smoke-kube-aliases/evidence.md`.
+
+## Documentation Impact
+
+Updates `docs/runbooks/synthetic-smoke-tests.md` only. Generated
+`docs/architecture.md` is expected to remain unchanged.
+
+## Implementation Steps
+
+1. Create the implementation branch and worktree, using the allowed sibling
+   fallback if the default worktree parent is unavailable.
+2. Add SDD spec, plan, tasks, and evidence artifacts.
+3. Update the synthetic smoke Manual Run section to source the alias script,
+   explain development and production aliases, and use `kp` for production
+   manual smoke commands.
+4. Run focused docs/workflow checks and record outcomes in evidence.
+5. Commit with a conventional docs commit.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Operators run smoke against the wrong cluster | Include `config current-context` examples and identify each alias target |
+| Docs imply alias behavior that drifts from the script | Keep `scripts/kube-aliases.sh` unchanged and name it as the source of truth |
+| Live smoke is skipped for a cluster-affecting change | Classify the slice as docs-only and record that no cluster behavior changed |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/document-smoke-kube-aliases/spec.md
+++ b/specs/document-smoke-kube-aliases/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: document-smoke-kube-aliases
+
+**Feature Branch**: `codex/document-smoke-kube-aliases`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: tiny
+**Input**: User description: "codex has issues getting the cluster context for testing. document these aliases as a source for running smokes manually as needed."
+
+## Summary
+
+Operators and Codex agents need the synthetic smoke runbook to point at the
+existing kube alias source when manual smoke checks require an explicit
+development or production cluster context.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/synthetic-smoke-tests.md`
+- `docs/runbooks/development-cluster.md`
+
+## Scope
+
+### In Scope
+
+- Document `scripts/kube-aliases.sh` in the synthetic smoke manual-run
+  workflow.
+- Clarify that `kd` and `fd` target development, while `kp` and `fp` target
+  production.
+- Show production manual synthetic smoke commands using the production
+  kubectl alias.
+- Add durable SDD artifacts and evidence for the docs-only change.
+
+### Out Of Scope
+
+- Changing `scripts/kube-aliases.sh`.
+- Changing synthetic smoke code, CronJob manifests, cluster state, kubeconfig
+  files, or Flux behavior.
+- Running a live manual smoke Job as part of this docs-only update.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Explicit Smoke Context (Priority: P1)
+
+As an operator or Codex agent, I need the manual smoke runbook to identify the
+alias source and commands that select the intended cluster context.
+
+**Why this priority**: This is the smallest useful change that addresses
+context confusion without changing cluster behavior.
+
+**Independent Test**: Review the synthetic smoke runbook and run a targeted
+search for the alias source and production manual-run commands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reader needs to run manual synthetic smoke checks, **When** they
+   read the Manual Run section, **Then** they can source the aliases, confirm the
+   current context, and run production smoke commands through `kp`.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The synthetic smoke runbook MUST document
+  `scripts/kube-aliases.sh` as the source for opt-in Kubernetes and Flux
+  aliases.
+- **FR-002**: The runbook MUST identify `kd` and `fd` as development helpers
+  and `kp` and `fp` as production helpers.
+- **FR-003**: The manual production synthetic smoke examples MUST use `kp`
+  rather than unqualified `kubectl`.
+- **FR-004**: The implementation MUST NOT change Kubernetes desired state,
+  cluster state, smoke test code, or alias behavior.
+- **FR-005**: Evidence MUST record docs-only validation and the development
+  smoke exception.
+
+## Risk And Validation Expectations
+
+**Tiny**: This is a docs-only update. Record review evidence and run focused
+documentation/workflow checks. No live development or production smoke is
+required because no executable behavior or desired cluster state changes.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `docs/runbooks/synthetic-smoke-tests.md` tells readers to source
+  `scripts/kube-aliases.sh` before manual smoke cluster commands.
+- **SC-002**: The runbook includes `kd`, `fd`, `kp`, and `fp` role guidance and
+  uses `kp` for production `synthetic-smoke` Job, watch, and log examples.
+- **SC-003**: Focused documentation search and SDD context validation pass.
+
+## Assumptions
+
+- The scheduled `synthetic-smoke` CronJob is production-oriented unless a
+  development-cluster workflow explicitly says otherwise.
+- The current alias definitions in `scripts/kube-aliases.sh` are already
+  correct and remain the source of truth.
+
+## Open Questions
+
+- None.

--- a/specs/document-smoke-kube-aliases/tasks.md
+++ b/specs/document-smoke-kube-aliases/tasks.md
@@ -1,0 +1,54 @@
+---
+description: "Document smoke kube alias usage tasks"
+---
+
+# Tasks: document-smoke-kube-aliases
+
+**Input**: `specs/document-smoke-kube-aliases/spec.md` and
+`specs/document-smoke-kube-aliases/plan.md`
+**Risk Tier**: tiny
+**Prerequisites**: Branch `codex/document-smoke-kube-aliases` and matching
+`specs/document-smoke-kube-aliases/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Spec And Plan
+
+- [x] T001 [FR-SPEC] Create
+      `specs/document-smoke-kube-aliases/spec.md`.
+- [x] T002 [FR-PLAN] Create
+      `specs/document-smoke-kube-aliases/plan.md`, including tiered TDD and
+      development validation expectations.
+- [x] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations in `specs/document-smoke-kube-aliases/plan.md`.
+
+## Phase 2: Implementation
+
+- [x] T004 [FR-001,FR-002,FR-003] Edit
+      `docs/runbooks/synthetic-smoke-tests.md` to document
+      `scripts/kube-aliases.sh`, alias targets, context confirmation, and
+      production manual smoke commands through `kp`.
+- [x] T005 [FR-004] Re-check constitution gates after implementation edits in
+      `specs/document-smoke-kube-aliases/plan.md`.
+
+## Phase 3: Verification
+
+- [x] T006 [FR-TEST] Run targeted `rg` validation against
+      `docs/runbooks/synthetic-smoke-tests.md`.
+- [x] T007 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T008 [FR-TEST] Run
+      `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
+- [x] T009 [FR-SMOKE] Record docs-only development smoke exception in
+      `specs/document-smoke-kube-aliases/evidence.md`.
+- [x] T010 [FR-EVIDENCE] Record command outcomes, exceptions, and final `HEAD`
+      in `specs/document-smoke-kube-aliases/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [x] T011 [FR-PR] Commit with a conventional commit message.
+- [x] T012 [FR-PR] Leave branch ready for push and PR creation.


### PR DESCRIPTION
## Summary

- Document `scripts/kube-aliases.sh` in the synthetic smoke manual-run workflow.
- Clarify `kd`/`fd` as development helpers and `kp`/`fp` as production helpers.
- Update production manual synthetic smoke examples to use `kp` so cluster context is explicit.

## Validation

- `rg -n "kube-aliases|kd config current-context|kp create job|synthetic-smoke" docs/runbooks/synthetic-smoke-tests.md`
- `python3 tools/architecture/render.py --check`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence`
- Commit hooks passed, including generated architecture check.

## Notes

- Docs-only change; no Kubernetes desired state, smoke code, aliases, secrets, or cluster state changed.
- Used fallback worktree path `/workspaces/homelab-ideas/document-smoke-kube-aliases` because `/workspaces/homelab-worktrees/` was not writable in this environment.