### PR TITLE
fix: stabilize homepage hash responses

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/access-broker-foundation"}
+{"feature_directory":"specs/homepage-hash-flicker"}

--- a/kubernetes/apps/homepage/base/deployment.yaml
+++ b/kubernetes/apps/homepage/base/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/name: homepage
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:

--- a/specs/homepage-hash-flicker/evidence.md
+++ b/specs/homepage-hash-flicker/evidence.md
@@ -1,0 +1,96 @@
+# Evidence: Homepage Hash Flicker
+
+**Branch**: `codex/homepage-hash-flicker`
+**Risk Tier**: medium
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: Manual Spec Kit artifact bootstrap following
+  `docs/runbooks/spec-driven-development.md` and
+  `docs/runbooks/implementation-workflow.md`.
+- Outcome: PASS
+- Spec Kit version: Not changed by this implementation.
+- Integration: Existing repo Codex integration.
+- Fallback: `/workspaces/homelab-worktrees` was not writable, so the dedicated
+  worktree was created at
+  `/workspaces/homelab/.codex/tmp/worktrees/homepage-hash-flicker`.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `git fetch origin && git worktree add /workspaces/homelab-worktrees/homepage-hash-flicker -b codex/homepage-hash-flicker origin/main` | FAIL | `/workspaces/homelab-worktrees` could not be created: permission denied. |
+| `git worktree add /workspaces/homelab/.codex/tmp/worktrees/homepage-hash-flicker -b codex/homepage-hash-flicker origin/main` | PASS | Fallback dedicated worktree created on `codex/homepage-hash-flicker` at `35b1785`. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | No output; exit code 0. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `env -i PATH="$PATH" HOME="$HOME" cluster_domain=lab.petebeegle.com homepage_target_domain=lab.petebeegle.com bash -c 'kubectl kustomize kubernetes/apps/homepage | flux envsubst --strict'` | PASS | Rendered to `/tmp/homepage-hash-flicker-prod.yaml`. |
+| `env -i PATH="$PATH" HOME="$HOME" cluster_domain=dev.lab.petebeegle.com homepage_target_domain=lab.petebeegle.com bash -c 'kubectl kustomize kubernetes/apps/homepage/development | flux envsubst --strict'` | PASS | Rendered to `/tmp/homepage-hash-flicker-dev.yaml`. |
+| Rendered `Deployment/homepage` replica assertion | PASS | Production and development renders both reported `Deployment/homepage replicas=1`. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `python3 tools/architecture/render.py --check` | PASS | No output; exit code 0. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| `https://homepage.lab.petebeegle.com/` | `curl -k -sS -L --max-redirs 8` | PASS pre-change | Returned `code=200 redirects=0 url=https://homepage.lab.petebeegle.com/ type=text/html; charset=utf-8`. |
+| `https://homepage.lab.petebeegle.com/api/hash` | Repeated curl over 75 seconds and a later 20-request sample | FAIL pre-change | Returned two unique hashes. Later 20-request sample returned 11 responses for `92123b128cb010f36cba1d09b85a33f0f3b55abe568121cd75248e71f72f1eaa` and 9 for `cdcb93fef29440bea0d268147ef991d04d0365da9ad236bddb339343ff0834f8`. |
+| Browser reload behavior | Static client bundle inspection | PASS diagnostic | Homepage client compares `/api/hash`, calls `/api/revalidate`, then `window.location.reload()` when the hash changes. |
+
+## Deployment State
+
+- Source fetched SHA: Not verified; PR not merged.
+- Target applied SHA: Not verified; PR not merged.
+- Live resource spec checked: Pre-change exact live spec not available because
+  no kube context is configured in this shell.
+- Gateway/listener/DNS/certificate checked: Existing route left unchanged;
+  pre-change curl proved the exact URL reaches Homepage.
+- Exact user-facing URL result: Pre-change `https://homepage.lab.petebeegle.com/`
+  returned HTTP `200` with no redirects. Post-merge verification remains
+  required after Flux applies the PR.
+
+## Development Validation
+
+- Profile: homepage or documented exception
+- Branch slug: homepage-hash-flicker
+- HEAD: PENDING
+- Report path: PENDING
+- Cleanup: PENDING
+- Result or exception: Development kubeconfig exists; branch smoke will be
+  attempted after committing an exact branch HEAD.
+
+## Documentation Impact
+
+- Updated: `specs/homepage-hash-flicker/`
+- Generated docs: Not expected.
+- No-docs rationale: Replica-count-only workload fix; behavior and HA tradeoff
+  are captured in implementation artifacts.
+
+## SDD Conformance
+
+- Local sources checked: `AGENTS.md`,
+  `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`,
+  `.specify/memory/constitution.md`.
+- Upstream Spec Kit sources checked: Existing local Spec Kit templates and
+  skills.
+- Spec -> Plan -> Tasks -> Implement alignment: PASS so far; local checks are
+  recorded and development smoke is pending exact-HEAD commit.
+- Artifact updates after implementation: PASS so far.
+
+## Exceptions And Follow-Ups
+
+- Dedicated worktree fallback used because `/workspaces/homelab-worktrees` was
+  not writable in this environment.
+- Post-merge live hash stability must be verified after Flux applies the PR.
+
+## Final State
+
+- Final branch: PENDING
+- Final HEAD: PENDING
+- Commit: PENDING

--- a/specs/homepage-hash-flicker/evidence.md
+++ b/specs/homepage-hash-flicker/evidence.md
@@ -23,6 +23,8 @@
 | `git fetch origin && git worktree add /workspaces/homelab-worktrees/homepage-hash-flicker -b codex/homepage-hash-flicker origin/main` | FAIL | `/workspaces/homelab-worktrees` could not be created: permission denied. |
 | `git worktree add /workspaces/homelab/.codex/tmp/worktrees/homepage-hash-flicker -b codex/homepage-hash-flicker origin/main` | PASS | Fallback dedicated worktree created on `codex/homepage-hash-flicker` at `35b1785`. |
 | `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | No output; exit code 0. |
+| `git commit -m "fix: stabilize homepage hash responses"` | PASS | Created `1256f583de9270cc34b0a981e99a1adcb612cd47`; pre-commit hooks passed, including `yamllint`, `k8svalidate`, and generated architecture check. |
+| `git push origin HEAD:refs/heads/codex/homepage-hash-flicker` | PASS | Branch pushed to origin. |
 
 ## Local Checks
 
@@ -41,11 +43,14 @@
 | `https://homepage.lab.petebeegle.com/` | `curl -k -sS -L --max-redirs 8` | PASS pre-change | Returned `code=200 redirects=0 url=https://homepage.lab.petebeegle.com/ type=text/html; charset=utf-8`. |
 | `https://homepage.lab.petebeegle.com/api/hash` | Repeated curl over 75 seconds and a later 20-request sample | FAIL pre-change | Returned two unique hashes. Later 20-request sample returned 11 responses for `92123b128cb010f36cba1d09b85a33f0f3b55abe568121cd75248e71f72f1eaa` and 9 for `cdcb93fef29440bea0d268147ef991d04d0365da9ad236bddb339343ff0834f8`. |
 | Browser reload behavior | Static client bundle inspection | PASS diagnostic | Homepage client compares `/api/hash`, calls `/api/revalidate`, then `window.location.reload()` when the hash changes. |
+| `codex/homepage-hash-flicker` | `python3 tools/development/verify_branch_deploy.py --app homepage --branch codex/homepage-hash-flicker --slug homepage-hash-flicker --push` | FAIL then PASS | First attempt pushed the branch but failed Terraform plan because ignored development tfvars were absent from the worktree. After staging and installing `terraform/development/terraform.tfvars` without logging contents, rerun passed. |
 
 ## Deployment State
 
-- Source fetched SHA: Not verified; PR not merged.
-- Target applied SHA: Not verified; PR not merged.
+- Source fetched SHA: Development Flux fetched
+  `codex/homepage-hash-flicker@sha1:1256f583de9270cc34b0a981e99a1adcb612cd47`.
+- Target applied SHA: Development Kustomization applied
+  `codex/homepage-hash-flicker@sha1:1256f583de9270cc34b0a981e99a1adcb612cd47`.
 - Live resource spec checked: Pre-change exact live spec not available because
   no kube context is configured in this shell.
 - Gateway/listener/DNS/certificate checked: Existing route left unchanged;
@@ -56,13 +61,22 @@
 
 ## Development Validation
 
-- Profile: homepage or documented exception
+- Profile: homepage
 - Branch slug: homepage-hash-flicker
-- HEAD: PENDING
-- Report path: PENDING
-- Cleanup: PENDING
-- Result or exception: Development kubeconfig exists; branch smoke will be
-  attempted after committing an exact branch HEAD.
+- HEAD: `1256f583de9270cc34b0a981e99a1adcb612cd47`
+- Report path: Inline command output from
+  `python3 tools/development/verify_branch_deploy.py --app homepage --branch codex/homepage-hash-flicker --slug homepage-hash-flicker --push`.
+- Cleanup: PASS; verifier deleted
+  `Kustomization/branch-homepage-homepage-hash-flicker`, waited for
+  `namespace/homepage-homepage-hash-flicker` deletion, and deleted
+  `GitRepository/branch-homepage-homepage-hash-flicker`.
+- Result or exception: PASS after installing the ignored development
+  `terraform.tfvars` into the worktree through
+  `.codex/tmp/implementation-secrets/homepage-hash-flicker/` without logging
+  secret contents. Terraform init/validate/plan completed, Flux fetched and
+  applied the branch, the branch namespace became Active, the branch pod became
+  Ready, Service and HTTPRoute checks ran, and the in-cluster HTTP probe matched
+  `Home Lab|Branch|Homepage`.
 
 ## Documentation Impact
 
@@ -79,18 +93,22 @@
   `.specify/memory/constitution.md`.
 - Upstream Spec Kit sources checked: Existing local Spec Kit templates and
   skills.
-- Spec -> Plan -> Tasks -> Implement alignment: PASS so far; local checks are
-  recorded and development smoke is pending exact-HEAD commit.
-- Artifact updates after implementation: PASS so far.
+- Spec -> Plan -> Tasks -> Implement alignment: PASS.
+- Artifact updates after implementation: PASS.
 
 ## Exceptions And Follow-Ups
 
 - Dedicated worktree fallback used because `/workspaces/homelab-worktrees` was
   not writable in this environment.
+- First development verifier attempt failed because ignored development
+  Terraform variables were not present in the worktree; rerun passed after
+  workflow-compliant staging and installation.
 - Post-merge live hash stability must be verified after Flux applies the PR.
 
 ## Final State
 
-- Final branch: PENDING
-- Final HEAD: PENDING
-- Commit: PENDING
+- Final branch: `codex/homepage-hash-flicker`
+- Final HEAD: `1256f583de9270cc34b0a981e99a1adcb612cd47` for the
+  smoke-verified implementation commit; this evidence update may create a
+  follow-up commit without changing rendered manifests.
+- Commit: `1256f583de9270cc34b0a981e99a1adcb612cd47`

--- a/specs/homepage-hash-flicker/plan.md
+++ b/specs/homepage-hash-flicker/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Homepage Hash Flicker
+
+**Branch**: `codex/homepage-hash-flicker` | **Date**: 2026-07-04 | **Spec**:
+`specs/homepage-hash-flicker/spec.md`
+
+**Input**: Feature specification from
+`specs/homepage-hash-flicker/spec.md`
+
+## Summary
+
+Change the shared Homepage Deployment to one replica so a browser session no
+longer receives alternating `/api/hash` values from different pods and triggers
+Homepage's built-in reload path.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes app manifest, Spec Kit artifacts
+**Dependencies**: kubectl, flux CLI, curl
+**Storage**: N/A
+**Ingress**: Existing Gateway API HTTPRoute preserved
+**Secrets**: No secret changes
+**Smoke Strategy**: Existing Homepage development profile if cluster credentials
+are available; otherwise render checks plus live curl pre/post evidence
+**Fanout Targets**: Render checks and live read-only curl checks are independent
+**Development Validation**: Homepage profile when kubeconfig/credentials are
+available; otherwise document exception
+**Post-Implementation SDD Conformance**: Local repo workflow sources checked
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/homepage-hash-flicker`; fallback worktree location is
+      recorded because `/workspaces/homelab-worktrees` was not writable.
+- [x] Documentation impact identified; no canonical docs change expected for a
+      replica-count-only fix.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/homepage-hash-flicker/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/homepage/base/deployment.yaml
+.specify/feature.json
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No new failing unit test is practical for a one-line
+Kubernetes manifest change. Use render assertions before and after the edit.
+
+**Local checks**:
+
+- `env -i PATH="$PATH" HOME="$HOME" cluster_domain=lab.petebeegle.com homepage_target_domain=lab.petebeegle.com bash -c 'kubectl kustomize kubernetes/apps/homepage | flux envsubst --strict'`
+- `env -i PATH="$PATH" HOME="$HOME" cluster_domain=dev.lab.petebeegle.com homepage_target_domain=lab.petebeegle.com bash -c 'kubectl kustomize kubernetes/apps/homepage/development | flux envsubst --strict'`
+- Rendered YAML assertion that both outputs include `replicas: 1` for
+  `Deployment/homepage`.
+
+**Development smoke**: Run
+`python3 tools/development/verify_branch_deploy.py --app homepage --branch codex/homepage-hash-flicker --slug homepage-hash-flicker --push`
+if development kubeconfig and required credentials are available. If not,
+record the unavailable-infrastructure exception and substitute local render plus
+live curl evidence.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization applied SHA, live resource spec, Gateway/listener match when
+applicable, and exact user-facing URL result.
+
+**Fanout plan**: Render checks and read-only curl checks may run independently;
+tracked edits remain sequential in the implementation worktree.
+
+**Evidence destination**: `specs/homepage-hash-flicker/evidence.md`.
+
+## Documentation Impact
+
+No canonical docs or generated architecture updates are expected. The behavior
+and availability tradeoff are recorded in the implementation artifacts.
+
+## Implementation Steps
+
+1. Bootstrap `specs/homepage-hash-flicker/` artifacts.
+2. Change `kubernetes/apps/homepage/base/deployment.yaml` to `replicas: 1`.
+3. Render production and development Homepage manifests and assert the replica
+   count.
+4. Attempt development validation or document the unavailable-infrastructure
+   exception.
+5. Record evidence and final branch state.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Homepage loses one-pod availability during node/pod disruption. | Accept the tradeoff to stop user-facing reloads; PDB remains but can no longer preserve availability during voluntary disruption with one replica. |
+| Flicker has another contributing cause. | Render and curl evidence target the verified `/api/hash` reload path; post-deployment hash sampling remains the acceptance check. |
+| Development validation cannot run from this environment. | Record the exception and substitute deterministic local renders plus read-only live curl evidence. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/homepage-hash-flicker/spec.md
+++ b/specs/homepage-hash-flicker/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Homepage Hash Flicker
+
+**Feature Branch**: `codex/homepage-hash-flicker`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: medium
+**Input**: User description: "Fix Homepage first-load reload/flicker caused by alternating `/api/hash` responses behind the Service."
+
+## Summary
+
+Homepage should load without repeated browser reloads or flicker. Read-only live
+checks showed the dashboard HTML returns `200` without redirects, but
+`/api/hash` alternates between two values while Homepage runs with two replicas.
+Homepage reloads when that hash changes, so the shared Deployment should use one
+replica until a future design can make the hash stable across pods.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/development-cluster.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/flux-gitops-source-of-truth.md`
+
+## Scope
+
+### In Scope
+
+- Change the shared Homepage Deployment replica count from two to one.
+- Preserve the existing Service, HTTPRoute, PDB, config merge flow, and branch
+  Homepage manifest.
+- Record the availability tradeoff and validation evidence.
+
+### Out Of Scope
+
+- Redesigning Homepage config hashing or the config reloader.
+- Adding session affinity, shared persistent config state, or new Gateway
+  routing behavior.
+- Changing private Homepage configuration.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stable Homepage Load (Priority: P1)
+
+As a dashboard user, I can open Homepage without the page repeatedly reloading
+because backend hash responses disagree.
+
+**Why this priority**: This directly fixes the reported user-facing flicker with
+the smallest GitOps change.
+
+**Independent Test**: Render the production and development Homepage manifests
+and confirm the shared Deployment renders with `replicas: 1`; after deployment,
+curl the exact user URL and repeatedly sample `/api/hash` to confirm only one
+hash value is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** the rendered shared Homepage Deployment, **When** production or
+   development kustomizations are rendered, **Then** the Deployment has exactly
+   one replica.
+2. **Given** the production Homepage URL after Flux applies the change, **When**
+   `/api/hash` is requested at least 20 times, **Then** only one unique hash is
+   observed.
+3. **Given** the production Homepage URL after Flux applies the change, **When**
+   the page is loaded in a browser or browser automation, **Then** Homepage does
+   not repeatedly reload due to hash churn.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The shared Homepage Deployment MUST render with `replicas: 1`.
+- **FR-002**: The implementation MUST preserve existing Homepage Service,
+  HTTPRoute, PDB, config merge, and branch manifest behavior.
+- **FR-003**: Evidence MUST record the intentional tradeoff of lower Homepage
+  availability for stable browser behavior.
+- **FR-004**: Evidence MUST include production and development render checks.
+- **FR-005**: Evidence MUST include development validation or a documented
+  unavailable-infrastructure exception with substitute checks.
+
+## Risk And Validation Expectations
+
+This is `medium` risk because it changes a Kubernetes app workload. It requires
+focused render checks and development validation when credentials are available,
+or a documented exception with substitute checks when they are not.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Rendered production Homepage manifests include `replicas: 1` for
+  the `homepage/homepage` Deployment.
+- **SC-002**: Rendered development Homepage manifests include `replicas: 1` for
+  the `homepage/homepage` Deployment.
+- **SC-003**: Production Homepage returns `200` with no redirects from the exact
+  user URL before or after deployment verification.
+- **SC-004**: Post-deployment `/api/hash` sampling returns one unique hash over
+  at least 20 requests, or the missing post-deployment layer is explicitly
+  recorded for follow-up.
+
+## Assumptions
+
+- The fastest reliable fix is preferred over preserving two-replica Homepage
+  availability.
+- No secret staging is required.
+- `docs/architecture.md` is not expected to change for a replica-count-only app
+  workload adjustment unless validation reports it stale.
+
+## Open Questions
+
+- None

--- a/specs/homepage-hash-flicker/tasks.md
+++ b/specs/homepage-hash-flicker/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: Homepage Hash Flicker
+
+**Input**: `specs/homepage-hash-flicker/spec.md` and
+`specs/homepage-hash-flicker/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Branch `codex/homepage-hash-flicker` and matching
+`specs/homepage-hash-flicker/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel or fan out to a helper lane because it touches
+  different files or performs read-only validation and has no dependency on
+  another incomplete task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+- Keep fanout coordinated through this task list and consolidate all results
+  into `specs/homepage-hash-flicker/evidence.md`.
+
+## Phase 1: Spec And Plan
+
+- [X] T001 [FR-SPEC] Create `specs/homepage-hash-flicker/spec.md`.
+- [X] T002 [FR-PLAN] Create `specs/homepage-hash-flicker/plan.md`,
+      including tiered TDD and development validation expectations.
+- [X] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations in `specs/homepage-hash-flicker/plan.md`.
+
+## Phase 2: Implementation
+
+- [X] T004 [FR-001] Edit `kubernetes/apps/homepage/base/deployment.yaml` so
+      the shared Homepage Deployment uses `replicas: 1`.
+- [X] T005 [FR-002] Verify the branch Homepage manifest, Service, HTTPRoute,
+      PDB, and config merge behavior are not changed.
+- [X] T006 [FR-002] Re-check constitution gates after implementation edits in
+      `specs/homepage-hash-flicker/plan.md`.
+
+## Phase 3: Verification
+
+- [X] T007 [FR-004] Render production Homepage with strict envsubst and assert
+      `Deployment/homepage` has `replicas: 1`.
+- [X] T008 [FR-004] Render development Homepage with strict envsubst and assert
+      `Deployment/homepage` has `replicas: 1`.
+- [ ] T009 [FR-005] Run Homepage development smoke validation or record the
+      unavailable-infrastructure exception in
+      `specs/homepage-hash-flicker/evidence.md`.
+- [ ] T010 [FR-003] Record command outcomes, URLs, smoke evidence, skipped
+      checks, exceptions, and final branch state in
+      `specs/homepage-hash-flicker/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [ ] T011 [FR-PR] Commit with a conventional commit message.
+- [ ] T012 [FR-PR] Push branch `codex/homepage-hash-flicker` and open a PR.
+
+## Dependencies
+
+- T004 depends on T001-T003.
+- T007 and T008 depend on T004.
+- T009 depends on T004 and can run after local render checks.
+- T010 depends on all completed implementation and verification tasks.
+- T011 and T012 are intentionally left for PR publication flow.
+
+## Fanout Guidance
+
+- T007 and T008 are read-only render checks and may run independently.
+- Live read-only curl checks may run independently from render checks.
+- Tracked edits stay sequential because this implementation changes a single
+  manifest and one artifact set.

--- a/specs/homepage-hash-flicker/tasks.md
+++ b/specs/homepage-hash-flicker/tasks.md
@@ -39,17 +39,18 @@
       `Deployment/homepage` has `replicas: 1`.
 - [X] T008 [FR-004] Render development Homepage with strict envsubst and assert
       `Deployment/homepage` has `replicas: 1`.
-- [ ] T009 [FR-005] Run Homepage development smoke validation or record the
+- [X] T009 [FR-005] Run Homepage development smoke validation or record the
       unavailable-infrastructure exception in
       `specs/homepage-hash-flicker/evidence.md`.
-- [ ] T010 [FR-003] Record command outcomes, URLs, smoke evidence, skipped
+- [X] T010 [FR-003] Record command outcomes, URLs, smoke evidence, skipped
       checks, exceptions, and final branch state in
       `specs/homepage-hash-flicker/evidence.md`.
 
 ## Phase 4: Commit And PR
 
-- [ ] T011 [FR-PR] Commit with a conventional commit message.
-- [ ] T012 [FR-PR] Push branch `codex/homepage-hash-flicker` and open a PR.
+- [X] T011 [FR-PR] Commit with a conventional commit message.
+- [X] T012 [FR-PR] Push branch `codex/homepage-hash-flicker`; PR creation is
+      available from the pushed branch URL.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Set shared Homepage Deployment to `replicas: 1` to stop alternating `/api/hash` responses across pods.
- Added Spec Kit artifacts under `specs/homepage-hash-flicker/` with the HA tradeoff and validation evidence.
- Preserved Homepage Service, HTTPRoute, PDB, config merge flow, and branch manifest behavior.

## Validation
- PASS: production Homepage render with strict envsubst; `Deployment/homepage replicas=1`.
- PASS: development Homepage render with strict envsubst; `Deployment/homepage replicas=1`.
- PASS: `git diff --check`.
- PASS: `python3 tools/architecture/render.py --check`.
- PASS: `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
- PASS: development Homepage branch smoke on implementation commit `1256f583de9270cc34b0a981e99a1adcb612cd47`; Flux fetched/applied the branch, pod became Ready, Service and HTTPRoute checks ran, in-cluster HTTP probe matched `Home Lab|Branch|Homepage`, and cleanup completed.

## Notes
- `/workspaces/homelab-worktrees` was not writable, so the implementation used the fallback dedicated worktree under `.codex/tmp/worktrees/`.
- First development verifier attempt failed until ignored development `terraform.tfvars` was staged and installed into the worktree without logging secret contents.
- Post-merge production verification should confirm `/api/hash` returns one unique value after Flux applies the PR.
