### PR TITLE
[codex] activate access broker smoke

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/homepage-hash-flicker"}
+{"feature_directory":"specs/access-broker-manual-smoke"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ This document is generated for agentic repo navigation. It records relationships
 - Root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
 - Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
 - Infra activation list: `crds.yaml`, `cert-manager.yaml`, `local-path-provisioner.yaml`, `cloudnative-pg.yaml`, `grafana-operator.yaml`, `intel-device-plugins-operator.yaml`, `intel-gpu-device-plugin.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `metrics-server.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
-- App activation list: `external.yaml`, `homepage.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `immich.yaml`, `home-assistant.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`, `private`.
+- App activation list: `external.yaml`, `homepage.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `immich.yaml`, `home-assistant.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`, `access-broker.yaml`, `private`.
 
 ### Development
 
@@ -95,6 +95,7 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Cluster | Kustomization | Path | Depends on | Substitute from | SOPS |
 | --- | --- | --- | --- | --- | --- |
+| `production` | `app-access-broker` | `./kubernetes/apps/access-broker` | `gateway`, `nfs-csi`, `app-cloudflare-tunnels` | `cluster-vars` | `sops` |
 | `production` | `app-cloudflare-tunnels` | `./kubernetes/apps/cloudflare-tunnels` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `app-external` | `./kubernetes/apps/external` | `gateway` | `cluster-vars` | `no` |
 | `production` | `app-foundryvtt` | `./kubernetes/apps/foundryvtt` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
@@ -174,7 +175,7 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Kind | Route | Hostnames | Parent Gateway | Backend refs |
 | --- | --- | --- | --- | --- |
-| `HTTPRoute` | `access-broker/access-broker-public` | `onboard.${cluster_domain}` | `gateway/public/http-gateway` | `access-broker:80` |
+| `HTTPRoute` | `access-broker/access-broker-public` | `onboard.petebeegle.com` | `gateway/public/http-gateway` | `access-broker:80` |
 | `HTTPRoute` | `authentik/authentik` | `authentik.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `authentik-server:80` |
 | `HTTPRoute` | `external/synology-route` | `synology.petebeegle.com` | `gateway/internal/synology-https-gateway` | `synology-proxy:8080` |
 | `HTTPRoute` | `foundry-bluegreen-fixture/foundry-fixture-green-preview` | `foundry-green-preview.dev.lab.petebeegle.com` | `gateway/internal/https-gateway` | `foundry-fixture-green:80` |

--- a/kubernetes/apps/access-broker/configmap.yaml
+++ b/kubernetes/apps/access-broker/configmap.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: access-broker
 data:
   HTTP_ADDR: ":8080"
-  PUBLIC_BASE_URL: "https://onboard.${cluster_domain}"
+  PUBLIC_BASE_URL: "https://onboard.petebeegle.com"
   AUTHENTIK_BASE_URL: "http://authentik-server.authentik.svc.cluster.local"
   WGEASY_BASE_URL: "http://wireguard-http.wireguard.svc.cluster.local:51821"
-  DATABASE_PATH: "/data/homelab-access.db"
+  ACCESS_STORE_PATH: "/data/homelab-access.json"
   DOWNLOAD_TOKEN_TTL: "15m"

--- a/kubernetes/apps/access-broker/httproute.yaml
+++ b/kubernetes/apps/access-broker/httproute.yaml
@@ -10,7 +10,7 @@ spec:
       namespace: gateway
       sectionName: http-gateway
   hostnames:
-    - onboard.${cluster_domain}
+    - onboard.petebeegle.com
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/access-broker/secret.yaml
+++ b/kubernetes/apps/access-broker/secret.yaml
@@ -5,23 +5,20 @@ metadata:
     namespace: access-broker
 type: Opaque
 stringData:
-    DISCORD_APP_ID: ENC[AES256_GCM,data:Z5Bqs44Jw+I8WQ==,iv:SBdHqQPR+n8a8zWPr0oPD3gZLRLNqSFG7spNM56dZW4=,tag:BGj3LXcIaE0lmHWkPrPXQw==,type:str]
-    DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:lzBcay0j+tvp9A==,iv:bXTSy3+ZL7yi+qKJdV8niw9xc2ZtuJQK11Gzim2pbIM=,tag:nihfdGnt002ePekc53ZYmA==,type:str]
-    DISCORD_BOT_TOKEN: ENC[AES256_GCM,data:HE0EGpBekN+uCw==,iv:CC2Evm3s254hqavW3cL/LDlNisECJWxbCPYzED0BlIA=,tag:ZImRuWF6yrl22YX/SXjFeA==,type:str]
-    AUTHENTIK_TOKEN: ENC[AES256_GCM,data:TQWlcS9j2X9Q2Q==,iv:T0onIHePCxwFJrBjEmc8GYii+hX05dP4wKxsuPDlMac=,tag:ar7auHk1JQfiBEZeTXtgIQ==,type:str]
-    WGEASY_PASSWORD: ENC[AES256_GCM,data:6pweEfyCFehm7w==,iv:Cy+cOF7f+ukF4h3/mQRfg8iCI6vZzk92RjGMy2dKRXc=,tag:2t7QNk1J2qu1XMPsMtZtgQ==,type:str]
+    DISCORD_APP_ID: ENC[AES256_GCM,data:DLbJDLjT3FjruMtkfuPP/bZmFw==,iv:vUZZ5PWSW8xicAVOAyhbWviV2JLi6Ro2bpznWNsnfO8=,tag:3HI5xKbCwJ2PQSzzA/b0Iw==,type:str]
+    DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:GmWEKQ3MJjRba/bJwTo+pFWY9n5A8mZF5aVzziIIGiFETKlo8CX1RuzklHZfEsPnyql6XgpzcCq4CPyUiY0AeQ==,iv:+k3shLq+zuJ74gN7h8fRprGShHfhaHyyxKzJFH8u+L0=,tag:nfxEOl1wIjyVhb/REDXw/A==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwL3JScDIxcnArbndoU1ho
-            ZlVyZHdKVS9rN0dzWWR6ZkkyWkZCMmQ5OGw0CjdaWlpZellpRUhlQ3FYSy9nOTVS
-            ZmIzRWlIdkZBR2VWVS9XdEVLcXhMNkUKLS0tIHNnQm8zNmJFbTI5SGwvaW1mb3NP
-            Mk5FdnVBckZ3UnRoeUJtajhaZVRoWXcK/JbAnJtKbagRZPSoT1OylkaR3avsT9ol
-            Yc3g1sTZjoYf6BZVA6l4QDxJGVJF+DYtdziW5Q69rTcer+0az57Qsg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiRk12Rm1xdTVqRzhNL3lR
+            Y21EaWZ2eGRsdGJGVTYxT2twTnFDdU5IM3lnCklEemVMcDBKOUk1UU1KaEMrZWtp
+            ZlRXQnhQNHNVaGtxVmd3T3dmOS85YkEKLS0tIG5ZbDEvUU9lS0ZPZ3Nsb1hPMnFH
+            a3hMTFdwbFhBZVJ0TU5XVnY3N0pMQVkKP1+QyWPfQBHevW+tAt7fnwCpJeWt+xYF
+            UsbWNDplzwTWkTeQOiQ7YxAB7lmNosLHIlcrON1i/ZQAcNTVIY+AlA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-04T18:51:22Z"
-    mac: ENC[AES256_GCM,data:CKUT58tKfcRGVh68Qnm8hp4xi9oOzriPSwkkMyBh+Qs1qGRHKFw1oBQzIGhoumBL4QwQDROgezRoseaID6X5xy5W25OVuvEg7voVUEj8qnx05/AE/JcnzEM1vhxf7zmv6wNTMaAeHdfECSEIra6H1W0/ETuuH/2DE9Q820qfqmo=,iv:r6SWR3PlhEc1u0nAcSZnOE/kbKMo5kY5LBbycnQtIn8=,tag:zmRCAF1B9pdhJAZaVJNJeA==,type:str]
+    lastmodified: "2026-07-04T19:20:39Z"
+    mac: ENC[AES256_GCM,data:AyVweCaTh5JYDtXN8d261q9aDBriRDIaoD8v6K+hf6FIkCjRNpA74JX66KltxKCMk47hgmOPaDxRv4UduAv3MkegB9xtwdzmSJE547QeDLIE0q6LoHWdfp0JGCwv32jKItki+LV4u/vU65YMDSexL+nj9oy6nx+rgYiF95/EL8g=,iv:80O4HcyGQ3+lwfKJkBJBRCusohkONbI1ZEhoSODYRK4=,tag:rG11BVHfDi7fjMx6UejtUQ==,type:str]
     version: 3.13.0

--- a/kubernetes/apps/cloudflare-tunnels/deployment.yaml
+++ b/kubernetes/apps/cloudflare-tunnels/deployment.yaml
@@ -123,5 +123,7 @@ data:
     # Public hostnames enter the cluster through gateway/public, then route by HTTPRoute.
     - hostname: foundry.petebeegle.com
       service: http://cilium-gateway-public.gateway.svc.cluster.local:80
+    - hostname: onboard.petebeegle.com
+      service: http://cilium-gateway-public.gateway.svc.cluster.local:80
     # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
     - service: http_status:404

--- a/kubernetes/clusters/production/apps/access-broker.yaml
+++ b/kubernetes/clusters/production/apps/access-broker.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-access-broker
+  namespace: flux-system
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./kubernetes/apps/access-broker
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: gateway
+    - name: nfs-csi
+    - name: app-cloudflare-tunnels
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/kubernetes/clusters/production/apps/kustomization.yaml
+++ b/kubernetes/clusters/production/apps/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - foundryvtt.yaml
   - valheim.yaml
   - synthetics.yaml
+  - access-broker.yaml
   - private

--- a/specs/access-broker-manual-smoke/evidence.md
+++ b/specs/access-broker-manual-smoke/evidence.md
@@ -1,0 +1,81 @@
+# Evidence: access-broker-manual-smoke
+
+**Branch**: `codex/access-broker-manual-smoke`
+**Risk Tier**: high
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: manual artifact creation from repo templates.
+- Outcome: PASS
+- Spec Kit version: existing repo installation
+- Integration: Codex
+- Fallback: default `/workspaces/homelab-worktrees` path unavailable; used `/home/vscode/homelab-worktrees/access-broker-manual-smoke`.
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed with no output. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/apps/access-broker` | PASS | Render assertion confirmed `onboard.petebeegle.com`, SOPS-encrypted Secret, `nfs-csi-storage`, `ACCESS_STORE_PATH=/data/homelab-access.json`, and no `Ingress`. |
+| `kubectl kustomize kubernetes/apps/cloudflare-tunnels` | PASS | Render assertion confirmed Cloudflare ingress for `onboard.petebeegle.com` to `cilium-gateway-public.gateway.svc.cluster.local:80`. |
+| `kubectl kustomize kubernetes/clusters/production` | PASS | Render assertion confirmed `app-access-broker`, path `./kubernetes/apps/access-broker`, and dependency on `app-cloudflare-tunnels`. |
+| `python3 tools/architecture/render.py --check` | PASS | Initial check reported stale generated docs; `python3 tools/architecture/render.py --write` refreshed `docs/architecture.md`; rerun passed. |
+| `rg -n "1523044601429102622\|784726fdbeaf7ad0d59cfdc84ee34c09a322893c59df4b261f4db655461928dd\|replace-me" kubernetes/apps/access-broker/secret.yaml; test $? -eq 1` | PASS | No plaintext Discord app identity or placeholders in encrypted Secret. |
+| `rg -n "kind: Ingress" kubernetes/apps/access-broker kubernetes/apps/cloudflare-tunnels kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1` | PASS | No Kubernetes `Ingress` added. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| `https://onboard.petebeegle.com/discord/interactions` | Manual Discord Developer Portal PING | PENDING | Run after app readiness and homelab activation PRs are merged and Flux applies them. |
+| Discord `#test` `/access request` | Manual Discord command | PENDING | Run after endpoint validates and slash command is registered. |
+
+## Deployment State
+
+- Source fetched SHA: pending
+- Target applied SHA: pending
+- Live resource spec checked: pending
+- Gateway/listener/DNS/certificate checked: pending
+- Exact user-facing URL result: pending
+
+## Development Validation
+
+- Profile: none
+- Branch slug: access-broker-manual-smoke
+- HEAD: pending
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Development cluster omits Cloudflare Tunnel and cannot receive public Discord webhook validation; substitute checks are render, SOPS, route, architecture, and PR checks.
+
+## Documentation Impact
+
+- Updated: SDD artifacts.
+- Generated docs: `docs/architecture.md` refreshed for active production app and public hostname.
+- No-docs rationale: Manual smoke instructions will be provided in PR/final handoff; durable runbook is deferred until approval/provisioning behavior exists.
+
+## SDD Conformance
+
+- Local sources checked: Spec Kit and implementation runbooks plus binding ADRs listed in spec.
+- Upstream Spec Kit sources checked: N/A; no workflow/template changes.
+- Spec -> Plan -> Tasks -> Implement alignment: PASS. The spec defines the manual smoke behavior, the plan records the production-smoke exception, tasks trace to requirements, and evidence records local checks.
+- Artifact updates after implementation: PASS. Tasks and evidence updated after render and validation checks.
+
+## Exceptions And Follow-Ups
+
+- Exception: production manual smoke is required for Discord public webhook validation.
+- Dependency: merge `homelab-access` PR `https://github.com/petebeegle/homelab-access/pull/4` before merging this homelab activation so `ghcr.io/petebeegle/homelab-access:main` has readiness behavior for the current smoke scope.
+- Pull request: `https://github.com/petebeegle/homelab/pull/350`
+- Follow-up: add channel allowlist after the Discord test channel ID is known.
+- Follow-up: add command registration helper or bot-token based registration workflow.
+
+## Final State
+
+- Final branch: codex/access-broker-manual-smoke
+- Final HEAD: verify with `git rev-parse HEAD`
+- Commit: local commit created; verify with `git rev-parse HEAD`

--- a/specs/access-broker-manual-smoke/plan.md
+++ b/specs/access-broker-manual-smoke/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: access-broker-manual-smoke
+
+**Branch**: `codex/access-broker-manual-smoke` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-manual-smoke/spec.md`
+
+**Input**: Feature specification from
+`specs/access-broker-manual-smoke/spec.md`
+
+## Summary
+
+Activate access-broker in production for a narrow Discord manual smoke: public
+Cloudflare ingress, Gateway HTTPRoute, SOPS-protected Discord app identity, and
+PVC-backed request storage. The app still only handles signed Discord PING and
+`/access request`.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Kubernetes, Flux, Gateway API, Cloudflare Tunnel, SOPS,
+storage
+**Dependencies**: `homelab-access` readiness PR, Flux, kubectl/kustomize, SOPS,
+architecture renderer
+**Storage**: `nfs-csi-storage`
+**Ingress**: Cloudflare Tunnel to `gateway/public` and app `HTTPRoute`
+**Secrets**: SOPS-encrypted `kubernetes/apps/access-broker/secret.yaml`
+**Smoke Strategy**: manual production Discord smoke after merge
+**Fanout Targets**: app readiness, manifest render, SOPS/secret scan,
+Cloudflare route scan
+**Development Validation**: none with documented exception because development
+does not run Cloudflare Tunnel or receive public Discord webhooks
+**Post-Implementation SDD Conformance**: local workflow docs reviewed
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation without exception; Cloudflare/Discord public
+      smoke cannot be represented in development and is recorded.
+- [x] Gateway API invariant preserved; no Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; Discord identity is in encrypted `secret.yaml`.
+- [x] NFS default considered for PVC-backed workload.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/access-broker-manual-smoke`; fallback worktree recorded.
+- [x] Documentation impact identified; generated architecture checked/updated.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+```text
+specs/access-broker-manual-smoke/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+```text
+kubernetes/apps/access-broker/
+kubernetes/apps/cloudflare-tunnels/deployment.yaml
+kubernetes/clusters/production/apps/access-broker.yaml
+kubernetes/clusters/production/apps/kustomization.yaml
+docs/architecture.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: App readiness behavior is covered in `homelab-access`;
+homelab changes are validated with render, SOPS, and route checks.
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/apps/cloudflare-tunnels`
+- `kubectl kustomize kubernetes/clusters/production`
+- `python3 tools/architecture/render.py --check`
+- Secret placeholder scan for `access-broker`
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+
+**Development smoke**: None. Development cluster omits Cloudflare Tunnel and
+cannot receive Discord public webhook validation.
+
+**Completion evidence**: Record local checks, PRs, and manual smoke instructions
+for Discord Developer Portal and `#test`.
+
+**Fanout plan**: Manifest edits, app readiness PR, and validation can proceed
+independently; evidence consolidates results.
+
+**Evidence destination**: `specs/access-broker-manual-smoke/evidence.md`.
+
+## Documentation Impact
+
+Generated `docs/architecture.md` must be refreshed if the active production
+Kustomization inventory changes.
+
+## Implementation Steps
+
+1. Update `homelab-access` readiness so current smoke does not require future
+   Authentik/wg-easy/bot-token settings.
+2. Configure access-broker hostname, store path, and encrypted Discord identity.
+3. Add Cloudflare Tunnel ingress and production Flux activation.
+4. Run local render/secret/architecture checks.
+5. Publish PRs and provide manual smoke instructions.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Public route exposed before provisioning is complete | Only `/discord/interactions` and placeholder `/download/` route; app only creates local pending requests |
+| Pod not Ready because future credentials are absent | App readiness PR requires only implemented Discord fields |
+| Discord command unavailable | User must register `/access request`; provide command guidance |
+| Cloudflare DNS missing | Record as manual smoke prerequisite |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| Production manual smoke before development smoke | Discord must reach public Cloudflare ingress; development cluster intentionally omits it | Local-only render cannot validate Discord endpoint URL |

--- a/specs/access-broker-manual-smoke/spec.md
+++ b/specs/access-broker-manual-smoke/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: access-broker-manual-smoke
+
+**Feature Branch**: `codex/access-broker-manual-smoke`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: high
+**Input**: User wants to manually smoke test the Discord app in server `#test`.
+
+## Summary
+
+Activate the access broker's current Discord request-intake behavior behind a
+public Cloudflare hostname so Discord can validate the Interactions Endpoint URL
+and the user can run `/access request` manually.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/flux-gitops-source-of-truth.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/sops-age-secrets.md`
+- `docs/decisions/synology-nfs-storage.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+
+## Scope
+
+### In Scope
+
+- Configure access-broker for `https://onboard.petebeegle.com`.
+- Add Discord app ID/public key to the SOPS-encrypted Secret.
+- Add Cloudflare Tunnel ingress for `onboard.petebeegle.com`.
+- Activate `app-access-broker` in production Flux for manual smoke.
+
+### Out Of Scope
+
+- Discord bot token and outbound Discord API calls.
+- Admin approval workflow.
+- Authentik account provisioning.
+- wg-easy peer creation.
+- Channel allowlisting for `#test`.
+
+## User Scenarios & Testing
+
+### User Story 1 - Discord Endpoint Validation (Priority: P1)
+
+As the operator, I can set the Discord Interactions Endpoint URL to the broker
+and have Discord validate the endpoint.
+
+**Why this priority**: Discord must validate the endpoint before any slash
+command smoke can work through the public webhook path.
+
+**Independent Test**: After Flux applies the PR, set the endpoint to
+`https://onboard.petebeegle.com/discord/interactions` in the Discord Developer
+Portal and confirm Discord accepts it.
+
+**Acceptance Scenarios**:
+
+1. **Given** the app is deployed and routed publicly, **When** Discord sends a
+   signed PING interaction, **Then** the broker validates the signature and
+   returns PONG.
+
+### User Story 2 - Manual Request In `#test` (Priority: P2)
+
+As the operator, I can run `/access request` in Discord `#test` and receive an
+ephemeral request ID.
+
+**Why this priority**: This proves the request intake path reaches the app and
+persists a pending request.
+
+**Independent Test**: Run `/access request` in `#test`.
+
+**Acceptance Scenarios**:
+
+1. **Given** the slash command exists and is run in `#test`, **When** the broker
+   receives the signed interaction, **Then** it persists or reuses a pending
+   request and replies with an ephemeral request ID.
+
+## Requirements
+
+- **FR-001**: The public endpoint MUST be
+  `https://onboard.petebeegle.com/discord/interactions`.
+- **FR-002**: Cloudflare Tunnel MUST route `onboard.petebeegle.com` to
+  `gateway/public`.
+- **FR-003**: The access broker HTTPRoute MUST attach to Gateway
+  `gateway/public`, section `http-gateway`.
+- **FR-004**: Discord app ID and public key MUST be stored only in SOPS-encrypted
+  `secret.yaml`.
+- **FR-005**: The broker MUST use `nfs-csi-storage` for request persistence.
+- **FR-006**: Evidence MUST distinguish local render checks from manual Discord
+  smoke.
+
+## Risk And Validation Expectations
+
+This is high risk because it activates a public routed authentication-adjacent
+endpoint. Development cannot fully validate Cloudflare-to-Discord behavior
+because the development cluster intentionally omits Cloudflare Tunnel. Required
+substitute checks are render, SOPS, route, activation, and generated
+architecture checks before manual production smoke.
+
+## Success Criteria
+
+- **SC-001**: `kubectl kustomize kubernetes/apps/access-broker` renders with
+  `onboard.petebeegle.com`, encrypted Secret data, `nfs-csi-storage`, and no
+  Kubernetes Ingress.
+- **SC-002**: `kubectl kustomize kubernetes/apps/cloudflare-tunnels` renders a
+  Cloudflare ingress rule for `onboard.petebeegle.com`.
+- **SC-003**: Production app activation renders `app-access-broker`.
+- **SC-004**: Manual smoke is ready for the Discord Developer Portal endpoint
+  URL and `/access request` in `#test`.
+
+## Assumptions
+
+- The user will create or has created DNS/Cloudflare routing for
+  `onboard.petebeegle.com` to the existing Cloudflare Tunnel if needed.
+- `homelab-access:main` includes the readiness change before this homelab PR is
+  merged.
+
+## Open Questions
+
+- None

--- a/specs/access-broker-manual-smoke/tasks.md
+++ b/specs/access-broker-manual-smoke/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: access-broker-manual-smoke
+
+**Input**: `specs/access-broker-manual-smoke/spec.md` and
+`specs/access-broker-manual-smoke/plan.md`
+**Risk Tier**: high
+**Prerequisites**: Branch `codex/access-broker-manual-smoke` and matching
+`specs/access-broker-manual-smoke/` artifacts.
+
+## Phase 1: Spec And Plan
+
+- [x] T001 [FR-SPEC] Create `specs/access-broker-manual-smoke/spec.md`.
+- [x] T002 [FR-PLAN] Create `specs/access-broker-manual-smoke/plan.md`.
+- [x] T003 [FR-DOCS] Confirm architecture/doc impact.
+
+## Phase 2: Implementation
+
+- [x] T004 [FR-001,FR-003] Configure access-broker hostname and HTTPRoute.
+- [x] T005 [FR-004] Add Discord app identity and SOPS-encrypt access-broker Secret.
+- [x] T006 [FR-002] Add Cloudflare Tunnel ingress for `onboard.petebeegle.com`.
+- [x] T007 [FR-005] Activate production Flux Kustomization for access-broker.
+- [x] T008 [FR-IMPL] Re-check constitution gates after edits.
+
+## Phase 3: Verification
+
+- [x] T009 [FR-TEST] Run access-broker render/assertions.
+- [x] T010 [FR-TEST] Run cloudflare-tunnels render/assertions.
+- [x] T011 [FR-TEST] Run production cluster render.
+- [x] T012 [FR-TEST] Run architecture check/update.
+- [x] T013 [FR-TEST] Run secret and Ingress scans.
+- [x] T014 [FR-TEST] Run SDD context validator.
+- [x] T015 [FR-SMOKE] Record development-smoke exception and manual production smoke handoff.
+- [x] T016 [FR-EVIDENCE] Record evidence in `specs/access-broker-manual-smoke/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [x] T017 [FR-PR] Commit homelab changes.
+- [x] T018 [FR-PR] Push branch and open PR.


### PR DESCRIPTION
## Summary

Activates the access broker for a narrow manual Discord smoke path.

## Changes

- Configures access-broker for `https://onboard.petebeegle.com`.
- Stores the Discord app ID/public key in SOPS-encrypted `kubernetes/apps/access-broker/secret.yaml`.
- Adds Cloudflare Tunnel ingress for `onboard.petebeegle.com` to the public Gateway.
- Adds production Flux activation for `app-access-broker` with dependencies on `gateway`, `nfs-csi`, and `app-cloudflare-tunnels`.
- Refreshes generated architecture and adds Spec Kit artifacts under `specs/access-broker-manual-smoke/`.

## Validation

- `kubectl kustomize kubernetes/apps/access-broker`
- `kubectl kustomize kubernetes/apps/cloudflare-tunnels`
- `kubectl kustomize kubernetes/clusters/production`
- `python3 tools/architecture/render.py --check`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- Secret plaintext scan for the Discord app identity
- Ingress scan confirming no Kubernetes `Ingress`
- Commit hooks passed, including `yamllint`, `k8svalidate`, and generated architecture check

## Manual smoke after merge

1. Merge `homelab-access` readiness PR first: https://github.com/petebeegle/homelab-access/pull/4
2. Wait for `ghcr.io/petebeegle/homelab-access:main` to publish.
3. Merge this PR and wait for Flux to apply `app-access-broker` and `app-cloudflare-tunnels`.
4. Ensure Cloudflare DNS routes `onboard.petebeegle.com` to the existing tunnel.
5. In Discord Developer Portal, set Interactions Endpoint URL to `https://onboard.petebeegle.com/discord/interactions`.
6. Register or sync `/access request` for the test guild.
7. Run `/access request` in `#test`; expected response is an ephemeral request ID.

## Notes

This exposes only the current request-intake behavior. It does not provision Authentik users, create VPN configs, notify admins, or restrict to `#test` yet.
