### PR TITLE
[codex] Fix Alloy CNPG scrape targets

### DIFF
--- a/kubernetes/infra/monitoring/alloy/config/config.alloy
+++ b/kubernetes/infra/monitoring/alloy/config/config.alloy
@@ -55,6 +55,15 @@ discovery.relabel "service" {
 		action        = "keep"
 	}
 
+	// CloudNativePG metrics are exposed on PostgreSQL pods. Its generated
+	// Services expose database ports, so inherited metrics annotations create
+	// unreachable service scrape targets.
+	rule {
+		source_labels = ["__meta_kubernetes_service_label_cnpg_io_cluster"]
+		regex         = ".+"
+		action        = "drop"
+	}
+
 	// Use custom port from annotation if specified
 	rule {
 		source_labels = ["__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"]

--- a/specs/fix-immich-cnpg-scrape/evidence.md
+++ b/specs/fix-immich-cnpg-scrape/evidence.md
@@ -1,0 +1,96 @@
+# Evidence: fix-immich-cnpg-scrape
+
+**Branch**: `codex/fix-immich-cnpg-scrape`
+**Risk Tier**: high
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: manual artifact creation from `.specify/templates/*`
+- Outcome: PASS
+- Spec Kit version: not invoked; local templates already present
+- Integration: codex repository templates
+- Fallback: `/workspaces/homelab-worktrees` was not writable, so the worktree
+  was created at `/workspaces/homelab-ideas/fix-immich-cnpg-scrape`.
+
+## Alert Triage Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| Grafana MCP alert/query APIs | FAIL | API returned `401 Unauthorized`; switched to production kubeconfig and direct Mimir query. |
+| `kubectl --kubeconfig=$HOME/.kube/homelab-production.config -n alloy get ds,pods -o wide` | PASS | Alloy DaemonSet desired/current/ready all `5`; all Alloy pods ready. |
+| Direct Mimir query: `up{job=~"prometheus.scrape.*|kubelet-.*"} == 0` with tenant `anonymous` | PASS | Active down targets were `immich-postgres-r`, `immich-postgres-ro`, and `immich-postgres-rw` on `:9187`. |
+| Direct Mimir query: `up{namespace="immich"}` with tenant `anonymous` | PASS | `prometheus.scrape.pods` target for `immich-postgres-1` on `:9187` was up; the three generated PostgreSQL service targets were down. |
+| `kubectl --kubeconfig=$HOME/.kube/homelab-production.config -n immich get svc,endpoints,endpointslices` | PASS | PostgreSQL services expose only `5432`; generated services do not expose `9187`. |
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD artifacts present on branch `codex/fix-immich-cnpg-scrape`. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/infra/monitoring/alloy` | PASS | Rendered Alloy ConfigMap includes `__meta_kubernetes_service_label_cnpg_io_cluster` drop rule. |
+| `helm template immich oci://ghcr.io/immich-app/immich-charts/immich --version 0.13.1 --namespace immich -f kubernetes/apps/immich/base/values.yaml` | PASS | Immich server metrics service still renders `:8081`; chart templating succeeds. |
+| `kubectl kustomize kubernetes/apps/immich` | PASS | CloudNativePG `inheritedMetadata` still annotates PostgreSQL resources for pod metrics on `9187`. |
+| `kubectl kustomize kubernetes/clusters/production` | PASS | Production Flux entrypoint renders successfully; nested component content is validated by the Alloy render above. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| Production Mimir `up{namespace="immich"}` | direct query through read-only port-forward | PASS | Before fix, pod target was up and generated service targets were down. |
+
+## Deployment State
+
+- Source fetched SHA: pending PR merge
+- Target applied SHA: pending PR merge
+- Live resource spec checked: pre-fix production service and pod specs checked
+- Gateway/listener/DNS/certificate checked: N/A
+- Exact user-facing URL result: N/A
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: pending
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development validation is not representative because the
+  default development cluster does not run the production monitoring stack and
+  cannot exercise the Alloy/Mimir target set. Substitute checks are local
+  renders plus read-only production metrics/resource verification.
+
+## Documentation Impact
+
+- Updated: None
+- Generated docs: Not required; architecture activation paths unchanged
+- No-docs rationale: Narrow Alloy service discovery fix; existing observability
+  topology remains accurate.
+
+## SDD Conformance
+
+- Local sources checked: `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`
+- Upstream Spec Kit sources checked: N/A
+- Spec -> Plan -> Tasks -> Implement alignment: Artifacts created before the
+  manifest edit.
+- Artifact updates after implementation: completed with implementation path,
+  validation results, and exceptions.
+
+## Exceptions And Follow-Ups
+
+- Worktree fallback path used because `/workspaces/homelab-worktrees` was not
+  writable.
+- After merge, verify Flux applies the change and the Mimir query
+  `up{namespace="immich"} == 0` returns no Immich PostgreSQL service targets.
+
+## Final State
+
+- Final branch: `codex/fix-immich-cnpg-scrape`
+- Final HEAD: recorded in final handoff after the last evidence amend
+- Commit: `fix(alloy): drop cnpg service scrape targets`

--- a/specs/fix-immich-cnpg-scrape/plan.md
+++ b/specs/fix-immich-cnpg-scrape/plan.md
@@ -1,0 +1,116 @@
+# Implementation Plan: fix-immich-cnpg-scrape
+
+**Branch**: `codex/fix-immich-cnpg-scrape` | **Date**: 2026-07-04 | **Spec**:
+`specs/fix-immich-cnpg-scrape/spec.md`
+
+**Input**: Feature specification from
+`specs/fix-immich-cnpg-scrape/spec.md`
+
+## Summary
+
+Add an Alloy service discovery relabel drop for CloudNativePG-generated
+Services so inherited `9187` annotations do not create unreachable service
+scrape targets. Keep the existing PostgreSQL pod metrics annotations and rely on
+Alloy pod discovery for database metrics.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Kubernetes, Flux, observability, shared Alloy config
+**Dependencies**: kubectl, helm, curl, jq
+**Storage**: Existing Immich PostgreSQL PVC unchanged
+**Ingress**: N/A
+**Secrets**: No secret changes
+**Smoke Strategy**: live read-only production metrics query plus local Alloy and
+production render checks; no user-facing route change
+**Fanout Targets**: N/A
+**Development Validation**: none with exception; development does not run the
+production monitoring stack by default and the active target set is
+production-specific
+**Post-Implementation SDD Conformance**: local runbooks only
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/fix-immich-cnpg-scrape`; fallback sibling worktree mode
+      is intentional because `/workspaces/homelab-worktrees` is not writable.
+- [x] Documentation impact identified; no docs update required for this narrow
+      app manifest correction.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/fix-immich-cnpg-scrape/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/infra/monitoring/alloy/config/config.alloy
+specs/fix-immich-cnpg-scrape/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No executable code test seam. Use focused manifest render
+checks and live read-only production evidence.
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/infra/monitoring/alloy`
+- `helm template immich oci://ghcr.io/immich-app/immich-charts/immich --version 0.13.1 --namespace immich -f kubernetes/apps/immich/base/values.yaml`
+- `kubectl kustomize kubernetes/clusters/production`
+
+**Development smoke**: none with exception; development does not run the
+production Immich/CNPG monitoring target set by default.
+
+**Automated smoke preference**: No user-facing route behavior changes. Use live
+metrics query against production Mimir as the operational smoke signal.
+
+**Completion evidence**: Record live target query, render outcomes, final branch
+state, and deployment follow-up needed after PR merge.
+
+**Fanout plan**: N/A.
+
+**Evidence destination**:
+`specs/fix-immich-cnpg-scrape/evidence.md`.
+
+## Documentation Impact
+
+No runbook or architecture change required. The generated architecture maps
+component activation and is not affected by this app manifest metadata change.
+
+## Implementation Steps
+
+1. Add a CloudNativePG service drop rule to Alloy service discovery.
+2. Render Alloy and production manifests to confirm valid desired state.
+3. Record live read-only query evidence and validation outcomes.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| PostgreSQL metrics disappear | Live evidence shows pod discovery already scrapes the PostgreSQL pod successfully; only service annotations are removed. |
+| Alert remains until Flux applies the change | Record post-merge verification steps for Flux reconciliation and Mimir query. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/fix-immich-cnpg-scrape/spec.md
+++ b/specs/fix-immich-cnpg-scrape/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: fix-immich-cnpg-scrape
+
+**Feature Branch**: `codex/fix-immich-cnpg-scrape`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: high
+**Input**: User description: "ive got an alloy scrape error alert"
+
+## Summary
+
+Stop Alloy from scraping CloudNativePG-generated PostgreSQL Services that do not
+expose metrics, while preserving the working pod-level PostgreSQL metrics
+scrape.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/observability-scrape-topology.md`
+- `docs/decisions/observability-stack.md`
+
+## Scope
+
+### In Scope
+
+- Drop CloudNativePG-generated Services from Alloy service metrics discovery.
+- Keep pod-level metrics discovery for the CloudNativePG PostgreSQL instance.
+- Record live read-only alert triage evidence and local render checks.
+
+### Out Of Scope
+
+- Changing the shared Alloy scrape topology.
+- Changing Immich application routing, storage, or authentication.
+- Mutating production resources outside Flux-managed desired state.
+
+## User Scenarios & Testing
+
+### User Story 1 - Clear Duplicate Postgres Service Targets (Priority: P1)
+
+Operators need Alloy scrape alerts to identify real scrape failures, not
+CloudNativePG service objects that do not expose the annotated metrics port.
+
+**Why this priority**: This directly addresses the active alert.
+
+**Independent Test**: Render the Immich manifests and confirm the CloudNativePG
+Cluster no longer applies Prometheus annotations through inherited metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** CloudNativePG generates PostgreSQL Services, **When** Alloy
+   evaluates service metrics discovery, **Then** services labeled with a
+   CloudNativePG cluster are dropped from service scraping.
+
+### User Story 2 - Preserve PostgreSQL Pod Metrics (Priority: P2)
+
+Operators still need Immich PostgreSQL metrics available through Alloy.
+
+**Why this priority**: Removing duplicate service targets must not remove useful
+database telemetry.
+
+**Independent Test**: Live read-only production query shows the PostgreSQL pod
+target is currently up on `:9187`, and local review confirms the pod exposes the
+metrics container port.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Immich PostgreSQL pod exposes port `9187`, **When** Alloy
+   scrapes pod targets, **Then** the PostgreSQL pod scrape remains available.
+
+## Requirements
+
+- **FR-001**: The implementation MUST drop CloudNativePG-generated Services
+  from Alloy service metrics discovery.
+- **FR-002**: The implementation MUST preserve GitOps as the source of truth and
+  avoid durable live-cluster mutations.
+- **FR-003**: The implementation MUST preserve CloudNativePG pod metrics
+  scraping for PostgreSQL pods that expose port `9187`.
+- **FR-004**: Evidence MUST include the live read-only alert query result, local
+  render validation, and any development validation exception.
+
+## Risk And Validation Expectations
+
+**High**: Include focused render checks and live read-only production
+verification because the change touches shared Alloy discovery behavior.
+Development validation is not representative because the active alert is from
+the production monitoring stack and development does not run that stack by
+default; record the exception and substitute checks.
+
+## Success Criteria
+
+- **SC-001**: Rendered Alloy config includes a service discovery drop rule for
+  services with CloudNativePG cluster labels.
+- **SC-002**: Production read-only query identifies only the known Immich
+  PostgreSQL service targets as the active Alloy scrape failures before the fix.
+- **SC-003**: Local validation commands complete successfully.
+
+## Assumptions
+
+- CloudNativePG `inheritedMetadata` is applied to generated Services and pods,
+  which is why the service targets exist even though only the pod exposes the
+  metrics port.
+- Pod-level Alloy discovery remains sufficient for Immich PostgreSQL metrics.
+
+## Open Questions
+
+- None.

--- a/specs/fix-immich-cnpg-scrape/tasks.md
+++ b/specs/fix-immich-cnpg-scrape/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: fix-immich-cnpg-scrape
+
+**Input**: `specs/fix-immich-cnpg-scrape/spec.md` and
+`specs/fix-immich-cnpg-scrape/plan.md`
+**Risk Tier**: high
+**Prerequisites**: Branch `codex/fix-immich-cnpg-scrape` and matching
+`specs/fix-immich-cnpg-scrape/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel or fan out to a helper lane because it touches
+  different files or performs read-only validation and has no dependency on
+  another incomplete task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+
+## Phase 1: Spec And Plan
+
+- [x] T001 [FR-SPEC] Create `specs/fix-immich-cnpg-scrape/spec.md`.
+- [x] T002 [FR-PLAN] Create `specs/fix-immich-cnpg-scrape/plan.md`,
+      including tiered TDD and development validation expectations.
+- [x] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations.
+
+## Phase 2: Implementation
+
+- [x] T004 [FR-001] Drop CloudNativePG-generated Services from Alloy service
+      discovery in `kubernetes/infra/monitoring/alloy/config/config.alloy`.
+- [x] T005 [FR-002] Re-check constitution gates after implementation edits.
+
+## Phase 3: Verification
+
+- [x] T006 [P] [FR-004] Run `kubectl kustomize kubernetes/infra/monitoring/alloy`.
+- [x] T007 [P] [FR-003] Run Immich Helm template validation with local values.
+- [x] T008 [P] [FR-004] Run `kubectl kustomize kubernetes/clusters/production`.
+- [x] T009 [FR-004] Record development validation exception and substitute live
+      read-only production query evidence.
+- [x] T010 [FR-004] Record command outcomes, skipped checks, exceptions, final
+      live verification, and final `HEAD` in
+      `specs/fix-immich-cnpg-scrape/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [ ] T011 [FR-PR] Commit with a conventional commit message.
+- [ ] T012 [FR-PR] Push branch `codex/fix-immich-cnpg-scrape` and open a PR.


### PR DESCRIPTION
## Summary

- Drop CloudNativePG-generated Services from Alloy service scrape discovery.
- Preserve pod-level CloudNativePG PostgreSQL metrics scraping on port 9187.
- Add Spec Kit artifacts and evidence for the alert triage and validation.

## Root Cause

CloudNativePG inherited the Immich PostgreSQL Prometheus annotations onto both pods and generated Services. The pod exposes metrics on `:9187`, but the generated `immich-postgres-r`, `immich-postgres-ro`, and `immich-postgres-rw` Services only expose Postgres `:5432`, so Alloy discovered unreachable service scrape targets and fired `Alloy Scrape Failures`.

## Validation

- `kubectl kustomize kubernetes/infra/monitoring/alloy`
- `helm template immich oci://ghcr.io/immich-app/immich-charts/immich --version 0.13.1 --namespace immich -f kubernetes/apps/immich/base/values.yaml`
- `kubectl kustomize kubernetes/apps/immich`
- `kubectl kustomize kubernetes/clusters/production`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- `git diff --check`
- Commit hooks, including generated architecture check

## Follow-up

After merge, verify Flux applies the change and `up{namespace="immich"} == 0` no longer returns the Immich PostgreSQL service targets.
