### PR TITLE
Implementation: home-assistant-dashboard-activity

### DIFF
--- a/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
@@ -405,17 +405,22 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
           "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "showPoints": "auto",
-            "spanNulls": false
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
           },
           "unit": "short"
         },
@@ -429,18 +434,16 @@
       },
       "id": 21,
       "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "show": false
         },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
+        "showHeader": true
       },
       "targets": [
         {
@@ -449,14 +452,16 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (__name__) (changes({__name__=~\"homeassistant_(light|switch|binary_sensor|person|device_tracker|automation|climate|cover|fan|lock|update)_state|homeassistant_sensor_.+\"}[$__rate_interval])) OR vector(0)",
-          "legendFormat": "{{__name__}}",
-          "range": true,
+          "expr": "topk(25, sum by (domain, entity, friendly_name) (increase(homeassistant_state_change_total{domain=~\"light|switch|binary_sensor|sensor|person|device_tracker|automation|climate|cover|fan|lock|update\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{entity}}",
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Recent Entity Changes",
-      "type": "timeseries"
+      "type": "table"
     },
     {
       "datasource": {
@@ -491,6 +496,71 @@
         "w": 12,
         "x": 12,
         "y": 6
+      },
+      "id": 27,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(25, max by (domain, entity, friendly_name, area) (homeassistant_last_updated_time_seconds{domain=~\"light|switch|binary_sensor|sensor|person|device_tracker|automation|climate|cover|fan|lock|update\"} * on(entity) group_left(area) homeassistant_entity_info))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{entity}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Recently Updated Entities",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
       },
       "id": 22,
       "options": {
@@ -512,7 +582,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(homeassistant_entity_available == 0) * on(entity) group_left(name, area) homeassistant_entity_info",
+          "expr": "(homeassistant_entity_available == 0) * on(entity) group_left(area) homeassistant_entity_info",
           "format": "table",
           "instant": true,
           "legendFormat": "{{entity}}",
@@ -522,210 +592,6 @@
       ],
       "title": "Unavailable Entities",
       "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "blue",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 0,
-        "y": 14
-      },
-      "id": 23,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum((homeassistant_light_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
-          "instant": true,
-          "legendFormat": "lights on",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Active Lights",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "blue",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 14
-      },
-      "id": 24,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum((homeassistant_switch_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
-          "instant": true,
-          "legendFormat": "switches on",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Active Switches",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 14
-      },
-      "id": 25,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum((homeassistant_binary_sensor_state == 1) * on(entity) group_left(area) homeassistant_entity_info) OR vector(0)",
-          "instant": true,
-          "legendFormat": "binary sensors on",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Active Binary Sensors",
-      "type": "stat"
     },
     {
       "datasource": {
@@ -757,9 +623,74 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
+        "w": 12,
+        "x": 12,
         "y": 14
+      },
+      "id": 23,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace((homeassistant_light_brightness_percent > 0) * on(entity) group_left(area) homeassistant_entity_info, \"active_metric\", \"light_brightness_percent\", \"entity\", \".*\") or label_replace((homeassistant_switch_state == 1) * on(entity) group_left(area) homeassistant_entity_info, \"active_metric\", \"switch_state\", \"entity\", \".*\") or label_replace((homeassistant_binary_sensor_state == 1) * on(entity) group_left(area) homeassistant_entity_info, \"active_metric\", \"binary_sensor_state\", \"entity\", \".*\")",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{entity}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Active Entities",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 22
       },
       "id": 26,
       "options": {
@@ -789,7 +720,7 @@
           "refId": "A"
         }
       ],
-      "title": "Entities By Area",
+      "title": "Inventory By Area",
       "type": "table"
     },
     {
@@ -798,7 +729,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 30
       },
       "id": 9,
       "panels": [],
@@ -832,7 +763,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 31
       },
       "id": 10,
       "options": {
@@ -892,7 +823,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 31
       },
       "id": 11,
       "options": {
@@ -931,7 +862,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 39
       },
       "id": 12,
       "panels": [],
@@ -947,7 +878,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 13,
       "options": {
@@ -984,7 +915,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 40
       },
       "id": 14,
       "options": {
@@ -1021,7 +952,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 48
       },
       "id": 15,
       "options": {
@@ -1069,6 +1000,6 @@
   "timezone": "browser",
   "title": "Home Assistant - Overview",
   "uid": "home-assistant-overview",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/specs/home-assistant-dashboard-activity/evidence.md
+++ b/specs/home-assistant-dashboard-activity/evidence.md
@@ -35,6 +35,62 @@
 | `python3 tools/architecture/render.py --check` | PASS | Generated architecture document unchanged. |
 | `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Passed against final committed SDD evidence. |
 
+## Follow-Up: Activity Panel Metric Semantics
+
+- Trigger: User feedback that some panels showed `0` and should not depend on
+  Grafana MCP query smoke when it is not returning properly.
+- Rationale: The follow-up avoids misleading zero-value stat panels and uses
+  known Home Assistant 2026.7.1 exporter metric names instead of guessed metric
+  shapes or Grafana MCP discovery. With namespace `homeassistant`, the dashboard
+  now uses `homeassistant_state_change_total`,
+  `homeassistant_last_updated_time_seconds`,
+  `homeassistant_entity_available`, `homeassistant_entity_info`,
+  `homeassistant_light_brightness_percent`, `homeassistant_switch_state`, and
+  `homeassistant_binary_sensor_state`.
+- Dashboard changes:
+  `Recent Entity Changes` is a table based on
+  `increase(homeassistant_state_change_total{domain=~"..."}[$__range])`;
+  `Recently Updated Entities` is a table based on
+  `homeassistant_last_updated_time_seconds`; `Unavailable Entities` remains a
+  table joined with `homeassistant_entity_info`; active lights, switches, and
+  binary sensors are combined into a `Current Active Entities` table using
+  known metrics; `Entities By Area` was renamed `Inventory By Area` so it is not
+  framed as activity.
+- Development smoke: skipped for this follow-up because only the Grafana
+  dashboard JSON and SDD/pr-summary evidence changed. Prior Home Assistant
+  branch development smoke passed for the app and Service/Gateway path; local
+  dashboard JSON and dashboard kustomize renders are the relevant substitute
+  checks.
+- Follow-up checks:
+  - `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`: PASS
+  - `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`: PASS
+  - `python3 tools/architecture/render.py --check`: PASS
+  - Final SDD context validator with `--require-evidence --head`: PASS
+
+## Follow-Up: Post-Merge Branch Rebuild
+
+- Trigger: PR #336 merged the original implementation into `origin/main` as
+  squash commit `e4b1b72`, while the remote
+  `codex/home-assistant-dashboard-activity` branch still carried the old
+  pre-merge implementation history.
+- Action: Fetched origin, preserved the follow-up patch in `.codex/tmp/`, reset
+  local `codex/home-assistant-dashboard-activity` to current `origin/main`
+  (`22171e2` at rebuild time), and reapplied only
+  `fix(home-assistant): use exporter-backed activity tables`.
+- Result: `git log --oneline origin/main..HEAD` contains only the follow-up
+  commit, and `git diff --name-status origin/main..HEAD` contains only:
+  `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`,
+  `specs/home-assistant-dashboard-activity/evidence.md`, and
+  `specs/home-assistant-dashboard-activity/tasks.md`.
+- Development smoke: skipped for the rebuild because the resulting delta is
+  still dashboard JSON plus SDD evidence/tasks only; no Kubernetes app, Service,
+  Gateway, storage, or secret behavior changes were reintroduced.
+- Post-rebuild checks:
+  - `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`: PASS
+  - `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`: PASS
+  - `python3 tools/architecture/render.py --check`: PASS
+  - Final SDD context validator with `--require-evidence --head`: PASS
+
 ## Development Validation
 
 - Profile: manual
@@ -85,6 +141,9 @@
   Grafana JSON-only change; focused render/schema checks are the substitute.
 - Grafana/Mimir live query smoke is blocked by Grafana datasource authorization
   in this session (`401 Unauthorized` for datasource UID `prometheus`).
+- Follow-up live query smoke intentionally not retried; the dashboard query
+  correction relies on Home Assistant exporter metric semantics supplied for
+  Home Assistant 2026.7.1, not Grafana MCP discovery.
 
 ## Final State
 

--- a/specs/home-assistant-dashboard-activity/tasks.md
+++ b/specs/home-assistant-dashboard-activity/tasks.md
@@ -87,6 +87,50 @@ attestation, and delegation token under `.codex/tmp/`
       --head` after commit.
 - [x] T027 [FR-007] Report exact `HEAD` and do not create verifier approval.
 
+## Phase 6: Dashboard Activity Follow-Up
+
+- [x] T028 [FR-004] Replace guessed Home Assistant Activity PromQL in
+      `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
+      with exporter-semantics-based queries using
+      `homeassistant_state_change_total`,
+      `homeassistant_last_updated_time_seconds`,
+      `homeassistant_entity_available`, `homeassistant_entity_info`,
+      `homeassistant_light_brightness_percent`,
+      `homeassistant_switch_state`, and
+      `homeassistant_binary_sensor_state`.
+- [x] T029 [FR-004] Replace zero-prone active entity stat panels in
+      `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`
+      with table panels that show rows only when matching active entity metrics
+      exist.
+- [x] T030 [FR-007] Record the no-development-smoke rationale for this
+      dashboard-only follow-up in
+      `specs/home-assistant-dashboard-activity/evidence.md`.
+- [x] T031 [FR-007] Run follow-up local checks:
+      `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`,
+      `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`, and
+      `python3 tools/architecture/render.py --check`.
+- [x] T032 [FR-007] Commit the focused follow-up with a conventional commit
+      message.
+- [x] T033 [FR-007] Run the SDD context validator with `--require-evidence
+      --head` after the follow-up commit and report exact `HEAD` without
+      creating verifier approval.
+
+## Phase 7: Post-Merge Branch Rebuild
+
+- [x] T034 [FR-007] Rebuild local branch
+      `codex/home-assistant-dashboard-activity` from current `origin/main`
+      after PR #336 merged the original implementation.
+- [x] T035 [FR-007] Reapply only the dashboard activity follow-up delta to
+      avoid duplicating original exporter/config/Service changes already merged
+      through PR #336.
+- [x] T036 [FR-007] Run post-rebuild local checks:
+      `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`,
+      `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`, and
+      `python3 tools/architecture/render.py --check`.
+- [x] T037 [FR-007] Run the SDD context validator with `--require-evidence
+      --head` after the rebuilt follow-up commit and report exact `HEAD`
+      without pushing or creating verifier approval.
+
 ## Dependencies
 
 - Phase 1 must complete before tracked edits.
@@ -96,6 +140,10 @@ attestation, and delegation token under `.codex/tmp/`
 - T013 should run after SDD bootstrap and before dashboard validation.
 - Verification tasks run after implementation edits.
 - Final evidence and PR summary are updated after validation and commit.
+- Phase 6 is a focused follow-up after user feedback and touches only the
+  dashboard JSON plus SDD/pr-summary evidence.
+- Phase 7 rebuilds the branch after PR #336 merged so the follow-up PR contains
+  only the dashboard activity delta relative to current `origin/main`.
 
 ## Parallel Execution Examples
 


### PR DESCRIPTION
## Summary
# Evidence: home-assistant-dashboard-activity

**Branch**: `codex/home-assistant-dashboard-activity`
**Risk Tier**: medium
**Started**: 2026-07-04
**Owner**: implementation-agent-home-assistant-dashboard-activity

## Spec Kit Initialization

- Command: Not rerun; repository Spec Kit scaffolding already present on
  `origin/main`.
- Outcome: Used existing `.specify/` templates and constitution.
- Spec Kit version: Not changed by this implementation.
- Integration: Existing repository integration.
- Fallback: None.

## Workflow Validation

| Command | Result | Notes |
| ------- | ------ | ----- |
| `git remote set-url origin https://github.com/petebeegle/homelab.git && git fetch origin && git checkout -B codex/home-assistant-dashboard-activity origin/main` | PASS | Corrected implementation clone from stale local remote base `1750d60847d94c62bf4d0b5bc89d30cfc4a74cce` to current `origin/main` `c3c4210e349f90b1027b9a21944119303329fe02` before tracked edits. |
| `python3 tools/codex-harness/validate_active_implementation.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
| `python3 tools/codex-harness/validate_implementation_plan.py --plan .codex/tmp/implementation-plan.yaml --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |
| `python3 tools/codex-harness/validate_workflow_attestations.py --kind owner --attestation .codex/tmp/implementation-owner-attestation.yaml --marker .codex/tmp/active-implementation --plan .codex/tmp/implementation-plan.yaml --root "$(pwd)" --branch "$(git branch --show-current)"` | PASS | Completed before tracked edits from corrected `origin/main` base. |

## Local Checks

| Command | Result | Notes |
| ------- | ------ | ----- |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed after SDD bootstrap artifacts were created. |
| `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json` | PASS | Dashboard JSON is valid. |
| `kubectl kustomize kubernetes/apps/home-assistant` | PASS | Production render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
| `kubectl kustomize kubernetes/apps/home-assistant/branch` | PASS | Branch render includes `prometheus:` config and Service scrape annotations for `/api/prometheus`. |
| `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` | PASS | Dashboard ConfigMap render includes Activity panels and no removed Home Assistant dashboard panel titles. |
| `python3 tools/architecture/render.py --check` | PASS | Generated architecture document unchanged. |
| `python3 tools/codex-harness/validate_sdd_context.py --marker .codex/tmp/active-implementation --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Passed against final committed SDD evidence. |

## Follow-Up: Activity Panel Metric Semantics

- Trigger: User feedback that some panels showed `0` and should not depend on
  Grafana MCP query smoke when it is not returning properly.
- Rationale: The follow-up avoids misleading zero-value stat panels and uses
  known Home Assistant 2026.7.1 exporter metric names instead of guessed metric
  shapes or Grafana MCP discovery. With namespace `homeassistant`, the dashboard
  now uses `homeassistant_state_change_total`,
  `homeassistant_last_updated_time_seconds`,
  `homeassistant_entity_available`, `homeassistant_entity_info`,
  `homeassistant_light_brightness_percent`, `homeassistant_switch_state`, and
  `homeassistant_binary_sensor_state`.
- Dashboard changes:
  `Recent Entity Changes` is a table based on
  `increase(homeassistant_state_change_total{domain=~"..."}[$__range])`;
  `Recently Updated Entities` is a table based on
  `homeassistant_last_updated_time_seconds`; `Unavailable Entities` remains a
  table joined with `homeassistant_entity_info`; active lights, switches, and
  binary sensors are combined into a `Current Active Entities` table using
  known metrics; `Entities By Area` was renamed `Inventory By Area` so it is not
  framed as activity.
- Development smoke: skipped for this follow-up because only the Grafana
  dashboard JSON and SDD/pr-summary evidence changed. Prior Home Assistant
  branch development smoke passed for the app and Service/Gateway path; local
  dashboard JSON and dashboard kustomize renders are the relevant substitute
  checks.
- Follow-up checks:
  - `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`: PASS
  - `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`: PASS
  - `python3 tools/architecture/render.py --check`: PASS
  - Final SDD context validator with `--require-evidence --head`: PASS

## Follow-Up: Post-Merge Branch Rebuild

- Trigger: PR #336 merged the original implementation into `origin/main` as
  squash commit `e4b1b72`, while the remote
  `codex/home-assistant-dashboard-activity` branch still carried the old
  pre-merge implementation history.
- Action: Fetched origin, preserved the follow-up patch in `.codex/tmp/`, reset
  local `codex/home-assistant-dashboard-activity` to current `origin/main`
  (`22171e2` at rebuild time), and reapplied only
  `fix(home-assistant): use exporter-backed activity tables`.
- Result: `git log --oneline origin/main..HEAD` contains only the follow-up
  commit, and `git diff --name-status origin/main..HEAD` contains only:
  `kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`,
  `specs/home-assistant-dashboard-activity/evidence.md`, and
  `specs/home-assistant-dashboard-activity/tasks.md`.
- Development smoke: skipped for the rebuild because the resulting delta is
  still dashboard JSON plus SDD evidence/tasks only; no Kubernetes app, Service,
  Gateway, storage, or secret behavior changes were reintroduced.
- Post-rebuild checks:
  - `jq empty kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json`: PASS
  - `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`: PASS
  - `python3 tools/architecture/render.py --check`: PASS
  - Final SDD context validator with `--require-evidence --head`: PASS

## Development Validation

- Profile: manual
- Branch slug: `home-assistant-dashboard-activity`
- Validated commit: `f3259955819ede0664503a2733e63752bbd7c7e1` for the pushed
  development validation commit.
- Report path: N/A; helper output captured in command log.
- Cleanup: PASS; helper deleted
  `kustomization.kustomize.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`,
  waited for namespace `home-assistant-home-assistant-dashboard-activity`
  deletion, and deleted
  `gitrepository.source.toolkit.fluxcd.io/branch-home-assistant-home-assistant-dashboard-activity`.
- Prerequisite preparation:
  `.codex/scripts/prepare_development_smoke_secrets.sh home-assistant-dashboard-activity /workspaces/homelab-ideas/home-assistant-dashboard-activity`
  passed and installed the ignored development Terraform tfvars into the
  implementation clone without logging secret contents.
- Result or exception:
  `python3 tools/development/verify_branch_deploy.py --app home-assistant --branch codex/home-assistant-dashboard-activity --slug home-assistant-dashboard-activity --push`
  PASS. The helper pushed the branch, ran Terraform init/validate/plan,
  applied the branch Flux activation, reconciled GitRepository and
  Kustomization to
  `codex/home-assistant-dashboard-activity@sha1:f3259955819ede0664503a2733e63752bbd7c7e1`,
  confirmed namespace active, waited for the Home Assistant pod Ready
  condition, checked PVC, Service, and HTTPRoute resources, ran the in-cluster
  HTTP probe successfully, and cleaned up the branch Flux resources and
  namespace.



## Changes
- kubernetes/infra/monitoring/grafana/dashboards/home-assistant-dashboard.json
- specs/home-assistant-dashboard-activity/evidence.md
- specs/home-assistant-dashboard-activity/tasks.md

## Commits
- 557bd73 fix(home-assistant): use exporter-backed activity tables

## Verification
- Spec Kit evidence: `specs/home-assistant-dashboard-activity/evidence.md`.
- HEAD: `557bd733d9bee79b53025a27a2a3355042a89142`.
