### PR TITLE
[codex] Add Immich user-oriented dashboard stats

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/homepage/branch` | `homepage.yaml` |
 | `kubernetes/apps/homepage/development` | `../base` |
 | `kubernetes/apps/homepage` | `base` |
-| `kubernetes/apps/immich/base` | `namespace.yaml`, `pvc.yaml`, `postgres.yaml`, `app.yaml`, `httproute.yaml`, `secret.yaml` |
+| `kubernetes/apps/immich/base` | `namespace.yaml`, `pvc.yaml`, `postgres.yaml`, `app.yaml`, `metrics-service.yaml`, `httproute.yaml`, `secret.yaml` |
 | `kubernetes/apps/immich/branch` | `../base` |
 | `kubernetes/apps/immich` | `base` |
 | `kubernetes/apps/jellyfin/branch` | `jellyfin.yaml` |

--- a/kubernetes/apps/immich/base/kustomization.yaml
+++ b/kubernetes/apps/immich/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - pvc.yaml
   - postgres.yaml
   - app.yaml
+  - metrics-service.yaml
   - httproute.yaml
   - secret.yaml
 configMapGenerator:

--- a/kubernetes/apps/immich/base/metrics-service.yaml
+++ b/kubernetes/apps/immich/base/metrics-service.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-server-metrics-ms
+  namespace: immich
+  labels:
+    app.kubernetes.io/name: server
+    app.kubernetes.io/instance: immich
+    app.kubernetes.io/service: immich-server-metrics-ms
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8082"
+    prometheus.io/path: /metrics
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics-ms
+      port: 8082
+      protocol: TCP
+      targetPort: metrics-ms
+  selector:
+    app.kubernetes.io/controller: main
+    app.kubernetes.io/instance: immich
+    app.kubernetes.io/name: server

--- a/kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json
@@ -20,29 +20,12 @@
   "liveNow": false,
   "panels": [
     {
+      "id": 1,
+      "title": "Immich Scrapes Up",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -50,10 +33,29 @@
         "x": 0,
         "y": 0
       },
-      "id": 1,
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "options": {
         "colorMode": "background",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
@@ -72,37 +74,18 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "min(up{namespace=\"immich\"}) OR vector(0)",
+          "expr": "min(up{namespace=\"immich\",service=~\"immich-server|immich-server-metrics-ms\"}) OR vector(0)",
           "refId": "A"
         }
-      ],
-      "title": "Scrape Health",
-      "type": "stat"
+      ]
     },
     {
+      "id": 2,
+      "title": "Users",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -110,10 +93,25 @@
         "x": 4,
         "y": 0
       },
-      "id": 2,
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "options": {
         "colorMode": "background",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
@@ -132,17 +130,81 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(kube_deployment_spec_replicas{namespace=\"immich\"} - kube_deployment_status_replicas_available{namespace=\"immich\"}) OR vector(0)",
+          "expr": "max(immich_users_total{namespace=\"immich\"}) OR vector(0)",
           "refId": "A"
         }
-      ],
-      "title": "Unavailable Deployments",
-      "type": "stat"
+      ]
     },
     {
+      "id": 3,
+      "title": "New Assets / Min",
+      "type": "stat",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_asset_repository_create_duration_count{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Job Failures / Hour",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -160,20 +222,14 @@
               }
             ]
           },
-          "unit": "short"
+          "unit": "ops",
+          "decimals": 1
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 0
-      },
-      "id": 3,
       "options": {
         "colorMode": "background",
-        "graphMode": "none",
+        "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
@@ -192,23 +248,30 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(max by (namespace, persistentvolumeclaim) (kube_persistentvolumeclaim_status_phase{namespace=\"immich\",phase=\"Pending\"} > bool 0)) OR vector(0)",
+          "expr": "(sum(rate(immich_jobs_asset_generate_thumbnails_failed_total{namespace=\"immich\"}[1h]) * 3600) OR on() vector(0)) + (sum(rate(immich_jobs_asset_extract_metadata_failed_total{namespace=\"immich\"}[1h]) * 3600) OR on() vector(0)) + (sum(rate(immich_jobs_asset_detect_faces_failed_total{namespace=\"immich\"}[1h]) * 3600) OR on() vector(0)) + (sum(rate(immich_jobs_smart_search_failed_total{namespace=\"immich\"}[1h]) * 3600) OR on() vector(0)) + (sum(rate(immich_jobs_ocr_failed_total{namespace=\"immich\"}[1h]) * 3600) OR on() vector(0))",
           "refId": "A"
         }
-      ],
-      "title": "Pending PVCs",
-      "type": "stat"
+      ]
     },
     {
+      "id": 5,
+      "title": "Active Background Queues",
+      "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
       },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 12,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "showPoints": "never",
@@ -224,54 +287,351 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 4
-      },
-      "id": 4,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (status) (rate(http_server_duration_milliseconds_count{namespace=\"immich\"}[5m])) OR on() vector(0)",
-          "legendFormat": "{{status}}",
-          "refId": "A"
+          "expr": "immich_queues_metadata_extraction_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "metadata"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_thumbnail_generation_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "thumbnails"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_video_conversion_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "C",
+          "legendFormat": "video"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_face_detection_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "D",
+          "legendFormat": "faces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_facial_recognition_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "E",
+          "legendFormat": "recognition"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_smart_search_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "F",
+          "legendFormat": "smart search"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_ocr_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "G",
+          "legendFormat": "ocr"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "immich_queues_duplicate_detection_active{namespace=\"immich\"} OR on() vector(0)",
+          "refId": "H",
+          "legendFormat": "duplicates"
         }
-      ],
-      "title": "API Requests",
-      "type": "timeseries"
+      ]
     },
     {
+      "id": 6,
+      "title": "Job Success / Min",
+      "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
       },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_generate_thumbnails_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "thumbnails"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_encode_video_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "video"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_detect_faces_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "C",
+          "legendFormat": "faces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_smart_search_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "D",
+          "legendFormat": "smart search"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_ocr_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "E",
+          "legendFormat": "ocr"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_detect_duplicates_success_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "F",
+          "legendFormat": "duplicates"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Job Failures And Skips / Min",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_generate_thumbnails_failed_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "thumbnail failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_generate_thumbnails_skipped_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "thumbnail skipped"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_encode_video_skipped_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "C",
+          "legendFormat": "video skipped"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_extract_metadata_failed_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "D",
+          "legendFormat": "metadata failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_asset_detect_faces_failed_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "E",
+          "legendFormat": "faces failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_smart_search_failed_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "F",
+          "legendFormat": "smart search failed"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(immich_jobs_ocr_failed_total{namespace=\"immich\"}[5m]) * 60) OR on() vector(0)",
+          "refId": "G",
+          "legendFormat": "ocr failed"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Processing Latency p95",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "showPoints": "never",
@@ -291,50 +651,248 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 4
-      },
-      "id": 5,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_milliseconds_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
-          "legendFormat": "p95",
-          "refId": "A"
+          "expr": "histogram_quantile(0.95, sum(rate(immich_media_repository_generate_thumbnail_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "thumbnail"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_media_repository_transcode_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "transcode"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_machine_learning_repository_detect_faces_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "C",
+          "legendFormat": "detect faces"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_machine_learning_repository_encode_image_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "D",
+          "legendFormat": "encode image"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_machine_learning_repository_ocr_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "E",
+          "legendFormat": "ocr"
         }
-      ],
-      "title": "API Latency",
-      "type": "timeseries"
+      ]
     },
     {
+      "id": 9,
+      "title": "Storage Latency p95",
+      "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
       },
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 10,
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_storage_repository_create_file_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "create file"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_storage_repository_overwrite_file_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "B",
+          "legendFormat": "overwrite"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_storage_repository_read_file_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "C",
+          "legendFormat": "read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(immich_storage_repository_stat_duration_bucket{namespace=\"immich\"}[5m])) by (le)) OR on() vector(0)",
+          "refId": "D",
+          "legendFormat": "stat"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Process CPU",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (service) (process_cpu_utilization{namespace=\"immich\",service=~\"immich-server|immich-server-metrics-ms\"}) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{service}}"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "title": "Process Memory",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "showPoints": "never",
@@ -354,52 +912,114 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 12
-      },
-      "id": 6,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
-          "displayMode": "list",
-          "placement": "bottom"
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
+      "pluginVersion": "12.0.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"immich\",container!=\"\",container!=\"POD\"}) OR on() vector(0)",
-          "legendFormat": "{{pod}}",
-          "refId": "A"
+          "expr": "sum by (service) (process_memory_usage{namespace=\"immich\",service=~\"immich-server|immich-server-metrics-ms\"}) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{service}}"
         }
-      ],
-      "title": "Pod Memory",
-      "type": "timeseries"
+      ]
     },
     {
+      "id": 12,
+      "title": "Network I/O",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (service, network_io_direction) (rate(system_network_io_total{namespace=\"immich\",service=~\"immich-server|immich-server-metrics-ms\"}[5m])) OR on() vector(0)",
+          "refId": "A",
+          "legendFormat": "{{service}} {{network_io_direction}}"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "title": "Recent Immich Warnings And Work Logs",
+      "type": "logs",
       "datasource": {
         "type": "loki",
         "uid": "loki"
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 12
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
-      "id": 7,
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
@@ -416,16 +1036,14 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{namespace=\"immich\"} |~ \"(?i)(error|warn|failed|exception|timeout|oauth|postgres|vchord)\"",
+          "expr": "{namespace=\"immich\"} |~ \"(?i)(error|warn|failed|exception|timeout|oauth|postgres|vchord|upload|ffprobe|transcod|thumbnail|face|ocr|smart.?search)\"",
           "refId": "A"
         }
-      ],
-      "title": "Recent Immich Warnings",
-      "type": "logs"
+      ]
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": [
     "immich",
     "photos",
@@ -435,13 +1053,13 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Immich Overview",
   "uid": "immich-overview",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/specs/immich-dashboard-stats/evidence.md
+++ b/specs/immich-dashboard-stats/evidence.md
@@ -1,0 +1,98 @@
+# Evidence: immich-dashboard-stats
+
+**Branch**: `codex/immich-dashboard-stats`
+**Risk Tier**: medium
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: manual artifact creation from repo templates after user-approved
+  implementation plan.
+- Outcome: PASS
+- Spec Kit version: not reinitialized; existing repo Spec Kit structure used.
+- Integration: existing repository integration.
+- Fallback: `/workspaces/homelab-worktrees` was not writable, so the
+  implementation worktree is `/workspaces/homelab-ideas/immich-dashboard-stats`.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `git worktree add /workspaces/homelab-worktrees/immich-dashboard-stats -b codex/immich-dashboard-stats origin/main` | FAIL | Parent directory could not be created: permission denied. |
+| `git worktree add /workspaces/homelab-ideas/immich-dashboard-stats -b codex/immich-dashboard-stats origin/main` | PASS | Worktree created from `origin/main`. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | SDD context validated after spec, plan, tasks, and evidence existed. |
+
+## Query Smoke
+
+Strict pass rule: every dashboard query must return at least one series, stream,
+log line, or an intentional zero-valued fallback vector.
+
+| Query | Result | Notes |
+| ----- | ------ | ----- |
+| PromQL dashboard matrix | PASS | `scrape_health=1`, `users=1`, `new_assets=1.3167/sec`, API CPU and memory returned live series. Queue, job, and processing panels returned intentional zero fallback before the new `8082` scrape Service exists in Mimir. |
+| Raw `8082` metric family smoke | PASS | Live `immich-server:8082/metrics` exposes queue, job, media, ML, and storage metric families needed by the dashboard. |
+| Loki warning/error query | PASS | Returned Immich upload/thumbnail/face/error log streams from Loki. |
+| Full dashboard PromQL parse smoke via Mimir port-forward | PASS | Checked 37 Prometheus targets from `immich-dashboard.json`; all returned success and at least one series, including intentional zero fallback vectors where the new `8082` scrape target is not reconciled yet. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `jq empty kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json` | PASS | Dashboard JSON parsed successfully. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `kubectl kustomize kubernetes/apps/immich` | PASS | Rendered the app and included `Service/immich-server-metrics-ms`; output stored at `/tmp/immich-app-render.yaml`. |
+| `export branch_slug=immich-dashboard-stats cluster_domain=dev.lab.petebeegle.com; kubectl kustomize kubernetes/apps/immich/branch \| flux envsubst --strict` | PASS | Rendered branch overlay with `Service/immich-server-metrics-ms` in namespace `immich-immich-dashboard-stats`; output stored at `/tmp/immich-branch-render.yaml`. |
+| `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards` | PASS | Rendered dashboard ConfigMaps and `GrafanaDashboard` resources; output stored at `/tmp/grafana-dashboards-render.yaml`. |
+| `kubectl kustomize kubernetes/infra/monitoring/grafana` | PASS | Rendered parent Grafana kustomization; output stored at `/tmp/grafana-render.yaml`. |
+| `python3 tools/architecture/render.py --check` | PASS | Failed before generated docs refresh, passed after `python3 tools/architecture/render.py --write`. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| `up{namespace="immich",service="immich-server-metrics-ms"}` | Post-merge production Mimir query | PENDING | New scrape target is not expected to exist until Flux applies the PR. |
+
+## Deployment State
+
+- Source fetched SHA: not merged/reconciled during implementation.
+- Target applied SHA: not merged/reconciled during implementation.
+- Live resource spec checked: local render verifies intended `Service/immich-server-metrics-ms`; live Mimir verification remains post-merge.
+- Gateway/listener/DNS/certificate checked: N/A, no route changes.
+- Exact user-facing URL result: N/A, dashboard-only observability change.
+
+## Development Validation
+
+- Profile: none
+- Branch slug: immich-dashboard-stats
+- HEAD: branch working tree based on `35b1785` before local commit.
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: PASS by documented substitute. Development validation is substituted by production
+  read-only query smoke and local render checks because development does not
+  carry equivalent production Immich upload/processing observability history.
+
+## Documentation Impact
+
+- Updated: `specs/immich-dashboard-stats/`, `docs/architecture.md`.
+- Generated docs: `docs/architecture.md` refreshed to include `metrics-service.yaml`.
+- No-docs rationale: existing Immich runbook still accurately describes dashboard ownership; this change adds panels and scrape coverage only.
+
+## SDD Conformance
+
+- Local sources checked: `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`.
+- Upstream Spec Kit sources checked: N/A; no workflow/template behavior change.
+- Spec -> Plan -> Tasks -> Implement alignment: PASS. The implementation follows the requested dashboard and scrape-target plan.
+- Artifact updates after implementation: PASS. Tasks and evidence were updated after implementation and validation.
+
+## Exceptions And Follow-Ups
+
+- Worktree path exception: `/workspaces/homelab-worktrees` is not writable.
+- Follow-up after merge/reconcile: confirm
+  `up{namespace="immich",service="immich-server-metrics-ms"}` appears in Mimir.
+
+## Final State
+
+- Final branch: `codex/immich-dashboard-stats`
+- Final HEAD: local implementation commit; verify with `git log -1`.
+- Commit: `feat(immich): add user-oriented dashboard stats`

--- a/specs/immich-dashboard-stats/plan.md
+++ b/specs/immich-dashboard-stats/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: immich-dashboard-stats
+
+**Branch**: `codex/immich-dashboard-stats` | **Date**: 2026-07-04 |
+**Spec**: `specs/immich-dashboard-stats/spec.md`
+
+**Input**: Feature specification from
+`specs/immich-dashboard-stats/spec.md`
+
+## Summary
+
+Add a dedicated annotated Immich microservices metrics Service for Alloy's
+existing service-annotation scraper, then replace the Immich Grafana dashboard
+with user-oriented upload, queue, job, processing, storage, resource, and log
+panels. Keep API metrics scraping unchanged and avoid global Alloy changes.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, Flux, Grafana, observability, SDD
+**Dependencies**: kubectl, flux CLI, jq, production kubeconfig for read-only
+query smoke
+**Storage**: N/A; no PVC changes
+**Ingress**: N/A; no Gateway API route changes
+**Secrets**: N/A; no secret changes
+**Smoke Strategy**: production read-only Mimir/Loki query smoke plus local
+render checks; post-merge live scrape verification recorded if unreconciled
+**Fanout Targets**: query smoke, render validation, evidence updates
+**Development Validation**: none; dashboard data depends on production Immich
+observability, with substitute query smoke and render checks
+**Post-Implementation SDD Conformance**: local workflow docs only
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation exception and
+      substitute query smoke are recorded.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; no PVC changes.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/immich-dashboard-stats`; worktree fallback is recorded.
+- [x] Documentation impact identified; generated architecture will be checked.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/immich-dashboard-stats/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/immich/base/metrics-service.yaml
+kubernetes/apps/immich/base/kustomization.yaml
+kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json
+docs/architecture.md
+specs/immich-dashboard-stats/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No executable code seam is introduced. The failing
+condition is invalid JSON, missing rendered Service, missing rendered dashboard,
+or dashboard queries that return no usable live data.
+
+**Local checks**:
+
+- `jq empty kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json`
+- `kubectl kustomize kubernetes/apps/immich`
+- `branch_slug=immich-dashboard-stats cluster_domain=dev.lab.petebeegle.com kubectl kustomize kubernetes/apps/immich/branch | flux envsubst --strict`
+- `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
+- `kubectl kustomize kubernetes/infra/monitoring/grafana`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+
+**Development smoke**: none; development does not carry the production Immich
+upload/processing metric history needed for strict dashboard smoke. Substitute
+checks are production read-only query smoke and deterministic local render
+validation.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks
+only as supplemental evidence.
+
+## Implementation Notes
+
+1. Create `immich-server-metrics-ms` as a small standalone Service rather than
+   changing Alloy's global discovery or relying on ServiceMonitor discovery.
+2. Query `immich_queues_*_active` and `immich_jobs_*_(success|failed|skipped)_total`
+   only after the microservices metrics scrape target exists.
+3. Use `OR on() vector(0)` fallbacks where a successful zero is useful, while
+   keeping labels for grouped panels where data exists.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| New `8082` target cannot be verified before merge because Flux has not reconciled the branch. | Record post-merge verification and validate the rendered service locally. |
+| Dashboard panels become empty if a metric family is absent after an Immich upgrade. | Use query-smoked current metric families and conservative fallback vectors for stat panels. |
+| Generated architecture inventory changes. | Run `render.py --check`, then `--write` if required. |

--- a/specs/immich-dashboard-stats/spec.md
+++ b/specs/immich-dashboard-stats/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: immich-dashboard-stats
+
+**Feature Branch**: `codex/immich-dashboard-stats`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: medium
+**Input**: User description: "modify the Immich Grafana dashboard with user-oriented stats"
+
+## Summary
+
+Operators need the GitOps-managed `Immich Overview` dashboard to reflect
+visible Immich activity during photo uploads and processing. The dashboard must
+show library growth, active background queues, job outcomes, processing/storage
+latency, users, resource pressure, and relevant warnings instead of mostly
+generic health panels that stay flat while Immich is working.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/immich.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+
+## Scope
+
+### In Scope
+
+- Add the minimum Kubernetes desired state needed for Alloy to scrape Immich
+  microservices metrics on port `8082`.
+- Replace the Immich Grafana dashboard panels with user-oriented Prometheus and
+  Loki queries.
+- Record live query smoke, render checks, generated architecture status, and
+  post-merge verification expectations.
+
+### Out Of Scope
+
+- Grafana alert rules.
+- Global Alloy ServiceMonitor support or global scrape-discovery redesign.
+- Immich app behavior, external route behavior, secrets, storage classes, or
+  user-facing application configuration.
+
+## User Scenarios & Testing
+
+### User Story 1 - See Upload Activity (Priority: P1)
+
+An operator uploading photos can open `Immich Overview` and see asset creation,
+background queue activity, and job outcomes move while Immich processes the
+library.
+
+**Why this priority**: This addresses the observed failure: uploads and
+processing were active, but the dashboard did not reflect useful work.
+
+**Independent Test**: Query-smoke the dashboard PromQL expressions against
+production Mimir and validate the Grafana dashboard JSON.
+
+**Acceptance Scenarios**:
+
+1. **Given** Immich metrics are being scraped, **When** assets are uploaded,
+   **Then** dashboard panels show non-flat library growth, queue, job, or
+   processing metrics.
+2. **Given** background work runs in Immich microservices, **When** Alloy
+   scrapes the app, **Then** the `metrics-ms` endpoint is available as a
+   distinct scrape target.
+
+### User Story 2 - Avoid Misleading Health (Priority: P2)
+
+An operator can trust the scrape-health panel because it evaluates the Immich
+API and microservices scrape targets instead of unrelated CNPG service targets.
+
+**Why this priority**: The previous `min(up{namespace="immich"})` query reported
+red because of unrelated down PostgreSQL services, even when Immich was working.
+
+**Independent Test**: Smoke the health PromQL query and render the app
+manifests that add the microservices metrics service.
+
+**Acceptance Scenarios**:
+
+1. **Given** Immich app metrics targets exist, **When** the dashboard evaluates
+   scrape health, **Then** it only considers `immich-server` and
+   `immich-server-metrics-ms`.
+
+## Requirements
+
+- **FR-001**: The implementation MUST add a GitOps-managed Service named
+  `immich-server-metrics-ms` in namespace `immich` for metrics port `8082`.
+- **FR-002**: The implementation MUST keep the existing `immich-server` API
+  metrics scrape on port `8081`.
+- **FR-003**: The implementation MUST update `Immich Overview` with panels for
+  users, new assets, active queues, job rates, processing latency, storage
+  latency, process resources, and warning/error logs.
+- **FR-004**: Dashboard PromQL and LogQL targets MUST use datasource UIDs
+  `prometheus` and `loki`.
+- **FR-005**: The implementation MUST NOT add Grafana alert rules or change
+  global Alloy scrape behavior.
+- **FR-006**: Evidence MUST record query smoke, JSON validation, app render,
+  branch overlay render, Grafana render, generated architecture status, and
+  any unavailable live post-merge verification.
+
+## Risk And Validation Expectations
+
+**Medium**: Include focused render checks for changed Kubernetes and Grafana
+manifests. Because development does not necessarily have the production Immich
+observability data required for strict dashboard smoke, use production
+read-only Mimir/Loki query smoke plus local render validation. Record post-merge
+verification for the new microservices scrape target if Flux has not reconciled
+the branch during implementation.
+
+## Success Criteria
+
+- **SC-001**: `kubectl kustomize kubernetes/apps/immich` renders the
+  `immich-server-metrics-ms` Service.
+- **SC-002**: Branch overlay rendering includes the same service transformed
+  into the branch namespace.
+- **SC-003**: `jq empty` passes for the updated dashboard JSON.
+- **SC-004**: Grafana dashboard kustomizations render successfully.
+- **SC-005**: Query smoke shows dashboard queries return data or intentional
+  zero-valued fallback vectors.

--- a/specs/immich-dashboard-stats/tasks.md
+++ b/specs/immich-dashboard-stats/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: immich-dashboard-stats
+
+**Input**: `specs/immich-dashboard-stats/spec.md` and
+`specs/immich-dashboard-stats/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Branch `codex/immich-dashboard-stats` and matching
+`specs/immich-dashboard-stats/` artifacts.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel or fan out to a helper lane because it touches
+  different files or performs read-only validation and has no dependency on
+  another incomplete task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+
+## Phase 1: Spec And Plan
+
+- [X] T001 [FR-SPEC] Create `specs/immich-dashboard-stats/spec.md`.
+- [X] T002 [FR-PLAN] Create `specs/immich-dashboard-stats/plan.md`,
+      including tiered TDD and development validation expectations.
+- [X] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+      expectations.
+
+## Phase 2: Query Smoke
+
+- [X] T004 [P] [FR-003] Run production read-only PromQL smoke for intended
+      Immich dashboard queries.
+- [X] T005 [P] [FR-003] Run production read-only Loki smoke for intended
+      Immich warning/error logs.
+
+## Phase 3: Implementation
+
+- [X] T006 [FR-001] Add
+      `kubernetes/apps/immich/base/metrics-service.yaml` and register it in
+      `kubernetes/apps/immich/base/kustomization.yaml`.
+- [X] T007 [FR-003] Replace user-oriented panels in
+      `kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json`.
+- [X] T008 [FR-DOCS] Update generated architecture if `render.py --check`
+      requires it.
+
+## Phase 4: Verification
+
+- [X] T009 [FR-TEST] Run `jq empty kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json`.
+- [X] T010 [FR-TEST] Run `kubectl kustomize kubernetes/apps/immich`.
+- [X] T011 [FR-TEST] Run branch overlay render with `flux envsubst --strict`.
+- [X] T012 [FR-TEST] Run Grafana dashboard and parent kustomize renders.
+- [X] T013 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [X] T014 [FR-TEST] Run SDD context validation.
+- [X] T015 [FR-SMOKE] Record development validation exception and post-merge
+      microservices scrape verification expectation.
+- [X] T016 [FR-EVIDENCE] Record command outcomes, smoke evidence, exceptions,
+      and final `HEAD` in `specs/immich-dashboard-stats/evidence.md`.
+
+## Phase 5: Commit And PR
+
+- [X] T017 [FR-PR] Commit with a conventional commit message.
+- [ ] T018 [FR-PR] Push branch `codex/immich-dashboard-stats` and open a PR if
+      requested.


### PR DESCRIPTION
## Summary

- add a dedicated `immich-server-metrics-ms` Service so Alloy can scrape Immich microservices metrics on port 8082
- replace the Immich Grafana dashboard with user-oriented panels for uploads, users, queues, jobs, processing/storage latency, runtime resources, and relevant logs
- add Spec Kit artifacts and refresh generated architecture inventory

## Why

The previous dashboard stayed mostly flat during photo uploads because it focused on generic HTTP/resource signals and only scraped the API metrics endpoint. Immich exposes the most useful background work metrics on the microservices endpoint, so this adds the minimum GitOps scrape target and updates the dashboard to use those signals.

## Validation

- `jq empty kubernetes/infra/monitoring/grafana/dashboards/immich-dashboard.json`
- `git diff --check`
- `kubectl kustomize kubernetes/apps/immich`
- `branch_slug=immich-dashboard-stats cluster_domain=dev.lab.petebeegle.com kubectl kustomize kubernetes/apps/immich/branch | flux envsubst --strict`
- `kubectl kustomize kubernetes/infra/monitoring/grafana/dashboards`
- `kubectl kustomize kubernetes/infra/monitoring/grafana`
- `python3 tools/architecture/render.py --check`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- production read-only Mimir/Loki smoke recorded in `specs/immich-dashboard-stats/evidence.md`
- commit hooks passed, including `k8svalidate`

## Follow-up

After merge and Flux reconcile, verify `up{namespace="immich",service="immich-server-metrics-ms"}` appears in Mimir.
