### PR TITLE
[codex] add human-gated SDD flow

### DIFF
--- a/.specify/templates/evidence-template.md
+++ b/.specify/templates/evidence-template.md
@@ -12,6 +12,18 @@
 - Integration:
 - Fallback:
 
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | [PASS/FAIL/SKIP] | [human-provided outcome, constraints, acceptance] |
+| Spec approval | [PASS/FAIL/PENDING] | [approver/context] |
+| Clarify | [PASS/SKIP] | [summary or skipped-gate rationale] |
+| Plan approval | [PASS/FAIL/PENDING] | [approver/context] |
+| Checklist | [PASS/SKIP] | [checklist path/summary or skipped-gate rationale] |
+| Tasks/analyze approval | [PASS/FAIL/PENDING] | [analyze result or skipped-analyze rationale] |
+| Converge | [PASS/SKIP] | [converge result or skipped-converge rationale] |
+
 ## Workflow Validation
 
 | Command | Result | Notes |
@@ -57,7 +69,7 @@
 
 - Local sources checked:
 - Upstream Spec Kit sources checked:
-- Spec -> Plan -> Tasks -> Implement alignment:
+- Human-gated Spec Kit alignment:
 - Artifact updates after implementation:
 
 ## Exceptions And Follow-Ups

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -26,6 +26,17 @@ none with reason]
 **Post-Implementation SDD Conformance**: [local docs only, upstream Spec Kit
 review required, or N/A]
 
+## Human Gates
+
+**Spec Gate**: [approved by <who/context> before planning, or pending]
+
+**Checklist Status**: [run with checklist path/summary | skipped with rationale]
+
+**Plan Gate**: [pending human approval | approved by <who/context> | rejected]
+
+**Expected Task/Analyze Gate**: [tasks plus analyze required before
+implementation | skipped/analyze exception allowed with rationale]
+
 ## Constitution Check
 
 *GATE: Must pass before tracked edits and be re-checked before commit.*

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -6,6 +6,15 @@
 **Risk Tier**: [tiny|low|medium|high]
 **Input**: User description: "$ARGUMENTS"
 
+## Human Gate Status
+
+**Intent Brief**: [Outcome, affected users/systems, constraints, non-goals,
+risks, and acceptance signals supplied by the human.]
+
+**Clarify Status**: [run with summary | skipped with rationale]
+
+**Spec Gate**: [pending human approval | approved by <who/context> | rejected]
+
 ## Summary
 
 [State the intended operator/user outcome in plain language. Avoid implementation

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -8,7 +8,16 @@ description: "Homelab SDD task list template"
 `specs/[IMPLEMENTATION]/plan.md`
 **Risk Tier**: [tiny|low|medium|high]
 **Prerequisites**: Branch `codex/[IMPLEMENTATION]` and matching
-`specs/[IMPLEMENTATION]/` artifacts.
+`specs/[IMPLEMENTATION]/` artifacts. `spec.md` and `plan.md` are approved
+inputs to this task list, not implementation tasks.
+
+## Human Gate Status
+
+**Spec Gate**: [approved by <who/context>]
+
+**Plan Gate**: [approved by <who/context>]
+
+**Analyze Requirement**: [run before implementation | skipped with rationale]
 
 ## Format: `[ID] [P?] [Req] Description`
 
@@ -20,34 +29,37 @@ description: "Homelab SDD task list template"
 - Keep fanout coordinated through this task list and consolidate all results
   into `specs/[IMPLEMENTATION]/evidence.md`.
 
-## Phase 1: Spec And Plan
+## Phase 1: Setup
 
-- [ ] T001 [FR-SPEC] Create or update `specs/[IMPLEMENTATION]/spec.md`.
-- [ ] T002 [FR-PLAN] Create or update `specs/[IMPLEMENTATION]/plan.md`,
-      including tiered TDD and development validation expectations.
-- [ ] T003 [FR-DOCS] Confirm documentation impact and generated architecture
+- [ ] T001 [FR-SETUP] Confirm branch, approved spec/plan, and documentation
       expectations.
+- [ ] T002 [FR-SETUP] Prepare any required local fixtures, generated inputs, or
+      test harness state.
 
 ## Phase 2: Implementation
 
+- [ ] T003 [P] [FR-IMPL] Edit [path].
 - [ ] T004 [P] [FR-IMPL] Edit [path].
-- [ ] T005 [P] [FR-IMPL] Edit [path].
-- [ ] T006 [FR-IMPL] Re-check constitution gates after implementation edits.
+- [ ] T005 [FR-IMPL] Re-check constitution gates after implementation edits.
 
 ## Phase 3: Verification
 
+- [ ] T006 [FR-ANALYZE] Run Spec Kit analyze before implementation, or record
+      skipped-analyze rationale in evidence for lightweight work.
 - [ ] T007 [FR-TEST] Run [focused local command].
 - [ ] T008 [FR-TEST] Run [broader local command].
 - [ ] T009 [FR-SMOKE] Run development smoke validation or record why the tier
       does not require it.
-- [ ] T010 [FR-EVIDENCE] Record command outcomes, SHAs, URLs when applicable,
+- [ ] T010 [FR-CONVERGE] Run Spec Kit converge after implementation, or record
+      skipped-converge rationale in evidence.
+- [ ] T011 [FR-EVIDENCE] Record command outcomes, human gate status, SHAs, URLs when applicable,
       smoke evidence, skipped checks, exceptions, final live verification, and
       final `HEAD` in `specs/[IMPLEMENTATION]/evidence.md`.
 
 ## Phase 4: Commit And PR
 
-- [ ] T011 [FR-PR] Commit with a conventional commit message.
-- [ ] T012 [FR-PR] Push branch `codex/[IMPLEMENTATION]` and open a PR.
+- [ ] T012 [FR-PR] Commit with a conventional commit message.
+- [ ] T013 [FR-PR] Push branch `codex/[IMPLEMENTATION]` and open a PR.
 
 ## Tier Guidance
 

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,10 +1,10 @@
 schema_version: "1.0"
 workflow:
   id: "speckit"
-  name: "Full SDD Cycle"
+  name: "Human-Gated SDD Cycle"
   version: "1.0.0"
   author: "GitHub"
-  description: "Runs specify → plan → tasks → implement with review gates"
+  description: "Runs specify → clarify → plan → checklist → tasks → analyze → implement → converge with review gates"
 
 requires:
   # 0.8.5 is the first release with engine-side resolution of the
@@ -12,13 +12,12 @@ requires:
   # as a literal integration key and fail at dispatch.
   speckit_version: ">=0.8.5"
   integrations:
-    # The four commands below (specify, plan, tasks, implement) are core
-    # spec-kit commands provided by every integration. The list here is an
-    # advisory, non-exhaustive compatibility hint following the documented
-    # ``any: [...]`` schema -- it is NOT a closed set. The workflow runs
-    # against any integration the project was initialized with, including
-    # ones not listed below, as long as that integration provides the four
-    # core commands referenced in ``steps``.
+    # The commands below follow the upstream production SDD path. The list here
+    # is an advisory, non-exhaustive compatibility hint following the documented
+    # ``any: [...]`` schema -- it is NOT a closed set. The workflow runs against
+    # any integration the project was initialized with, including ones not
+    # listed below, as long as that integration provides the commands
+    # referenced in ``steps``.
     any:
       - "claude"
       - "copilot"
@@ -46,9 +45,15 @@ steps:
     input:
       args: "{{ inputs.spec }}"
 
+  - id: clarify
+    command: speckit.clarify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
   - id: review-spec
     type: gate
-    message: "Review the generated spec before planning."
+    message: "Review the generated spec and clarifications before planning."
     options: [approve, reject]
     on_reject: abort
 
@@ -58,9 +63,15 @@ steps:
     input:
       args: "{{ inputs.spec }}"
 
+  - id: checklist
+    command: speckit.checklist
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
   - id: review-plan
     type: gate
-    message: "Review the plan before generating tasks."
+    message: "Review the plan and checklist before generating tasks."
     options: [approve, reject]
     on_reject: abort
 
@@ -70,8 +81,32 @@ steps:
     input:
       args: "{{ inputs.spec }}"
 
+  - id: analyze
+    command: speckit.analyze
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-tasks-analysis
+    type: gate
+    message: "Review tasks and analysis before implementation."
+    options: [approve, reject]
+    on_reject: abort
+
   - id: implement
     command: speckit.implement
     integration: "{{ inputs.integration }}"
     input:
       args: "{{ inputs.spec }}"
+
+  - id: converge
+    command: speckit.converge
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-converge
+    type: gate
+    message: "Review converge results and final evidence before PR handoff."
+    options: [approve, reject]
+    on_reject: abort

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,12 @@ Synology NFS, Grafana/Loki/Mimir/Alloy.
   `/workspaces/homelab-worktrees/<implementation>` on branch
   `codex/<implementation>`. Use the current checkout only when explicitly
   requested; sibling clones are an allowed fallback.
-- Run the Spec Kit cycle: specify, plan, tasks, then implement.
+- Treat SDD as a human decision workflow. Humans own intent, constraints, and
+  acceptance; agents draft artifacts and stop for the spec, plan, and
+  task/analysis gates before implementation unless a lightweight exception is
+  recorded.
+- For meaningful work, run the full Spec Kit cycle: specify, clarify, plan,
+  checklist, tasks, analyze, implement, then converge.
 - In `plan.md`, declare SDD tier, workflow risk tier, smoke strategy, fanout
   targets, and exceptions before implementation edits.
 - In `tasks.md`, mark independent non-conflicting fanout work with `[P]`;

--- a/docs/runbooks/implementation-workflow.md
+++ b/docs/runbooks/implementation-workflow.md
@@ -31,8 +31,12 @@ Use this runbook for every repository code change. The binding decision is
    `.codex/tmp/implementation-secrets/<implementation>/` in the main checkout,
    preserving repo-relative paths and never logging contents. Install staged
    files into the worktree or clone before commands that need them.
-4. Run the Spec Kit cycle in the implementation worktree or checkout:
-   `specify -> plan -> tasks -> implement`.
+4. Run the Spec Kit cycle in the implementation worktree or checkout as a
+   human decision workflow. For meaningful work, use:
+   `specify -> clarify -> human spec approval -> plan -> checklist -> human plan approval -> tasks -> analyze -> human implementation approval -> implement -> converge`.
+   Tiny wording-only changes and obvious low-risk local edits may skip selected
+   quality gates only when the skipped `clarify`, `checklist`, `analyze`, or
+   `converge` step and rationale are recorded in evidence.
 5. Keep durable implementation context in `specs/<implementation>/`:
    `spec.md`, `plan.md`, `tasks.md`, and `evidence.md`.
 6. In `plan.md`, declare the SDD tier, workflow risk tier, smoke strategy,
@@ -63,6 +67,27 @@ The local workflow guard enforces the branch and artifact contract:
 
 Local owner attestations, verifier attestations, delegation token files, and
 exact-`HEAD` verifier approval files are no longer part of the workflow.
+Human approval gates are recorded in SDD artifacts and PR review evidence; the
+local guard intentionally does not add hard blockers for those gates.
+
+## Human Gate Sequence
+
+Humans provide intent, constraints, and acceptance. Agents draft artifacts and
+pause when a decision changes the next phase of work:
+
+- **Spec gate**: After `specify` and any needed `clarify`, confirm the desired
+  behavior, non-goals, affected systems, edge cases, and acceptance criteria.
+- **Plan gate**: After `plan` and any useful `checklist`, confirm the technical
+  approach, blast radius, validation strategy, rollback/exception handling, and
+  fit with binding ADRs.
+- **Task/analyze gate**: After `tasks` and `analyze`, confirm the work is
+  ordered, testable, traceable to requirements, and small enough to implement.
+- **Converge/evidence gate**: After implementation, run `converge` or record a
+  skipped-converge exception, update artifacts for discoveries, and record final
+  evidence before PR handoff.
+
+For `tiny` and clear `low` changes, a single human approval may cover multiple
+gates. The evidence must still state which quality gates were skipped and why.
 
 ## Prompt Catch
 
@@ -183,6 +208,8 @@ precise status words such as `rendered`, `pushed`, `merged`, `fetched by Flux`,
 
 Before requesting PR review, audit:
 
+- Human gate evidence records spec, plan, task/analysis, and converge status or
+  explicit skipped-gate exceptions.
 - The plan declares the intended TDD and development validation expectations for
   the risk tier.
 - Skipped tests, missing smoke profiles, unavailable infrastructure, or other

--- a/docs/runbooks/spec-driven-development.md
+++ b/docs/runbooks/spec-driven-development.md
@@ -70,20 +70,58 @@ Each implementation owns:
 Runtime files under `.codex/tmp/` are ignored and are not durable
 documentation. Durable implementation context belongs in `specs/<implementation>/`.
 
+## Human Decision Workflow
+
+Treat SDD as a staged decision workflow, not as post-implementation
+documentation. Humans own intent, constraints, and acceptance. Agents draft the
+formal artifacts, surface ambiguity, and pause at gates before moving from
+"what" to "how" to "do."
+
+Start from a problem brief rather than a human-written implementation plan:
+
+- desired outcome and why it matters;
+- affected users, systems, clusters, or operators;
+- constraints, invariants, non-goals, and risks;
+- acceptance signals that would make the change obviously correct;
+- repo context, ADRs, runbooks, incidents, or links the agent should read.
+
+For meaningful work, use these gates:
+
+1. **Intent brief**: Human supplies outcome, constraints, risks, and context.
+2. **Spec gate**: Agent runs `specify` and, when ambiguity matters, `clarify`;
+   human approves the desired behavior before planning.
+3. **Plan gate**: Agent runs `plan` and, when useful, `checklist`; human approves
+   the technical approach before tasks.
+4. **Task/analyze gate**: Agent runs `tasks` and `analyze`; human approves that
+   the work is small enough, ordered, and testable before implementation.
+5. **Implementation**: Agent implements against approved artifacts.
+6. **Converge/evidence**: Agent runs `converge` or records why it is not needed,
+   updates artifacts for discoveries, and writes final evidence.
+
+Tiny wording-only changes and obvious low-risk local edits may skip selected
+gates, but the skipped `clarify`, `checklist`, `analyze`, or `converge` step and
+rationale must be recorded in `evidence.md`. Silent skipped gates should be
+treated as missing SDD, not lightweight SDD.
+
 ## Upstream Conformance
 
-Homelab follows the upstream Spec Kit phase order: Spec -> Plan -> Tasks ->
-Implement. Upstream Spec Kit documentation is useful for process checks and
-tooling updates, but repo-local sources remain binding when they are stricter:
-`AGENTS.md`, this runbook, `docs/runbooks/implementation-workflow.md`, binding
-ADRs, and harness validators.
+Homelab follows the upstream Spec Kit production path for meaningful work:
+Constitution -> Specify -> Clarify -> Plan -> Checklist -> Tasks -> Analyze ->
+Implement -> Converge. Upstream Spec Kit documentation is useful for process
+checks and tooling updates, but repo-local sources remain binding when they are
+stricter: `AGENTS.md`, this runbook,
+`docs/runbooks/implementation-workflow.md`, binding ADRs, and harness
+validators.
 
 After implementation, evidence should include a short SDD conformance check
 against both local workflow sources and upstream Spec Kit guidance when the
 change alters agent workflow, Spec Kit templates, or implementation standards.
 The check should confirm that the spec defines behavior before implementation,
-the plan records technical approach and constraints, tasks are actionable, and
-implementation evidence is reconciled back into the artifact set.
+clarifications or skipped clarifications are recorded, the plan records
+technical approach and constraints, checklist or skipped-checklist rationale is
+recorded, tasks are actionable, analyze ran before implementation or was
+explicitly skipped, and implementation evidence is reconciled back into the
+artifact set through converge or a recorded converge exception.
 
 ## Enforced Guard Behavior
 
@@ -138,16 +176,21 @@ risk tier in `plan.md` when needed.
 2. Create or reuse the default worktree:
    `/workspaces/homelab-worktrees/<implementation>` on branch
    `codex/<implementation>`.
-3. Create `specs/<implementation>/spec.md` from
+3. Capture the human intent brief and create `specs/<implementation>/spec.md` from
    `.specify/templates/spec-template.md`.
-4. Create `specs/<implementation>/plan.md` from
-   `.specify/templates/plan-template.md`.
-5. Create `specs/<implementation>/tasks.md` from
-   `.specify/templates/tasks-template.md`.
-6. Create `specs/<implementation>/evidence.md` from
+4. Run `clarify` for meaningful ambiguity, or record why it is skipped; stop for
+   human spec approval.
+5. Create `specs/<implementation>/plan.md` from
+   `.specify/templates/plan-template.md`, run checklist when useful, and stop
+   for human plan approval.
+6. Create `specs/<implementation>/tasks.md` from
+   `.specify/templates/tasks-template.md`, run `analyze`, and stop for human
+   task/analysis approval before implementation.
+7. Create `specs/<implementation>/evidence.md` from
    `.specify/templates/evidence-template.md`.
-7. Implement the change in the worktree or explicitly selected checkout.
-8. Record command outcomes, development validation, exceptions, final `HEAD`,
+8. Implement the change in the worktree or explicitly selected checkout.
+9. Run `converge` or record why it is skipped.
+10. Record command outcomes, development validation, exceptions, final `HEAD`,
    and documentation impact in `evidence.md`.
 
 ## Development Validation
@@ -190,6 +233,9 @@ one implementation, one branch, one `specs/<implementation>/`, one PR contract.
 ## Review Checklist
 
 - The spec links relevant binding ADRs and runbooks.
+- Human gate status is recorded for spec, plan, and task/analysis checkpoints.
+- Skipped `clarify`, `checklist`, `analyze`, or `converge` steps have explicit
+  evidence exceptions.
 - The plan declares SDD tier, workflow tier when needed, tests, smoke
   expectations, fanout targets, docs impact, and risks.
 - Tasks are concrete enough for an implementation owner to execute.

--- a/specs/sdd-human-gated-speckit-flow/evidence.md
+++ b/specs/sdd-human-gated-speckit-flow/evidence.md
@@ -1,0 +1,112 @@
+# Evidence: sdd-human-gated-speckit-flow
+
+**Branch**: `codex/sdd-human-gated-speckit-flow`
+**Risk Tier**: low
+**Started**: 2026-07-04
+
+## Spec Kit Initialization
+
+- Command: Manual artifact bootstrap from repo templates and approved plan
+- Outcome: PASS
+- Spec Kit version: Existing repo scaffolding; no reinitialization performed
+- Integration: Existing Codex integration
+- Fallback: Used sibling worktree `/workspaces/homelab-ideas/sdd-human-gated-speckit-flow`
+  because `/workspaces/homelab-worktrees` is not writable
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | PASS | User supplied decision-complete repair plan. |
+| Spec approval | PASS | User explicitly requested implementation of the proposed plan. |
+| Clarify | SKIP | No open questions after approved plan; docs-and-evidence enforcement selected. |
+| Plan approval | PASS | User supplied approved implementation plan. |
+| Checklist | SKIP | Low-risk docs/template change; targeted content checks substitute. |
+| Tasks/analyze approval | PASS | Tasks trace to approved plan; analyze represented by targeted validation below. |
+| Converge | SKIP | Low-risk docs/template change; artifact alignment checked manually and by targeted validation. |
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Required spec, plan, and tasks exist for `sdd-human-gated-speckit-flow`. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Final SDD context and evidence validation passed. |
+| `SPECIFY_FEATURE_DIRECTORY=specs/sdd-human-gated-speckit-flow .specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | PASS | Resolved this implementation's feature directory and `tasks.md`. |
+| `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` | PASS/WARN | Exited 0 but resolved repo-pinned `.specify/feature.json` to `specs/access-broker-manual-smoke`; explicit `SPECIFY_FEATURE_DIRECTORY` is needed for this worktree. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture is unchanged. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `rg -n "clarify|checklist|analyze|converge|human gate" docs AGENTS.md .specify/templates .specify/workflows && ! rg -n "Spec And Plan" .specify/templates/tasks-template.md` | PASS | Human-gate and full Spec Kit terms are present; `Spec And Plan` no longer appears in the task template. |
+| `python3` workflow order check for `.specify/workflows/speckit/workflow.yml` | PASS | Verified order: specify, clarify, review-spec, plan, checklist, review-plan, tasks, analyze, review-tasks-analysis, implement, converge, review-converge. |
+| `python3` workflow YAML check with PyYAML | SKIP | PyYAML unavailable in this environment; no-dependency order check substituted. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| N/A | docs/template-only change | SKIP | No user-facing, routed, deployed, or operational runtime path. |
+
+## Deployment State
+
+- Source fetched SHA: N/A
+- Target applied SHA: N/A
+- Live resource spec checked: N/A
+- Gateway/listener/DNS/certificate checked: N/A
+- Exact user-facing URL result: N/A
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- Validation base commit: `61c214254024b1fad90da6dc4a2fc24b15da6334`
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: Docs/template-only change; no live cluster validation required.
+
+## Documentation Impact
+
+- Updated: `AGENTS.md`, `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`, `.specify/templates/*`,
+  `.specify/workflows/speckit/workflow.yml`
+- Generated docs: `python3 tools/architecture/render.py --check` passed; no
+  generated architecture update required.
+- No-docs rationale: N/A
+
+## SDD Conformance
+
+- Local sources checked: `AGENTS.md`,
+  `docs/runbooks/spec-driven-development.md`,
+  `docs/runbooks/implementation-workflow.md`,
+  `.specify/memory/constitution.md`
+- Upstream Spec Kit sources checked:
+  `https://github.github.com/spec-kit/quickstart.html`,
+  `https://github.com/github/spec-kit`
+- Human-gated Spec Kit alignment: PASS. Quickstart documents lean
+  `specify -> plan -> tasks -> implement` for experiments and the production or
+  ambiguous path `constitution -> specify -> clarify -> plan -> checklist ->
+  tasks -> analyze -> implement -> converge`; this implementation aligns
+  Homelab docs/templates to the production path while preserving explicit
+  lightweight exceptions.
+- Artifact updates after implementation: PASS. Spec, plan, tasks, and evidence
+  updated for this implementation.
+
+## Exceptions And Follow-Ups
+
+- Sibling worktree fallback used because `/workspaces/homelab-worktrees` is not
+  writable.
+- `.specify/feature.json` on `origin/main` points to
+  `specs/access-broker-manual-smoke`, so generic Spec Kit prerequisite checks
+  resolve that feature unless `SPECIFY_FEATURE_DIRECTORY` is set.
+
+## Final State
+
+- Final branch: `codex/sdd-human-gated-speckit-flow`
+- Validation base commit: `61c214254024b1fad90da6dc4a2fc24b15da6334`
+- Working tree: Uncommitted implementation changes in intended docs/templates
+  plus `specs/sdd-human-gated-speckit-flow/`; branch shows behind `origin/main`
+  by 1 because `origin/main` advanced after worktree creation.
+- Commit: See Git commit for this branch.

--- a/specs/sdd-human-gated-speckit-flow/plan.md
+++ b/specs/sdd-human-gated-speckit-flow/plan.md
@@ -1,0 +1,147 @@
+# Implementation Plan: sdd-human-gated-speckit-flow
+
+**Branch**: `codex/sdd-human-gated-speckit-flow` | **Date**: 2026-07-04 |
+**Spec**: `specs/sdd-human-gated-speckit-flow/spec.md`
+
+**Input**: Feature specification from
+`specs/sdd-human-gated-speckit-flow/spec.md`
+
+## Summary
+
+Repair Homelab's SDD workflow guidance so future meaningful changes are driven
+by human-approved intent artifacts before code. The implementation updates
+runbooks, templates, and workflow YAML to include clarify, checklist, analyze,
+and converge gates, while keeping enforcement lightweight through evidence.
+
+## Technical Context
+
+**Risk Tier**: low
+**Workflow Tier**: docs-only
+**Primary Areas**: documentation, Spec Kit templates, workflow metadata, agent guidance
+**Dependencies**: Git, Python local validators, upstream Spec Kit docs/repo review
+**Storage**: N/A
+**Ingress**: N/A
+**Secrets**: N/A
+**Smoke Strategy**: none; docs/template-only change with no live user path
+**Fanout Targets**: read-only validation and content inspection only
+**Development Validation**: none; no Kubernetes, Terraform, Flux, Gateway, app,
+storage, or secret behavior changes
+**Post-Implementation SDD Conformance**: upstream Spec Kit review required
+
+## Human Gates
+
+**Spec Gate**: Approved by user in the implementation prompt through the
+provided plan/spec intent. This implementation records the gate as satisfied by
+the explicit "PLEASE IMPLEMENT THIS PLAN" request.
+
+**Plan Gate**: Approved by user in the implementation prompt. No additional
+technical decision remains open.
+
+**Task/Analyze Gate**: This implementation is low-risk docs/template work.
+`analyze` is represented by targeted consistency checks and recorded in
+evidence instead of a hard blocker.
+
+**Skipped Gate Exceptions**: `clarify` and `checklist` are skipped for this
+implementation because the user supplied a decision-complete plan and selected
+docs-and-evidence enforcement in the prior planning turn.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation exception is
+      recorded because this is docs/template-only.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; not applicable.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/sdd-human-gated-speckit-flow`; sibling worktree fallback
+      is intentional because `/workspaces/homelab-worktrees` is not writable.
+- [x] Documentation impact identified; runbooks, templates, workflow YAML, and
+      agent guidance will be updated.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/sdd-human-gated-speckit-flow/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+AGENTS.md
+docs/runbooks/spec-driven-development.md
+docs/runbooks/implementation-workflow.md
+.specify/templates/spec-template.md
+.specify/templates/plan-template.md
+.specify/templates/tasks-template.md
+.specify/templates/evidence-template.md
+.specify/workflows/speckit/workflow.yml
+specs/sdd-human-gated-speckit-flow/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No failing-code test seam is appropriate for docs/template
+guidance. Validate with SDD context checks, generated architecture check,
+targeted content inspections, YAML review, and `git diff --check`.
+
+**Local checks**:
+
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
+- `python3 tools/architecture/render.py --check`
+- `git diff --check`
+- targeted `rg` checks for `clarify`, `checklist`, `analyze`, `converge`,
+  `human gate`, and absence of `Spec And Plan` in
+  `.specify/templates/tasks-template.md`
+
+**Development smoke**: none; docs/template-only change.
+
+**Automated smoke preference**: Not applicable to this change because there is
+no user-facing, routed, deployed, or operational runtime path.
+
+**Completion evidence**: Record validation outcomes, skipped gate exceptions,
+docs-only smoke exception, final branch, and final `HEAD`.
+
+**Fanout plan**: Validation checks may run independently after edits. Tracked
+edits stay sequential because several files describe the same workflow contract.
+
+**Evidence destination**:
+`specs/sdd-human-gated-speckit-flow/evidence.md`.
+
+## Documentation Impact
+
+Update workflow runbooks, top-level agent guidance, Spec Kit templates, and the
+Spec Kit workflow YAML. `docs/architecture.md` is not expected to change because
+no Kubernetes or Terraform source changes are made.
+
+## Implementation Steps
+
+1. Bootstrap SDD artifacts for this implementation.
+2. Update runbooks and AGENTS guidance to describe human-gated SDD.
+3. Update templates and workflow YAML to include full quality-gate sequence and
+   evidence fields.
+4. Run local validation and targeted content checks.
+5. Record evidence, review diff, commit, and prepare PR handoff.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Guidance becomes too ceremonial for tiny fixes | Preserve lightweight path with explicit skipped-gate exceptions. |
+| Workflow YAML references commands unavailable in some integrations | Keep commands aligned to upstream Spec Kit names and document repo-local evidence as the binding fallback. |
+| Templates become inconsistent with runbooks | Use targeted content checks and manual YAML/order inspection before handoff. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/sdd-human-gated-speckit-flow/spec.md
+++ b/specs/sdd-human-gated-speckit-flow/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: sdd-human-gated-speckit-flow
+
+**Feature Branch**: `codex/sdd-human-gated-speckit-flow`
+**Created**: 2026-07-04
+**Status**: Draft
+**Risk Tier**: low
+**Input**: User description: "Repair Homelab SDD Human Gates"
+
+## Summary
+
+Homelab's Spec Kit workflow must treat SDD as a human decision workflow, not a
+post-implementation documentation workflow. Future agents should draft and
+pause at spec, plan, and task/analysis gates before implementation, then
+reconcile evidence after implementation.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/decisions/codex-implementation-workflow.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- Upstream Spec Kit quickstart: `https://github.github.com/spec-kit/quickstart.html`
+- Upstream Spec Kit repository: `https://github.com/github/spec-kit`
+
+## Scope
+
+### In Scope
+
+- Define the normal meaningful-work SDD path as staged human gates:
+  intent brief, specify/clarify, spec approval, plan/checklist, plan approval,
+  tasks/analyze, implementation approval, implement, converge, evidence.
+- Preserve lightweight handling for `tiny` and obvious `low` changes when
+  skipped gates are recorded as explicit exceptions.
+- Update runbooks, Spec Kit templates, workflow YAML, and concise agent guidance
+  for future implementations.
+- Record this implementation's docs-only validation and upstream conformance
+  evidence.
+
+### Out Of Scope
+
+- Adding hard local guard blockers for gate approval evidence.
+- Rewriting historical `specs/*` artifacts.
+- Changing Kubernetes, Terraform, Flux, Gateway, or application behavior.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Human Gates Precede Implementation (Priority: P1)
+
+As an implementation owner, I can see that meaningful Homelab changes must pass
+human review at spec, plan, and task/analysis checkpoints before implementation
+starts.
+
+**Why this priority**: It fixes the current implementation-shaped workflow and
+keeps future code review anchored to approved intent.
+
+**Independent Test**: Inspect the runbooks and workflow YAML for the sequence
+`specify`, `clarify`, spec gate, `plan`, `checklist`, plan gate, `tasks`,
+`analyze`, implementation gate, `implement`, `converge`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a normal medium-risk change, **When** an agent follows the runbook,
+   **Then** it stops for human spec, plan, and task/analysis approval before
+   implementation edits.
+
+### User Story 2 - Lightweight Work Has Explicit Exceptions (Priority: P1)
+
+As a reviewer, I can distinguish intentionally lightweight SDD from missing SDD
+gates.
+
+**Why this priority**: Tiny and obvious low-risk work should stay ergonomic
+without normalizing silent skipped quality gates.
+
+**Independent Test**: Inspect templates and evidence guidance for skipped
+`clarify`, `checklist`, `analyze`, or `converge` exception recording.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tiny wording-only change, **When** clarify or analyze is skipped,
+   **Then** evidence records the skipped gate and rationale.
+
+### User Story 3 - Tasks Are Implementation Tasks (Priority: P2)
+
+As an implementation agent, I get task lists that execute an approved plan
+instead of listing spec and plan creation as implementation tasks.
+
+**Why this priority**: Tasks should be the handoff after spec and plan gates,
+not a place to backfill those gates.
+
+**Independent Test**: Inspect `.specify/templates/tasks-template.md` and confirm
+there is no `Spec And Plan` task phase.
+
+**Acceptance Scenarios**:
+
+1. **Given** a generated `tasks.md`, **When** a reviewer reads it, **Then** the
+   prerequisites identify approved spec/plan inputs and tasks begin with setup
+   or implementation preparation.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: SDD runbooks MUST define SDD as a human decision workflow where
+  humans own intent, constraints, and acceptance.
+- **FR-002**: Workflow guidance MUST include `clarify`, `checklist`, `analyze`,
+  and `converge` in the normal meaningful-work path.
+- **FR-003**: Lightweight skipped gates MUST be recorded as explicit exceptions
+  in evidence.
+- **FR-004**: Spec, plan, tasks, and evidence templates MUST expose gate status
+  or gate evidence fields.
+- **FR-005**: The task template MUST remove the `Spec And Plan` phase and treat
+  spec/plan as prerequisites.
+- **FR-006**: The Spec Kit workflow YAML MUST model the full quality-gate
+  sequence and review gates.
+- **FR-007**: Evidence MUST record docs-only smoke exception, validation
+  commands, and upstream conformance review for this implementation.
+
+## Risk And Validation Expectations
+
+**Low**: This changes workflow documentation, templates, and local workflow
+metadata only. Run focused local checks and targeted content inspections. No
+development-cluster smoke is required because no live app or cluster behavior
+changes.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Runbooks describe human-gated SDD before implementation.
+- **SC-002**: Templates capture clarify/checklist/analyze/converge status or
+  exceptions.
+- **SC-003**: `tasks-template.md` no longer has a `Spec And Plan` task phase.
+- **SC-004**: Workflow YAML includes clarify, checklist, analyze, implement,
+  and converge in the intended order.
+
+## Assumptions
+
+- Use docs-and-evidence enforcement, not hard local blockers.
+- Keep the one implementation, one branch, one `specs/<implementation>/`, one
+  PR model.
+- Do not rewrite historical specs.
+- Sibling worktree fallback is acceptable because `/workspaces/homelab-worktrees`
+  is not writable in this environment.
+
+## Open Questions
+
+- None.

--- a/specs/sdd-human-gated-speckit-flow/tasks.md
+++ b/specs/sdd-human-gated-speckit-flow/tasks.md
@@ -1,0 +1,62 @@
+---
+description: "Repair Homelab SDD human gate workflow"
+---
+
+# Tasks: sdd-human-gated-speckit-flow
+
+**Input**: `specs/sdd-human-gated-speckit-flow/spec.md` and
+`specs/sdd-human-gated-speckit-flow/plan.md`
+**Risk Tier**: low
+**Prerequisites**: Branch `codex/sdd-human-gated-speckit-flow`, matching
+`specs/sdd-human-gated-speckit-flow/` artifacts, and user-approved plan.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel or fan out because it touches different files or
+  performs read-only validation and has no dependency on another incomplete
+  task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+- Consolidate results into
+  `specs/sdd-human-gated-speckit-flow/evidence.md`.
+
+## Phase 1: Documentation Contract
+
+- [X] T001 [FR-001,FR-002,US1] Update
+      `docs/runbooks/spec-driven-development.md` with human decision workflow,
+      gate sequence, lightweight exceptions, and upstream conformance guidance.
+- [X] T002 [FR-001,FR-002,US1] Update
+      `docs/runbooks/implementation-workflow.md` with the normal meaningful-work
+      SDD path and evidence expectations.
+- [X] T003 [FR-001,US1] Update `AGENTS.md` with concise human-gate guidance.
+
+## Phase 2: Templates And Workflow
+
+- [X] T004 [FR-004,US1,US2] Update
+      `.specify/templates/spec-template.md`,
+      `.specify/templates/plan-template.md`, and
+      `.specify/templates/evidence-template.md` with human gate and skipped-gate
+      evidence fields.
+- [X] T005 [FR-005,US3] Update `.specify/templates/tasks-template.md` so spec
+      and plan are prerequisites, not implementation tasks.
+- [X] T006 [FR-006,US1] Update `.specify/workflows/speckit/workflow.yml` with
+      clarify, checklist, analyze, implement, converge, and review gates.
+
+## Phase 3: Verification
+
+- [X] T007 [P] [FR-007] Run
+      `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`.
+- [X] T008 [P] [FR-007] Run `python3 tools/architecture/render.py --check`.
+- [X] T009 [P] [FR-007] Run `git diff --check`.
+- [X] T010 [P] [FR-007] Run targeted `rg` checks for `clarify`, `checklist`,
+      `analyze`, `converge`, `human gate`, and absence of `Spec And Plan` in
+      `.specify/templates/tasks-template.md`.
+- [X] T011 [FR-007] Manually inspect `.specify/workflows/speckit/workflow.yml`
+      order against upstream Spec Kit quickstart.
+
+## Phase 4: Evidence And Handoff
+
+- [X] T012 [FR-007] Record command outcomes, skipped gate exceptions, docs-only
+      smoke exception, upstream conformance review, final branch, and final
+      `HEAD` in `specs/sdd-human-gated-speckit-flow/evidence.md`.
+- [X] T013 [FR-007] Review `git diff --stat` and `git status --short`.


### PR DESCRIPTION
## Summary
- Treat Homelab SDD as a human decision workflow with explicit spec, plan, task/analyze, and converge gates.
- Add clarify/checklist/analyze/converge status and skipped-gate evidence fields to Spec Kit templates.
- Update the Spec Kit workflow YAML to model the full production gate sequence.

## Validation
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"`
- `python3 tools/architecture/render.py --check`
- `git diff --check HEAD~1..HEAD`
- targeted `rg` checks for clarify/checklist/analyze/converge/human gate and absence of `Spec And Plan` in `tasks-template.md`

## Notes
- Docs/template-only change; no live cluster smoke required.
- SDD evidence: `specs/sdd-human-gated-speckit-flow/evidence.md`.
