### PR TITLE
docs(workflow): strengthen SDD smoke and fanout standards

### DIFF
--- a/.specify/templates/evidence-template.md
+++ b/.specify/templates/evidence-template.md
@@ -24,6 +24,20 @@
 | ------- | ------ | ----- |
 | `[command]` | [PASS/FAIL/SKIP] | [notes] |
 
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| [exact URL, smoke profile, or Job] | [development profile, synthetic Job, Gateway curl, Playwright, etc.] | [PASS/FAIL/SKIP] | [SHA, status, or exception] |
+
+## Deployment State
+
+- Source fetched SHA:
+- Target applied SHA:
+- Live resource spec checked:
+- Gateway/listener/DNS/certificate checked:
+- Exact user-facing URL result:
+
 ## Development Validation
 
 - Profile: [whoami|manual|none]
@@ -38,6 +52,13 @@
 - Updated:
 - Generated docs:
 - No-docs rationale:
+
+## SDD Conformance
+
+- Local sources checked:
+- Upstream Spec Kit sources checked:
+- Spec -> Plan -> Tasks -> Implement alignment:
+- Artifact updates after implementation:
 
 ## Exceptions And Follow-Ups
 

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -18,8 +18,13 @@
 **Storage**: [NFS class expectation or N/A]
 **Ingress**: [Gateway API route expectation or N/A]
 **Secrets**: [SOPS expectation or N/A]
+**Smoke Strategy**: [development profile, synthetic smoke Job, scriptable
+Gateway/DNS/browser smoke, or none with reason]
+**Fanout Targets**: [independent tasks safe for helper lanes or N/A]
 **Development Validation**: [whoami profile, manual smoke, include-cluster-base,
 none with reason]
+**Post-Implementation SDD Conformance**: [local docs only, upstream Spec Kit
+review required, or N/A]
 
 ## Constitution Check
 
@@ -67,6 +72,19 @@ tier.]
 
 **Development smoke**: [Profile, manual commands, include-cluster-base, or none
 with reason.]
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization or HelmRelease applied SHA, live resource spec, Gateway/listener
+match when applicable, and exact user-facing URL result.
+
+**Fanout plan**: [List independent non-conflicting tasks and how results will be
+consolidated into evidence.md.]
 
 **Evidence destination**: `specs/[IMPLEMENTATION]/evidence.md`.
 

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -12,10 +12,13 @@ description: "Homelab SDD task list template"
 
 ## Format: `[ID] [P?] [Req] Description`
 
-- **[P]**: Can run in parallel because it touches different files and has no
-  dependency on another task.
+- **[P]**: Can run in parallel or fan out to a helper lane because it touches
+  different files or performs read-only validation and has no dependency on
+  another incomplete task.
 - **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
 - Include exact file paths in each task.
+- Keep fanout coordinated through this task list and consolidate all results
+  into `specs/[IMPLEMENTATION]/evidence.md`.
 
 ## Phase 1: Spec And Plan
 
@@ -37,8 +40,9 @@ description: "Homelab SDD task list template"
 - [ ] T008 [FR-TEST] Run [broader local command].
 - [ ] T009 [FR-SMOKE] Run development smoke validation or record why the tier
       does not require it.
-- [ ] T010 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
-      and final `HEAD` in `specs/[IMPLEMENTATION]/evidence.md`.
+- [ ] T010 [FR-EVIDENCE] Record command outcomes, SHAs, URLs when applicable,
+      smoke evidence, skipped checks, exceptions, final live verification, and
+      final `HEAD` in `specs/[IMPLEMENTATION]/evidence.md`.
 
 ## Phase 4: Commit And PR
 
@@ -70,3 +74,13 @@ description: "Homelab SDD task list template"
   shared base paths.
 - Use `--include-cluster-base` when shared development base resources must
   reconcile before app acceptance.
+
+## Fanout Guidance
+
+- Prefer fanout for independent repo inspection, test design, render checks,
+  smoke execution, docs/evidence updates, public/private repo audits, and live
+  read-only verification.
+- Do not fan out tracked edits that touch the same files unless the task
+  boundary is explicit enough to avoid conflicts.
+- Fanout does not change the one implementation, one branch, one
+  `specs/[IMPLEMENTATION]/`, one PR contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ Synology NFS, Grafana/Loki/Mimir/Alloy.
   `codex/<implementation>`. Use the current checkout only when explicitly
   requested; sibling clones are an allowed fallback.
 - Run the Spec Kit cycle: specify, plan, tasks, then implement.
+- In `plan.md`, declare SDD tier, workflow risk tier, smoke strategy, fanout
+  targets, and exceptions before implementation edits.
+- In `tasks.md`, mark independent non-conflicting fanout work with `[P]`;
+  consolidate all helper-lane results into one `evidence.md`.
 - Before worktree or clone commands that need ignored local secret/config files,
   stage them under
   `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout
@@ -55,6 +59,10 @@ Synology NFS, Grafana/Loki/Mimir/Alloy.
   repo-relative paths in worktrees or clones before commands that need them.
 - Runtime scratch files stay under `.codex/tmp/` and are not committed. Durable
   requirements, plans, tasks, and evidence stay under `specs/<implementation>/`.
+- Prefer automated smoke for user-facing, routed, deployed, or operational
+  changes. Do not call such work done from render checks, pod readiness, Service
+  probes, or route `Accepted=True` alone; verify the exact user path or record
+  the unverified layer.
 - Push and PR automation require matching non-empty Spec Kit artifacts,
   including `evidence.md`; normal GitHub PR review and status checks provide
   review gating.

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -35,14 +35,18 @@ Use this runbook for every repository code change. The binding decision is
    `specify -> plan -> tasks -> implement`.
 5. Keep durable implementation context in `specs/<implementation>/`:
    `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
-6. Make tracked-file changes only on `codex/<implementation>`, never on `main`.
-7. Run relevant checks, collect TDD evidence, and collect required development
+6. In `plan.md`, declare the SDD tier, workflow risk tier, smoke strategy,
+   fanout targets, and exceptions before implementation edits.
+7. In `tasks.md`, mark independent fanout work with `[P]` and keep all
+   fanout results coordinated through one `evidence.md`.
+8. Make tracked-file changes only on `codex/<implementation>`, never on `main`.
+9. Run relevant checks, collect TDD evidence, and collect required development
    validation evidence for covered cluster-affecting changes.
-8. Record command outcomes, development validation evidence or exceptions,
-   final branch state, and documentation impact in
+10. Record command outcomes, development validation evidence or exceptions,
+   SHAs, user-facing URLs, final branch state, and documentation impact in
    `specs/<implementation>/evidence.md`.
-9. Commit with a conventional commit message.
-10. Create the pull request against `main`. Review gating happens through
+11. Commit with a conventional commit message.
+12. Create the pull request against `main`. Review gating happens through
     normal GitHub PR review and status checks.
 
 ## Guard Gates
@@ -126,6 +130,55 @@ Default development validation paths:
   branch coverage that cannot be safely emulated manually, or production-only
   integrations that development cannot represent.
 
+Automated smoke is preferred whenever practical. For user-facing, routed,
+deployed, or operational changes, choose the strongest available automated
+validation in this order:
+
+1. Existing development branch smoke profile.
+2. Production synthetic smoke or a one-off in-cluster synthetic Job.
+3. Scriptable Gateway, DNS, HTTP, or browser smoke against the exact user URL.
+4. Manual browser verification only as supplemental evidence.
+
+Do not report routed or deployed work as complete from pod readiness, Service
+probes, render checks, or `Accepted=True` route status alone. Evidence must
+identify the layer proved: rendered intent, pushed branch, merged commit,
+Flux-fetched source, kustomization-applied revision, live resource spec, and
+user-facing behavior. If a layer is not verified, state that explicitly.
+
+## Fanout And Helper Lanes
+
+Use fanout to reduce elapsed time when workstreams are independent and
+non-conflicting. Good targets include repo inspection, test design, render
+validation, smoke execution, docs/evidence updates, public/private repo audits,
+and live read-only verification.
+
+Fanout must be declared in `plan.md`, represented with `[P]` tasks in
+`tasks.md`, and consolidated into the implementation's single `evidence.md`.
+Do not split responsibility across multiple branches or PRs unless the work is
+intentionally decomposed into separate implementations.
+
+Tracked edits that touch the same files should stay sequential unless the
+partition is explicit enough to avoid collisions. Read-only validation and
+smoke checks are preferred fanout targets.
+
+## Post-Merge Verification
+
+For deploy follow-up, verify the live system in layers before declaring the
+change deployed:
+
+1. The GitHub PR is merged and the merge SHA is known.
+2. The Flux source has fetched the merge SHA.
+3. The target Kustomization or HelmRelease applied the merge SHA.
+4. The live resource spec matches the intended rendered state.
+5. Gateway listener, DNS, certificate, backend, and route status match the
+   intended exposure when applicable.
+6. The exact user-facing URL, protocol, path, and network plane return the
+   expected HTTP/browser result.
+
+Record each verified layer in `evidence.md` or the PR/deploy handoff. Use
+precise status words such as `rendered`, `pushed`, `merged`, `fetched by Flux`,
+`applied`, and `verified from user path`.
+
 ## Evidence Audit
 
 Before requesting PR review, audit:
@@ -138,3 +191,7 @@ Before requesting PR review, audit:
 - Development validation evidence includes app name, branch, branch slug, exact
   `HEAD`, smoke profile or documented exception, report path if one was
   produced, and cleanup status.
+- User-facing or deploy evidence includes exact URLs, SHAs, live resource state,
+  and automated smoke result when applicable.
+- Workflow or template changes include a local SDD audit and, when they change
+  Spec Kit behavior or standards, an upstream Spec Kit conformance check.

--- a/docs/runbooks/spec-driven-development.md
+++ b/docs/runbooks/spec-driven-development.md
@@ -70,6 +70,21 @@ Each implementation owns:
 Runtime files under `.codex/tmp/` are ignored and are not durable
 documentation. Durable implementation context belongs in `specs/<implementation>/`.
 
+## Upstream Conformance
+
+Homelab follows the upstream Spec Kit phase order: Spec -> Plan -> Tasks ->
+Implement. Upstream Spec Kit documentation is useful for process checks and
+tooling updates, but repo-local sources remain binding when they are stricter:
+`AGENTS.md`, this runbook, `docs/runbooks/implementation-workflow.md`, binding
+ADRs, and harness validators.
+
+After implementation, evidence should include a short SDD conformance check
+against both local workflow sources and upstream Spec Kit guidance when the
+change alters agent workflow, Spec Kit templates, or implementation standards.
+The check should confirm that the spec defines behavior before implementation,
+the plan records technical approach and constraints, tasks are actionable, and
+implementation evidence is reconciled back into the artifact set.
+
 ## Enforced Guard Behavior
 
 The harness treats `specs/<implementation>/` as durable implementation context.
@@ -96,6 +111,11 @@ for local scratch state such as prompt-intent markers and draft PR summaries.
 
 If future operators need the information after the branch is merged, it belongs
 in a committed spec, runbook, ADR, or generated documentation.
+
+When requirements change during implementation or acceptance, update the
+nearest SDD artifact before continuing. Adjust `spec.md` for intended behavior,
+`plan.md` for approach or validation strategy, `tasks.md` for execution order or
+fanout, and `evidence.md` for observed results and exceptions.
 
 ## Tiered Workflow
 
@@ -136,19 +156,44 @@ Development-cluster validation follows
 `docs/decisions/tdd-and-development-smoke-evidence.md` and
 `docs/runbooks/development-cluster.md`.
 
+Prefer automated smoke evidence for every user-facing, routed, deployed, or
+operational change. Use the strongest practical automated signal in this order:
+
+1. Existing development branch smoke profile.
+2. Production synthetic smoke or a one-off in-cluster synthetic Job.
+3. Scriptable Gateway, DNS, HTTP, or browser smoke against the exact user URL.
+4. Manual browser verification only as supplemental evidence.
+
 Use `smoke_profile: none` only for docs-only/local-only work or when required
 development infrastructure or credentials are unavailable. Record the reason and
-substitute checks in `evidence.md`.
+substitute checks in `evidence.md`. A routed or deployed change is not complete
+from pod readiness, Service probes, render checks, or `Accepted=True` route
+status alone; evidence must prove the intended user path or clearly state which
+layer remains unverified.
 
 Use `--include-cluster-base` when shared development base resources must
 reconcile before app acceptance.
+
+## Fanout
+
+Use fanout when tasks are independent and non-conflicting. Good fanout targets
+include repo inspection, test design, render validation, smoke execution,
+documentation/evidence updates, public/private repo audits, and live read-only
+verification. Mark parallelizable work with `[P]` in `tasks.md`, keep tracked
+edits coordinated through the single implementation branch, and consolidate all
+results into one `evidence.md`.
+
+Do not fan out tracked edits that touch the same files unless the task
+boundaries are explicit enough to avoid collisions. Fanout does not replace the
+one implementation, one branch, one `specs/<implementation>/`, one PR contract.
 
 ## Review Checklist
 
 - The spec links relevant binding ADRs and runbooks.
 - The plan declares SDD tier, workflow tier when needed, tests, smoke
-  expectations, docs impact, and risks.
+  expectations, fanout targets, docs impact, and risks.
 - Tasks are concrete enough for an implementation owner to execute.
-- Evidence includes exact command outcomes and exceptions.
+- Evidence includes exact command outcomes, SHAs, URLs when applicable, smoke
+  results, skipped checks, final live verification, and exceptions.
 - The branch is `codex/<implementation>` and artifacts live under matching
   `specs/<implementation>/`.

--- a/specs/sdd-agent-workflow-standards/evidence.md
+++ b/specs/sdd-agent-workflow-standards/evidence.md
@@ -1,0 +1,72 @@
+# Evidence: sdd-agent-workflow-standards
+
+**Branch**: `codex/sdd-agent-workflow-standards`
+**Risk Tier**: low
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: Manual artifact bootstrap from repo templates.
+- Outcome: PASS; created `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
+- Spec Kit version: Not changed by this implementation.
+- Integration: Existing repo Spec Kit integration.
+- Fallback: Used `/workspaces/homelab-ideas/sdd-agent-workflow-standards`
+  because `/workspaces/homelab-worktrees` is unavailable.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts present on `codex/sdd-agent-workflow-standards`. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/architecture/render.py --check` | PASS | No generated architecture changes required. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `rg -n "Spec -> Plan -> Tasks -> Implement|Smoke Strategy|Automated smoke|Fanout Targets|Post-Implementation SDD Conformance|fetched by Flux|verified from user path|Upstream Spec Kit" AGENTS.md docs/runbooks .specify/templates specs/sdd-agent-workflow-standards` | PASS | Confirmed workflow, smoke, fanout, and conformance language exists. |
+| `pre-commit run --all-files` | PASS | All hooks passed, including generated architecture, policy, k8svalidate, Terraform docs/fmt, and synthetic smoke mirroring. |
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: N/A
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: This is a docs/template-only workflow change. It does
+  not alter Kubernetes, Terraform, Flux, Gateway, storage, secret references,
+  branch overlays, or app behavior.
+
+## Upstream SDD Conformance
+
+- Source: `https://github.github.com/spec-kit/`
+- Source: `https://github.com/github/spec-kit`
+- Source: `https://github.github.com/spec-kit/quickstart.html`
+- Result: PASS. Upstream docs describe Spec Kit as SDD with specs at the
+  center, the core process as Spec -> Plan -> Tasks -> Implement, and
+  quickstart validation before implementation. This implementation keeps that
+  order, preserves repo-local stricter workflow gates, and records post-edit
+  evidence in the SDD artifact set.
+
+## Documentation Impact
+
+- Updated: `AGENTS.md`, `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`,
+  `.specify/templates/plan-template.md`,
+  `.specify/templates/tasks-template.md`, and
+  `.specify/templates/evidence-template.md`.
+- Generated docs: `python3 tools/architecture/render.py --check` passed; no
+  update required.
+- No-docs rationale: N/A
+
+## Exceptions And Follow-Ups
+
+- Development smoke omitted for docs/template-only work.
+
+## Final State
+
+- Final branch: PENDING
+- Final HEAD: PENDING
+- Commit: PENDING

--- a/specs/sdd-agent-workflow-standards/evidence.md
+++ b/specs/sdd-agent-workflow-standards/evidence.md
@@ -67,6 +67,7 @@
 
 ## Final State
 
-- Final branch: PENDING
-- Final HEAD: PENDING
-- Commit: PENDING
+- Final branch: `codex/sdd-agent-workflow-standards`
+- Final HEAD: recorded by PR head after evidence handoff update
+- Commit: `2554e48 docs(workflow): strengthen SDD smoke and fanout standards`
+- Pull request: `https://github.com/petebeegle/homelab/pull/341`

--- a/specs/sdd-agent-workflow-standards/plan.md
+++ b/specs/sdd-agent-workflow-standards/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: sdd-agent-workflow-standards
+
+**Branch**: `codex/sdd-agent-workflow-standards` | **Date**: 2026-07-04 |
+**Spec**: `specs/sdd-agent-workflow-standards/spec.md`
+
+**Input**: Feature specification from
+`specs/sdd-agent-workflow-standards/spec.md`
+
+## Summary
+
+Strengthen Homelab's agent workflow standards by updating the SDD and
+implementation runbooks plus Spec Kit templates. The change makes automated
+smoke preference, fanout coordination, exact evidence, and upstream SDD
+conformance explicit for future implementations.
+
+## Technical Context
+
+**Risk Tier**: low
+**Workflow Tier**: docs-only
+**Primary Areas**: docs, Spec Kit templates, agent guidance
+**Dependencies**: Git, Python for repo validators, internet access for upstream
+Spec Kit conformance review
+**Storage**: N/A
+**Ingress**: N/A
+**Secrets**: N/A
+**Development Validation**: none; docs/template-only change with no live app or
+cluster behavior
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation exception is
+      recorded because this is docs/template-only.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; not applicable.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/sdd-agent-workflow-standards`; sibling worktree fallback
+      is intentional because `/workspaces/homelab-worktrees` is absent.
+- [x] Documentation impact identified; docs and templates will be updated.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/sdd-agent-workflow-standards/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+AGENTS.md
+docs/runbooks/spec-driven-development.md
+docs/runbooks/implementation-workflow.md
+.specify/templates/plan-template.md
+.specify/templates/tasks-template.md
+.specify/templates/evidence-template.md
+specs/sdd-agent-workflow-standards/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No failing-code test seam is appropriate for docs/template
+guidance. Validate by SDD context checks, generated architecture check, targeted
+content inspection, and upstream Spec Kit conformance review.
+
+**Local checks**:
+
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+- `python3 tools/architecture/render.py --check`
+- `git diff --check`
+- targeted `rg` checks for smoke, fanout, and upstream conformance language
+
+**Development smoke**: none; this implementation changes documentation and
+templates only.
+
+**Evidence destination**:
+`specs/sdd-agent-workflow-standards/evidence.md`.
+
+## Documentation Impact
+
+Update workflow runbooks, top-level agent guidance, and Spec Kit templates.
+`docs/architecture.md` is not expected to change because no Kubernetes or
+Terraform source changes are made.
+
+## Implementation Steps
+
+1. Bootstrap SDD artifacts for this implementation.
+2. Update workflow docs and templates with smoke, fanout, exact evidence, and
+   upstream conformance expectations.
+3. Validate local docs/template state and record upstream Spec Kit conformance.
+4. Commit and open a PR.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Guidance becomes too broad to follow | Keep rules tied to concrete artifacts and evidence fields. |
+| Online SDD guidance drifts | Record upstream URLs and make repo-local docs binding when stricter. |
+| Fanout causes file conflicts | Require fanout tasks to be independent and consolidated through one evidence file. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/sdd-agent-workflow-standards/spec.md
+++ b/specs/sdd-agent-workflow-standards/spec.md
@@ -1,0 +1,143 @@
+# Feature Specification: sdd-agent-workflow-standards
+
+**Feature Branch**: `codex/sdd-agent-workflow-standards`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: low
+**Input**: User description: "Implement a general SDD-first agent workflow that conforms to repo SDD docs and upstream Spec Kit standards, strongly favors automated smoke testing, and uses fanout for independent work."
+
+## Summary
+
+Agents need clearer workflow standards for Homelab repository changes: durable
+Spec Kit artifacts come first, automated smoke is preferred for user-facing and
+operational changes, fanout is used where it is safe, and final evidence
+distinguishes rendered intent from live verified behavior.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- Upstream Spec Kit docs at `https://github.github.com/spec-kit/`
+- Upstream Spec Kit repository at `https://github.com/github/spec-kit`
+
+## Scope
+
+### In Scope
+
+- Clarify SDD-first defaults in repo workflow documentation.
+- Add smoke, fanout, and post-implementation conformance expectations to
+  templates used for future implementation artifacts.
+- Record this implementation's SDD and upstream conformance evidence.
+
+### Out Of Scope
+
+- Adding hard CI gates for smoke profiles or route policy.
+- Changing Kubernetes manifests or live cluster state.
+- Changing the current branch/worktree guard implementation.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - SDD-First Work Starts Consistently (Priority: P1)
+
+An implementation agent can start a repository change and know exactly which
+SDD artifacts, tiers, and evidence fields must exist before tracked edits and
+before handoff.
+
+**Why this priority**: It prevents ad hoc implementation and keeps future work
+reviewable.
+
+**Independent Test**: Review the runbooks and templates, then validate the SDD
+artifact set with the repo harness.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new implementation, **When** an agent reads the workflow docs and
+   templates, **Then** the agent sees that Spec Kit artifacts are required before
+   normal implementation and evidence is required before push/PR handoff.
+
+### User Story 2 - Smoke Is Preferred And Evidence Is Precise (Priority: P1)
+
+An implementation agent can choose validation for routed, deployed, or
+user-facing changes without substituting readiness or render checks for
+user-path smoke.
+
+**Why this priority**: Recent Homepage work showed that partial signals can be
+misreported as user-visible success.
+
+**Independent Test**: Inspect docs/templates for ordered smoke preference,
+exception rules, and deployment completion states.
+
+**Acceptance Scenarios**:
+
+1. **Given** a routed or operational change, **When** an agent writes the plan
+   and evidence, **Then** automated smoke is the default expectation and any
+   skipped smoke has a documented blocker and substitute checks.
+
+### User Story 3 - Fanout Is Safe And Coordinated (Priority: P2)
+
+An implementation agent can identify fanout opportunities without breaking the
+single-implementation branch/spec/PR contract.
+
+**Why this priority**: Independent workstreams can reduce slow implementation
+cycles when they are coordinated through tasks and evidence.
+
+**Independent Test**: Inspect task template and workflow docs for parallel task
+rules, fanout examples, and consolidation into one evidence file.
+
+**Acceptance Scenarios**:
+
+1. **Given** independent seams such as repo inspection, tests, docs, and smoke,
+   **When** an agent writes `tasks.md`, **Then** safe fanout tasks are marked
+   `[P]` and final results are consolidated in one evidence file.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The workflow docs MUST state that repo changes use Spec Kit
+  artifacts by default and that repo-local workflow sources remain binding when
+  stricter than upstream Spec Kit.
+- **FR-002**: The plan template MUST require SDD tier, workflow risk tier, smoke
+  strategy, fanout targets, exceptions, and post-implementation SDD conformance.
+- **FR-003**: The tasks template MUST make fanout/parallel markers explicit and
+  require consolidation into one implementation evidence file.
+- **FR-004**: The evidence template MUST record command outcomes, SHAs, URLs,
+  smoke results, skipped checks, exceptions, final live verification, and
+  upstream SDD conformance.
+- **FR-005**: Workflow guidance MUST prefer automated smoke evidence for
+  user-facing, routed, deployed, or operational changes.
+- **FR-006**: Workflow guidance MUST prohibit calling routed or deployed work
+  complete from pod readiness, Service probes, render checks, or route
+  `Accepted=True` alone.
+- **FR-007**: Evidence MUST record this implementation's local checks,
+  docs-only smoke exception, and upstream Spec Kit conformance review.
+
+## Risk And Validation Expectations
+
+**Low**: This is workflow documentation and template guidance. Run focused
+local checks for SDD context, markdown/content consistency, and generated docs
+status. Development smoke is not required because no Kubernetes, Terraform,
+Flux, Gateway, app behavior, storage, or secret reference changes are made.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Future implementation templates expose smoke strategy, fanout
+  targets, exceptions, and upstream SDD conformance fields.
+- **SC-002**: Workflow docs describe automated smoke preference and live
+  verification completion states.
+- **SC-003**: Evidence records local checks, the docs-only smoke exception, and
+  upstream Spec Kit conformance sources.
+
+## Assumptions
+
+- Repo-local SDD docs and ADRs are binding when stricter than upstream Spec Kit.
+- This change is documentation/template guidance and does not need live
+  development-cluster smoke.
+- Fanout means coordinated independent workstreams, not multiple conflicting
+  implementations inside one branch.
+
+## Open Questions
+
+- None.

--- a/specs/sdd-agent-workflow-standards/tasks.md
+++ b/specs/sdd-agent-workflow-standards/tasks.md
@@ -1,0 +1,72 @@
+---
+description: "General SDD-first agent workflow implementation tasks"
+---
+
+# Tasks: sdd-agent-workflow-standards
+
+**Input**: `specs/sdd-agent-workflow-standards/spec.md` and
+`specs/sdd-agent-workflow-standards/plan.md`
+**Risk Tier**: low
+**Prerequisites**: Branch `codex/sdd-agent-workflow-standards` and matching
+`specs/sdd-agent-workflow-standards/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no
+  dependency on another task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+
+## Phase 1: Spec And Plan
+
+- [X] T001 [FR-SPEC] Create
+      `specs/sdd-agent-workflow-standards/spec.md`.
+- [X] T002 [FR-PLAN] Create
+      `specs/sdd-agent-workflow-standards/plan.md`, including SDD tier,
+      workflow tier, smoke strategy, fanout targets, and exceptions.
+- [X] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations in `specs/sdd-agent-workflow-standards/plan.md`.
+
+## Phase 2: Implementation
+
+- [X] T004 [P] [FR-001,FR-005,FR-006] Update
+      `docs/runbooks/spec-driven-development.md` with SDD-first, smoke-first,
+      fanout, and upstream conformance guidance.
+- [X] T005 [P] [FR-001,FR-005,FR-006] Update
+      `docs/runbooks/implementation-workflow.md` with exact completion states,
+      automated smoke preference, fanout defaults, and post-merge verification.
+- [X] T006 [P] [FR-002,FR-003,FR-004] Update `.specify/templates/plan-template.md`,
+      `.specify/templates/tasks-template.md`, and
+      `.specify/templates/evidence-template.md`.
+- [X] T007 [P] [FR-001] Update `AGENTS.md` with concise smoke/fanout workflow
+      reminders.
+- [X] T008 [FR-IMPL] Re-check constitution gates after implementation edits in
+      `specs/sdd-agent-workflow-standards/plan.md`.
+
+## Phase 3: Verification
+
+- [X] T009 [FR-TEST] Run
+      `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
+- [X] T010 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [X] T011 [FR-TEST] Run `git diff --check`.
+- [X] T012 [FR-TEST] Run targeted `rg` checks for smoke, fanout, upstream
+      conformance, and completion-state language.
+- [X] T013 [FR-SMOKE] Record development smoke profile `none` with docs-only
+      rationale in `specs/sdd-agent-workflow-standards/evidence.md`.
+- [X] T014 [FR-EVIDENCE] Record upstream Spec Kit conformance review,
+      command outcomes, exceptions, and final `HEAD` in
+      `specs/sdd-agent-workflow-standards/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [ ] T015 [FR-PR] Commit with a conventional commit message.
+- [ ] T016 [FR-PR] Push branch `codex/sdd-agent-workflow-standards` and open a
+      PR.
+
+## Fanout Notes
+
+- T004-T007 are safe fanout targets because they touch separate files or
+  template groups and can be reviewed against the same requirements.
+- T009-T012 are safe fanout targets after implementation edits because they are
+  read-only validation commands.
+- T014 consolidates all fanout results into one evidence file.

--- a/specs/sdd-agent-workflow-standards/tasks.md
+++ b/specs/sdd-agent-workflow-standards/tasks.md
@@ -59,8 +59,8 @@ description: "General SDD-first agent workflow implementation tasks"
 
 ## Phase 4: Commit And PR
 
-- [ ] T015 [FR-PR] Commit with a conventional commit message.
-- [ ] T016 [FR-PR] Push branch `codex/sdd-agent-workflow-standards` and open a
+- [X] T015 [FR-PR] Commit with a conventional commit message.
+- [X] T016 [FR-PR] Push branch `codex/sdd-agent-workflow-standards` and open a
       PR.
 
 ## Fanout Notes


### PR DESCRIPTION
## Summary
- strengthen SDD-first workflow guidance for repo changes
- require future plans/templates to declare smoke strategy, fanout targets, exceptions, and post-implementation SDD conformance
- prefer automated smoke for user-facing, routed, deployed, or operational work
- document precise deploy completion states instead of treating partial signals as done

## Validation
- python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts
- python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence
- python3 tools/architecture/render.py --check
- git diff --check
- pre-commit run --all-files

## SDD conformance
- Local repo workflow docs reviewed: docs/runbooks/spec-driven-development.md and docs/runbooks/implementation-workflow.md
- Upstream Spec Kit reviewed: https://github.github.com/spec-kit/ and https://github.com/github/spec-kit
- This implementation follows Spec -> Plan -> Tasks -> Implement and records evidence in specs/sdd-agent-workflow-standards/