### PR TITLE
[codex] add access broker foundation

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/pretty-discord-alert-triage-cards"}
+{"feature_directory":"specs/access-broker-foundation"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,6 +147,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
 | `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
 | `kubernetes/infra/network/vpn` | `./namespace.yaml`, `./global-config.yaml`, `./secret.yaml`, `./pvc.yaml`, `./deployment.yaml`, `./service.yaml`, `./vpn-dns.yaml`, `./httproute.yaml` |
+| `kubernetes/apps/access-broker` | `namespace.yaml`, `configmap.yaml`, `secret.yaml`, `pvc.yaml`, `deployment.yaml`, `service.yaml`, `httproute.yaml` |
 | `kubernetes/apps/cloudflare-tunnels` | `namespace.yaml`, `secret.yaml`, `deployment.yaml`, `podmonitor.yaml` |
 | `kubernetes/apps/external` | `namespace.yaml`, `synology.yaml` |
 | `kubernetes/apps/foundry-bluegreen-fixture` | `namespace.yaml`, `pvc-blue.yaml`, `pvc-green.yaml`, `deployment-blue.yaml`, `deployment-green.yaml`, `service-blue.yaml`, `service-green.yaml`, `httproute-green-preview.yaml` |
@@ -173,6 +174,7 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
+| `HTTPRoute` | `access-broker/access-broker-public` | `onboard.${cluster_domain}` | `gateway/public/http-gateway` | `access-broker:80` |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.dev.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |
@@ -204,6 +206,7 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- | --- | --- |
 | HelmRelease values | `jellyfin-${branch_slug}/jellyfin-${branch_slug}` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/branch/jellyfin.yaml` |
 | HelmRelease values | `valheim/valheim-server` | `nfs-csi-storage` | `kubernetes/apps/valheim/app.yaml` |
+| PVC | `access-broker/access-broker-data` | `nfs-csi-storage` | `kubernetes/apps/access-broker/pvc.yaml` |
 | PVC | `foundry-bluegreen-fixture/foundry-fixture-blue` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-blue.yaml` |
 | PVC | `foundry-bluegreen-fixture/foundry-fixture-green` | `nfs-csi-storage` | `kubernetes/apps/foundry-bluegreen-fixture/pvc-green.yaml` |
 | PVC | `foundryvtt/foundryvtt-data-pvc` | `nfs-csi-storage` | `kubernetes/apps/foundryvtt/pvc.yaml` |
@@ -223,6 +226,7 @@ This lists secret manifest presence only. Secret values are not rendered.
 
 | Component | Secret | SOPS encrypted | Path |
 | --- | --- | --- | --- |
+| `access-broker` | `access-broker/access-broker-secret` | `yes` | `kubernetes/apps/access-broker/secret.yaml` |
 | `authentik` | `authentik/authentik-secrets` | `yes` | `kubernetes/infra/authentik/secret.yaml` |
 | `cloudflare-tunnels` | `cloudflare/tunnel-credentials` | `yes` | `kubernetes/apps/cloudflare-tunnels/secret.yaml` |
 | `controllers/cert-manager` | `cert-manager/cloudflare-api-token` | `yes` | `kubernetes/infra/controllers/cert-manager/secret.yaml` |

--- a/kubernetes/apps/access-broker/configmap.yaml
+++ b/kubernetes/apps/access-broker/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: access-broker-config
+  namespace: access-broker
+data:
+  HTTP_ADDR: ":8080"
+  PUBLIC_BASE_URL: "https://onboard.${cluster_domain}"
+  AUTHENTIK_BASE_URL: "http://authentik-server.authentik.svc.cluster.local"
+  WGEASY_BASE_URL: "http://wireguard-http.wireguard.svc.cluster.local:51821"
+  DATABASE_PATH: "/data/homelab-access.db"
+  DOWNLOAD_TOKEN_TTL: "15m"

--- a/kubernetes/apps/access-broker/deployment.yaml
+++ b/kubernetes/apps/access-broker/deployment.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: access-broker
+  namespace: access-broker
+  labels:
+    app.kubernetes.io/name: access-broker
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: access-broker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: access-broker
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: /metrics
+    spec:
+      securityContext:
+        fsGroup: 65532
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: access-broker
+          image: ghcr.io/petebeegle/homelab-access:main
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: access-broker-config
+            - secretRef:
+                name: access-broker-secret
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: access-broker-data

--- a/kubernetes/apps/access-broker/httproute.yaml
+++ b/kubernetes/apps/access-broker/httproute.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: access-broker-public
+  namespace: access-broker
+spec:
+  parentRefs:
+    - name: public
+      namespace: gateway
+      sectionName: http-gateway
+  hostnames:
+    - onboard.${cluster_domain}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /download/
+        - path:
+            type: Exact
+            value: /discord/interactions
+      backendRefs:
+        - name: access-broker
+          port: 80

--- a/kubernetes/apps/access-broker/kustomization.yaml
+++ b/kubernetes/apps/access-broker/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/kubernetes/apps/access-broker/namespace.yaml
+++ b/kubernetes/apps/access-broker/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: access-broker
+  labels:
+    app.kubernetes.io/name: access-broker
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kubernetes/apps/access-broker/pvc.yaml
+++ b/kubernetes/apps/access-broker/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: access-broker-data
+  namespace: access-broker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-csi-storage
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/access-broker/secret.yaml
+++ b/kubernetes/apps/access-broker/secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: access-broker-secret
+    namespace: access-broker
+type: Opaque
+stringData:
+    DISCORD_APP_ID: ENC[AES256_GCM,data:Z5Bqs44Jw+I8WQ==,iv:SBdHqQPR+n8a8zWPr0oPD3gZLRLNqSFG7spNM56dZW4=,tag:BGj3LXcIaE0lmHWkPrPXQw==,type:str]
+    DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:lzBcay0j+tvp9A==,iv:bXTSy3+ZL7yi+qKJdV8niw9xc2ZtuJQK11Gzim2pbIM=,tag:nihfdGnt002ePekc53ZYmA==,type:str]
+    DISCORD_BOT_TOKEN: ENC[AES256_GCM,data:HE0EGpBekN+uCw==,iv:CC2Evm3s254hqavW3cL/LDlNisECJWxbCPYzED0BlIA=,tag:ZImRuWF6yrl22YX/SXjFeA==,type:str]
+    AUTHENTIK_TOKEN: ENC[AES256_GCM,data:TQWlcS9j2X9Q2Q==,iv:T0onIHePCxwFJrBjEmc8GYii+hX05dP4wKxsuPDlMac=,tag:ar7auHk1JQfiBEZeTXtgIQ==,type:str]
+    WGEASY_PASSWORD: ENC[AES256_GCM,data:6pweEfyCFehm7w==,iv:Cy+cOF7f+ukF4h3/mQRfg8iCI6vZzk92RjGMy2dKRXc=,tag:2t7QNk1J2qu1XMPsMtZtgQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwL3JScDIxcnArbndoU1ho
+            ZlVyZHdKVS9rN0dzWWR6ZkkyWkZCMmQ5OGw0CjdaWlpZellpRUhlQ3FYSy9nOTVS
+            ZmIzRWlIdkZBR2VWVS9XdEVLcXhMNkUKLS0tIHNnQm8zNmJFbTI5SGwvaW1mb3NP
+            Mk5FdnVBckZ3UnRoeUJtajhaZVRoWXcK/JbAnJtKbagRZPSoT1OylkaR3avsT9ol
+            Yc3g1sTZjoYf6BZVA6l4QDxJGVJF+DYtdziW5Q69rTcer+0az57Qsg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-04T18:51:22Z"
+    mac: ENC[AES256_GCM,data:CKUT58tKfcRGVh68Qnm8hp4xi9oOzriPSwkkMyBh+Qs1qGRHKFw1oBQzIGhoumBL4QwQDROgezRoseaID6X5xy5W25OVuvEg7voVUEj8qnx05/AE/JcnzEM1vhxf7zmv6wNTMaAeHdfECSEIra6H1W0/ETuuH/2DE9Q820qfqmo=,iv:r6SWR3PlhEc1u0nAcSZnOE/kbKMo5kY5LBbycnQtIn8=,tag:zmRCAF1B9pdhJAZaVJNJeA==,type:str]
+    version: 3.13.0

--- a/kubernetes/apps/access-broker/service.yaml
+++ b/kubernetes/apps/access-broker/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: access-broker
+  namespace: access-broker
+  labels:
+    app.kubernetes.io/name: access-broker
+spec:
+  selector:
+    app.kubernetes.io/name: access-broker
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http

--- a/specs/access-broker-foundation/evidence.md
+++ b/specs/access-broker-foundation/evidence.md
@@ -1,0 +1,88 @@
+# Evidence: access-broker-foundation
+
+**Branch**: `codex/access-broker-foundation`
+**Risk Tier**: high
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: manual artifact creation from repo templates after user requested implementation.
+- Outcome: PASS
+- Spec Kit version: not changed
+- Integration: existing Codex integration
+- Fallback: default `/workspaces/homelab-worktrees` path was unavailable due to permissions; used `/home/vscode/homelab-worktrees/access-broker-foundation`.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed with no output on branch `codex/access-broker-foundation`. |
+
+## App Repository Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `docker run --rm -v "$PWD":/src -w /src golang:1.23-alpine go test ./...` | PASS | Ran in `/home/vscode/homelab-access`; host Go is unavailable, so validation used the Go container. |
+| `docker build -t homelab-access:foundation .` | PASS | Built the foundation image successfully in `/home/vscode/homelab-access`. |
+| `git commit -m "feat: bootstrap homelab access broker"` | PASS | App repo branch `codex/access-broker-foundation` committed as `252c7bf68bc15ba97430836e80808f1ef291600f` after initializing app repo `main` and rebasing the feature branch. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/apps/access-broker` | PASS | Rendered Namespace, ConfigMap, SOPS-encrypted Secret, Service, PVC, Deployment, and HTTPRoute. |
+| `python3 tools/architecture/render.py --check` | PASS | Initial check reported stale generated docs; `python3 tools/architecture/render.py --write` refreshed `docs/architecture.md`; rerun passed. |
+| `rg -n "replace-me\|DISCORD_BOT_TOKEN: [^E]\|AUTHENTIK_TOKEN: [^E]\|WGEASY_PASSWORD: [^E]" kubernetes/apps/access-broker/secret.yaml specs/access-broker-foundation kubernetes/apps/access-broker` | PASS | No plaintext placeholder or unencrypted secret values found. |
+| `kubectl kustomize kubernetes/apps/access-broker >/tmp/access-broker-render.yaml && python3 - <<'PY' ... PY` | PASS | Confirmed HTTPRoute present, SOPS encrypted secret present, PVC uses `nfs-csi-storage`, `fsGroup: 65532` is set, and rendered package contains no `kind: Ingress`. |
+| `rg -n "access-broker\|kind: Ingress\|apiVersion: networking.k8s.io/v1" kubernetes/clusters kubernetes/apps/access-broker kubernetes/apps/cloudflare-tunnels` | PASS | `access-broker` appears only in the inactive app package; no cluster activation reference or Cloudflare rule was added. Existing Flux NetworkPolicy API strings are unrelated. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| access-broker live deployment | none | SKIP | The app package is intentionally inactive; no Flux Kustomization or Cloudflare Tunnel rule is activated in this foundation PR. |
+
+## Deployment State
+
+- Source fetched SHA: N/A; inactive package only.
+- Target applied SHA: N/A; inactive package only.
+- Live resource spec checked: N/A; inactive package only.
+- Gateway/listener/DNS/certificate checked: N/A; route contract renders only.
+- Exact user-facing URL result: N/A; no live route.
+
+## Development Validation
+
+- Profile: none
+- Branch slug: access-broker-foundation
+- HEAD: pending
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development smoke skipped because this PR does not activate Flux, Cloudflare Tunnel, or a live route. Substitute checks are app tests/build and Kubernetes render checks.
+
+## Documentation Impact
+
+- Updated: SDD artifacts under `specs/access-broker-foundation/`.
+- Generated docs: `docs/architecture.md` refreshed because the generated inventory includes the inactive app package.
+- No-docs rationale: Runtime operator runbook is deferred until live Discord/Auth/wg-easy behavior exists.
+
+## SDD Conformance
+
+- Local sources checked: `docs/runbooks/spec-driven-development.md`, `docs/runbooks/implementation-workflow.md`, binding ADRs listed in spec.
+- Upstream Spec Kit sources checked: N/A; no Spec Kit template or workflow changes.
+- Spec -> Plan -> Tasks -> Implement alignment: PASS. The spec defines the foundation scope, the plan records the inactive deployment strategy, tasks trace to requirements, and evidence records checks and exceptions.
+- Artifact updates after implementation: PASS. Tasks and evidence were updated after implementation and validation.
+
+## Exceptions And Follow-Ups
+
+- Follow-up: commit and push `/home/vscode/homelab-access` to initialize `https://github.com/petebeegle/homelab-access`.
+- Follow-up: implement Discord interactions in `homelab-access`.
+- Follow-up: implement Authentik invite/group client in `homelab-access`.
+- Follow-up: implement wg-easy v15.3.0 adapter in `homelab-access`.
+- Follow-up: activate Cloudflare Tunnel and Flux only after real credentials and one-time download implementation exist.
+
+## Final State
+
+- Final branch: codex/access-broker-foundation
+- Final HEAD: not recorded in committed evidence to avoid a self-referential amend loop; verify with `git rev-parse HEAD` during handoff.
+- Commit: local commit created; verify with `git rev-parse HEAD` during handoff.
+- Pull requests: `https://github.com/petebeegle/homelab-access/pull/1` and `https://github.com/petebeegle/homelab/pull/346`.

--- a/specs/access-broker-foundation/plan.md
+++ b/specs/access-broker-foundation/plan.md
@@ -1,0 +1,134 @@
+# Implementation Plan: access-broker-foundation
+
+**Branch**: `codex/access-broker-foundation` | **Date**: 2026-07-04 | **Spec**:
+`specs/access-broker-foundation/spec.md`
+
+**Input**: Feature specification from `specs/access-broker-foundation/spec.md`
+
+## Summary
+
+Bootstrap the cross-repo foundation for the access broker. `homelab-access`
+gets a Go service, tests, Dockerfile, and CI. This repo gets an inactive
+Kubernetes app package that defines the deployment, storage, secret, service,
+and public route contract without activating Flux or Cloudflare Tunnel routing.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Go app, Kubernetes, Gateway API, Flux preparation, storage,
+secrets, SDD artifacts
+**Dependencies**: Docker, Go container image, kubectl/kustomize, SOPS, Python 3
+**Storage**: `nfs-csi-storage` PVC for future broker state
+**Ingress**: Gateway API `HTTPRoute` to `gateway/public`, section `http-gateway`
+**Secrets**: SOPS-encrypted `kubernetes/apps/access-broker/secret.yaml`
+**Smoke Strategy**: none for live cluster because this foundation is inactive;
+substitute checks are Go tests/build and Kubernetes render checks
+**Fanout Targets**: app scaffold, Kubernetes package, SDD/evidence, render/build
+validation
+**Development Validation**: none with reason: no Flux activation or live route
+is introduced in this PR
+**Post-Implementation SDD Conformance**: local workflow docs reviewed
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/access-broker-foundation`; fallback worktree mode is
+      intentional and recorded.
+- [x] Documentation impact identified; SDD artifacts record activation deferral.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/access-broker-foundation/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/access-broker/
+.specify/feature.json
+specs/access-broker-foundation/
+```
+
+External app repository changes:
+
+```text
+/home/vscode/homelab-access/
+├── .github/workflows/ci.yml
+├── Dockerfile
+├── cmd/homelab-access/main.go
+├── internal/config/config.go
+├── internal/server/server.go
+├── internal/server/server_test.go
+├── go.mod
+└── README.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add handler tests for the app foundation before future
+broker integrations. Kubernetes changes are validated with render checks and
+secret encryption checks.
+
+**Local checks**:
+
+- `docker run --rm -v "$PWD":/src -w /src golang:1.23-alpine go test ./...`
+- `docker build -t homelab-access:foundation .`
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+
+**Development smoke**: None. This implementation does not activate the app in
+development or production and does not create a live route.
+
+**Fanout plan**: App scaffold and Kubernetes package are independent; SDD and
+evidence can be updated after both streams finish. Validation results are
+consolidated into `specs/access-broker-foundation/evidence.md`.
+
+**Evidence destination**: `specs/access-broker-foundation/evidence.md`.
+
+## Documentation Impact
+
+No generated architecture update is expected because the package is inactive and
+not referenced by cluster Flux entrypoints. The SDD artifacts are the durable
+documentation for this foundation slice.
+
+## Implementation Steps
+
+1. Bootstrap `homelab-access` with Go service, tests, Dockerfile, GitHub
+   Actions, and README.
+2. Add inactive `kubernetes/apps/access-broker` package with encrypted secret
+   shape and public-route contract.
+3. Run app tests/build and homelab render/workflow checks.
+4. Record activation deferral, fallback worktree path, and verification results.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Placeholder deployment is accidentally activated | Do not add cluster-layer Flux Kustomization references in this PR |
+| Secret placeholders leak or become confused with real values | Encrypt `secret.yaml` with SOPS and document activation deferral |
+| wg-easy API behavior changes before integration work | Defer adapter implementation to a tested follow-up pinned to deployed wg-easy |
+| Public route exists before one-time token implementation | Define route contract only; defer Cloudflare Tunnel and Flux activation |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/access-broker-foundation/spec.md
+++ b/specs/access-broker-foundation/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: access-broker-foundation
+
+**Feature Branch**: `codex/access-broker-foundation`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: high
+**Input**: User description: "implement the long-term Discord/Auth/VPN broker plan using https://github.com/petebeegle/homelab-access"
+
+## Summary
+
+Create the foundation for a Discord-driven homelab access broker. The broker
+application source lives in `petebeegle/homelab-access`; this repository owns
+the GitOps deployment contract and safe activation path.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/add-secret.md`
+- `docs/decisions/flux-gitops-source-of-truth.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/sops-age-secrets.md`
+- `docs/decisions/synology-nfs-storage.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+
+## Scope
+
+### In Scope
+
+- Bootstrap `homelab-access` as a Go service with health, readiness, metrics,
+  container build, and CI.
+- Add an inactive Kubernetes app package for `access-broker` in this repo.
+- Define encrypted placeholder secret shape, config, PVC, Deployment, Service,
+  and public HTTPRoute contract for future activation.
+- Record validation evidence and exceptions.
+
+### Out Of Scope
+
+- Live Discord command handling.
+- Authentik user/invite provisioning.
+- wg-easy peer provisioning.
+- Cloudflare Tunnel activation for `onboard.${cluster_domain}`.
+- Production or development Flux activation.
+
+## User Scenarios & Testing
+
+### User Story 1 - App Foundation Exists (Priority: P1)
+
+As an operator, I can review and build a minimal `homelab-access` service before
+the access workflow integrations are added.
+
+**Why this priority**: The broker needs a stable app/image contract before this
+repo can safely deploy it.
+
+**Independent Test**: Run Go tests in a Go container and build the container
+image from the `homelab-access` checkout.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app repo scaffold, **When** tests run, **Then** health,
+   readiness, and metrics handlers pass.
+2. **Given** the app repo scaffold, **When** the container builds, **Then** a
+   runnable image is produced.
+
+### User Story 2 - GitOps Deployment Contract Exists (Priority: P2)
+
+As an operator, I can render the future `access-broker` Kubernetes package
+without activating it in a cluster.
+
+**Why this priority**: Deployment shape, secret names, storage, and route shape
+can be reviewed before real credentials or public exposure exist.
+
+**Independent Test**: Run `kubectl kustomize kubernetes/apps/access-broker`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the homelab repo desired state, **When** the access-broker package
+   is rendered, **Then** it contains a Deployment, Service, PVC, encrypted
+   Secret, and Gateway API HTTPRoute.
+
+## Requirements
+
+- **FR-001**: The app repository MUST contain a Go service scaffold with
+  `/healthz`, `/readyz`, `/metrics`, `/discord/interactions`, and
+  `/download/{token}` endpoints.
+- **FR-002**: The app repository MUST include container build and GitHub Actions
+  CI definitions.
+- **FR-003**: The homelab repository MUST add an inactive `access-broker`
+  Kubernetes app package.
+- **FR-004**: The package MUST use Gateway API `HTTPRoute` and MUST NOT add
+  Kubernetes `Ingress`.
+- **FR-005**: The package MUST use StorageClass `nfs-csi-storage` for broker
+  persistence.
+- **FR-006**: Secret material shape MUST be committed only in SOPS-encrypted
+  `secret.yaml`.
+- **FR-007**: Evidence MUST record app repo checks, homelab render checks,
+  workflow exceptions, and activation deferrals.
+
+## Risk And Validation Expectations
+
+This is high risk because it establishes authentication, VPN, secret, public
+route, and future operational automation surfaces. This foundation does not
+activate the service, so live development smoke is deferred; local app tests,
+container build, render checks, SOPS checks, and architecture check are required.
+
+## Success Criteria
+
+- **SC-001**: `docker run --rm -v "$PWD":/src -w /src golang:1.23-alpine go test ./...`
+  passes in the `homelab-access` checkout.
+- **SC-002**: `docker build -t homelab-access:foundation .` passes in the
+  `homelab-access` checkout.
+- **SC-003**: `kubectl kustomize kubernetes/apps/access-broker` passes in this
+  repo.
+- **SC-004**: The `access-broker` app is not included in production or
+  development Flux Kustomization activation lists.
+
+## Assumptions
+
+- `homelab-access` owns application source and image publishing.
+- This repo owns deployment manifests, SOPS secrets, routing, Flux activation,
+  and operational documentation.
+- Runtime provisioning behavior lands in follow-up PRs.
+
+## Open Questions
+
+- None

--- a/specs/access-broker-foundation/tasks.md
+++ b/specs/access-broker-foundation/tasks.md
@@ -1,0 +1,50 @@
+# Tasks: access-broker-foundation
+
+**Input**: `specs/access-broker-foundation/spec.md` and
+`specs/access-broker-foundation/plan.md`
+**Risk Tier**: high
+**Prerequisites**: Branch `codex/access-broker-foundation` and matching
+`specs/access-broker-foundation/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+## Phase 1: Spec And Plan
+
+- [x] T001 [FR-SPEC] Create `specs/access-broker-foundation/spec.md`.
+- [x] T002 [FR-PLAN] Create `specs/access-broker-foundation/plan.md`,
+      including tiered TDD and development validation expectations.
+- [x] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations in `specs/access-broker-foundation/evidence.md`.
+
+## Phase 2: App Repository Foundation
+
+- [x] T004 [P] [FR-001] Create Go service scaffold in `/home/vscode/homelab-access`.
+- [x] T005 [P] [FR-002] Add Dockerfile, `.dockerignore`, `.gitignore`, CI, and
+      README in `/home/vscode/homelab-access`.
+
+## Phase 3: Homelab GitOps Foundation
+
+- [x] T006 [P] [FR-003,FR-005] Add inactive Kubernetes app package under
+      `kubernetes/apps/access-broker/`.
+- [x] T007 [P] [FR-006] Add and SOPS-encrypt
+      `kubernetes/apps/access-broker/secret.yaml`.
+- [x] T008 [FR-004] Confirm no production or development Flux activation and no
+      Kubernetes `Ingress` resources were added.
+- [x] T009 [FR-IMPL] Re-check constitution gates after implementation edits.
+
+## Phase 4: Verification
+
+- [x] T010 [FR-TEST] Run app Go tests in the Go container.
+- [x] T011 [FR-TEST] Run app Docker build.
+- [x] T012 [FR-TEST] Run `kubectl kustomize kubernetes/apps/access-broker`.
+- [x] T013 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T014 [FR-TEST] Run workflow/SDD context validator.
+- [x] T015 [FR-SMOKE] Record no-live-smoke exception because the app is inactive.
+- [x] T016 [FR-EVIDENCE] Record command outcomes, SHAs, skipped checks,
+      exceptions, and final states in `specs/access-broker-foundation/evidence.md`.
+
+## Phase 5: Commit And PR
+
+- [x] T017 [FR-PR] Commit homelab changes with a conventional commit message.
+- [x] T018 [FR-PR] Push branch `codex/access-broker-foundation` and open PRs for
+      both repositories when credentials are available.


### PR DESCRIPTION
## Summary

Adds the inactive GitOps deployment foundation for the future `homelab-access` broker.

## Changes

- Adds `kubernetes/apps/access-broker` with Namespace, ConfigMap, SOPS-encrypted Secret shape, PVC, Deployment, Service, and Gateway API HTTPRoute.
- Leaves the app inactive: no production/development Flux Kustomization reference and no Cloudflare Tunnel ingress rule are added.
- Refreshes generated architecture docs and adds Spec Kit artifacts under `specs/access-broker-foundation/`.

## Validation

- `docker run --rm -v "$PWD":/src -w /src golang:1.23-alpine go test ./...` in `/home/vscode/homelab-access`
- `docker build -t homelab-access:foundation .` in `/home/vscode/homelab-access`
- `kubectl kustomize kubernetes/apps/access-broker`
- `python3 tools/architecture/render.py --check`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- Commit hooks passed, including `yamllint`, `k8svalidate`, and generated architecture check.

## Related

App foundation PR: https://github.com/petebeegle/homelab-access/pull/1

## Notes

This PR deliberately does not activate the service in Flux or expose it through Cloudflare. Activation should wait for real broker behavior and credentials.
