### PR TITLE
Wire access broker Discord OAuth callback

### DIFF
--- a/kubernetes/apps/access-broker/configmap.yaml
+++ b/kubernetes/apps/access-broker/configmap.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   HTTP_ADDR: ":8080"
   PUBLIC_BASE_URL: "https://onboard.petebeegle.com"
+  DISCORD_REDIRECT_URI: "https://onboard.petebeegle.com/oauth/callback"
   AUTHENTIK_BASE_URL: "http://authentik-server.authentik.svc.cluster.local"
   WGEASY_BASE_URL: "http://wireguard-http.wireguard.svc.cluster.local:51821"
   ACCESS_STORE_PATH: "/data/homelab-access.json"

--- a/kubernetes/apps/access-broker/deployment.yaml
+++ b/kubernetes/apps/access-broker/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: access-broker
       annotations:
+        homelab.petebeegle.com/restarted-for: "discord-oauth-callback-2026-07-04"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: /metrics

--- a/specs/access-broker-oauth-callback/evidence.md
+++ b/specs/access-broker-oauth-callback/evidence.md
@@ -1,0 +1,56 @@
+# Evidence: access-broker-oauth-callback
+
+**Branch**: `codex/access-broker-oauth-callback`
+**Date**: 2026-07-04
+
+## Context
+
+- `homelab-access` PR #5 merged and adds `GET /oauth/callback`.
+- Discord bot token checks showed the bot token is valid for app
+  `1523044601429102622`, but the bot is not in guild `1324020069222842378`.
+- Official Discord OAuth documentation requires `client_id:client_secret` or
+  form `client_secret` for authorization-code token exchange. The bot token
+  cannot replace the Client Secret.
+
+## Workflow Notes
+
+- Fallback worktree used:
+  `/home/vscode/homelab-worktrees/access-broker-oauth-callback`.
+- Default `/workspaces/homelab-worktrees` path was avoided based on prior
+  environment failures.
+- Clarify/checklist/analyze skipped because the user gave direct implementation
+  approval for a narrow manual-smoke unblock and the failing URL identified the
+  missing route.
+- Development validation exception: Discord production app install and redirect
+  URL are bound to `onboard.petebeegle.com`; development does not have an
+  equivalent registered app/client secret.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `docker run --rm -v "$PWD":/src -w /src golang:1.23 sh -c 'gofmt -w internal/config/config.go internal/server/server.go internal/server/server_test.go && go test ./...'` in `homelab-access` | PASS | Callback app tests passed before PR #5 merge. |
+| `gh pr merge 5 --squash --delete-branch` in `homelab-access` | PASS | Merged callback implementation into `petebeegle/homelab-access`. |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-render.yaml && rg -n "DISCORD_REDIRECT_URI\|restarted-for\|imagePullPolicy\|kind: Ingress" /tmp/access-broker-render.yaml \|\| true` | PASS | Render includes `DISCORD_REDIRECT_URI`, rollout annotation, and `imagePullPolicy: Always`; no rendered `Ingress` line appeared. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-render.yaml && rg -n "app-access-broker\|DISCORD_REDIRECT_URI\|discord-oauth-callback-2026-07-04" /tmp/production-render.yaml` | PASS | Production cluster render still includes `app-access-broker`; app package content is applied by Flux from its path. |
+| `(rg -n "kind: Ingress" kubernetes/apps/access-broker kubernetes/apps/cloudflare-tunnels kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1)` | PASS | No Kubernetes `Ingress` introduced. |
+| `(rg -n "1523044601429102622\|784726fdbeaf7ad0d59cfdc84ee34c09a322893c59df4b261f4db655461928dd\|MTUyMzA0\|GBtIrX\|DISCORD_CLIENT_SECRET" kubernetes/apps/access-broker; test $? -eq 1)` | PASS | No plaintext Discord app ID, public key, provided bot token prefix, or client-secret key was introduced in access-broker Kubernetes manifests. |
+
+## SDD Conformance
+
+- Spec, plan, tasks, and evidence artifacts exist under one implementation
+  directory.
+- Plan declares risk tier, workflow tier, smoke strategy, fanout target, and
+  development validation exception.
+- Converge skipped: the implementation is a two-line manifest follow-up with
+  no generated task drift after validation.
+
+## Final State
+
+- Final branch head is recorded by the GitHub PR after push.
+
+## Remaining Requirement
+
+`DISCORD_CLIENT_SECRET` is still required in `access-broker-secret` before the
+OAuth callback can exchange Discord's code successfully. This value cannot be
+derived from the bot token, public key, or app ID.

--- a/specs/access-broker-oauth-callback/plan.md
+++ b/specs/access-broker-oauth-callback/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: access-broker-oauth-callback
+
+**Branch**: `codex/access-broker-oauth-callback` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-oauth-callback/spec.md`
+
+**Input**: Feature specification from
+`specs/access-broker-oauth-callback/spec.md`
+
+## Summary
+
+Wire the production access-broker deployment to the Discord OAuth callback URL
+and force a Pod rollout so the merged `homelab-access` callback code is pulled
+from `ghcr.io/petebeegle/homelab-access:main`.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes app config, Flux GitOps, Discord OAuth smoke
+**Dependencies**: Flux, kubectl/kustomize, merged `homelab-access` PR #5
+**Storage**: Existing `nfs-csi-storage` PVC unchanged
+**Ingress**: Existing Gateway API HTTPRoute and Cloudflare Tunnel unchanged
+**Secrets**: Existing SOPS Secret unchanged; `DISCORD_CLIENT_SECRET` remains
+required and cannot be committed without the real secret value
+**Smoke Strategy**: Scriptable public URL smoke after deployment
+**Fanout Targets**: Render checks and live read-only verification can run
+independently after merge
+**Development Validation**: Exception. This is a production Discord application
+install callback tied to `onboard.petebeegle.com`; development lacks the app
+registration, client secret, and Discord redirect configuration.
+**Post-Implementation SDD Conformance**: Local workflow review recorded in
+evidence.
+
+## Human Gates
+
+**Spec Gate**: Approved by direct user implementation instruction.
+
+**Checklist Status**: Skipped; narrow urgent smoke unblock with clear acceptance.
+
+**Plan Gate**: Approved by direct user implementation instruction.
+
+**Expected Task/Analyze Gate**: Analyze skipped with rationale recorded in
+evidence; task list is short and traceable.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation exception recorded.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; unchanged.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/access-broker-oauth-callback`; fallback worktree path is
+      recorded.
+- [x] Documentation impact identified; existing access-broker docs/spec evidence
+      are sufficient.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/access-broker-oauth-callback/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/access-broker/configmap.yaml
+kubernetes/apps/access-broker/deployment.yaml
+specs/access-broker-oauth-callback/
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: No executable code in this repo. Validate by kustomize
+render assertions and post-merge live HTTP smoke.
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/clusters/production`
+- `rg -n "kind: Ingress" kubernetes/apps/access-broker`
+
+**Development smoke**: Exception as above.
+
+**Completion evidence**: Record PR merge SHA, Flux-applied SHA, live Deployment
+spec, and public `/oauth/callback` HTTP result.
+
+**Fanout plan**: Render validation and live status checks are independent and
+consolidated into `evidence.md`.
+
+**Evidence destination**:
+`specs/access-broker-oauth-callback/evidence.md`.
+
+## Documentation Impact
+
+No generated architecture change expected; app topology and routes are
+unchanged.
+
+## Implementation Steps
+
+1. Add `DISCORD_REDIRECT_URI` to the access-broker ConfigMap.
+2. Add a Pod-template rollout annotation for the OAuth callback rollout.
+3. Run render checks and record evidence.
+4. Commit, push, PR, merge, and verify Flux/live HTTP behavior.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Callback still cannot complete exchange without client secret | Record explicit remaining requirement and avoid committing fake secret data |
+| Mutable `:main` image is cached | Deployment already has `imagePullPolicy: Always`; Pod template annotation forces rollout |

--- a/specs/access-broker-oauth-callback/spec.md
+++ b/specs/access-broker-oauth-callback/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: access-broker-oauth-callback
+
+**Feature Branch**: `codex/access-broker-oauth-callback`
+**Created**: 2026-07-04
+**Status**: Approved for implementation
+**Risk Tier**: medium
+**Input**: User needs the deployed access broker to support Discord's OAuth
+code-grant redirect during manual smoke testing.
+
+## Human Gate Status
+
+**Intent Brief**: Complete the Discord install path for the production
+`onboard.petebeegle.com` access broker so a redirect to `/oauth/callback` does
+not 404 and the updated application image rolls through GitOps.
+
+**Clarify Status**: Skipped. The user provided direct implementation approval
+after the 404 and Discord `Missing Access` failure made the required route
+clear.
+
+**Spec Gate**: Approved by direct user instruction: "you fucking do it."
+
+## Summary
+
+The production access-broker deployment should explicitly configure the Discord
+OAuth redirect URI and roll the Pod template so the merged `homelab-access`
+callback implementation is pulled and served.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+
+## Scope
+
+### In Scope
+
+- Configure `DISCORD_REDIRECT_URI=https://onboard.petebeegle.com/oauth/callback`.
+- Force a durable Deployment rollout through a GitOps-owned Pod template change.
+- Record validation and the remaining client-secret requirement.
+
+### Out Of Scope
+
+- Committing plaintext Discord client secrets.
+- Completing Authentik or WireGuard provisioning.
+
+## User Scenarios & Testing
+
+### User Story 1 - Callback Route Is Served (Priority: P1)
+
+The operator installs the Discord app with a code-grant redirect and lands on
+the access broker instead of a generic 404.
+
+**Why this priority**: This unblocks the manual Discord smoke path.
+
+**Independent Test**: Render the access-broker manifests and verify the
+redirect URI and rollout annotation are present.
+
+**Acceptance Scenarios**:
+
+1. **Given** the access broker is deployed from GitOps, **When** Discord
+   redirects to `/oauth/callback`, **Then** the request reaches the access
+   broker callback handler.
+
+## Requirements
+
+- **FR-001**: The access-broker ConfigMap MUST set
+  `DISCORD_REDIRECT_URI=https://onboard.petebeegle.com/oauth/callback`.
+- **FR-002**: The Deployment Pod template MUST change so Flux rolls a fresh Pod
+  that pulls `ghcr.io/petebeegle/homelab-access:main`.
+- **FR-003**: The implementation MUST preserve Gateway API usage and avoid
+  Kubernetes `Ingress`.
+- **FR-004**: Evidence MUST record that Discord `DISCORD_CLIENT_SECRET` is still
+  required to complete the code exchange.
+
+## Risk And Validation Expectations
+
+Medium Kubernetes application configuration change. Run focused kustomize render
+checks and production post-merge verification; development validation is
+unavailable for this Discord production app/install path and must be recorded as
+an exception.
+
+## Success Criteria
+
+- **SC-001**: `kubectl kustomize kubernetes/apps/access-broker` renders the
+  redirect URI and rollout annotation.
+- **SC-002**: After merge and Flux apply, the live Deployment includes the new
+  config and `/oauth/callback` no longer returns the generic route 404.
+
+## Assumptions
+
+- `homelab-access` PR #5 is merged before this GitOps change is deployed.
+- The Discord Client Secret cannot be derived from the bot token or public key
+  and must come from the Developer Portal.
+
+## Open Questions
+
+- None for this PR. The operator still needs to provide `DISCORD_CLIENT_SECRET`
+  for a successful OAuth exchange.

--- a/specs/access-broker-oauth-callback/tasks.md
+++ b/specs/access-broker-oauth-callback/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: access-broker-oauth-callback
+
+**Input**: `specs/access-broker-oauth-callback/spec.md` and
+`specs/access-broker-oauth-callback/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Branch `codex/access-broker-oauth-callback` and matching
+Spec Kit artifacts.
+
+## Human Gate Status
+
+**Spec Gate**: Approved by direct user implementation instruction.
+
+**Plan Gate**: Approved by direct user implementation instruction.
+
+**Analyze Requirement**: Skipped with rationale recorded in evidence.
+
+## Phase 1: Setup
+
+- [x] T001 [FR-SETUP] Confirm branch, fallback worktree, and approved scope.
+- [x] T002 [FR-SETUP] Confirm `homelab-access` OAuth callback PR #5 is merged.
+
+## Phase 2: Implementation
+
+- [x] T003 [FR-001] Edit `kubernetes/apps/access-broker/configmap.yaml`.
+- [x] T004 [FR-002] Edit `kubernetes/apps/access-broker/deployment.yaml`.
+- [x] T005 [FR-003] Re-check constitution gates after implementation edits.
+
+## Phase 3: Verification
+
+- [x] T006 [FR-TEST] Run `kubectl kustomize kubernetes/apps/access-broker`.
+- [x] T007 [FR-TEST] Run `kubectl kustomize kubernetes/clusters/production`.
+- [x] T008 [FR-TEST] Run no-Ingress and plaintext-secret scans.
+- [x] T009 [FR-SMOKE] Record development validation exception.
+- [x] T010 [FR-CONVERGE] Record skipped-converge rationale.
+- [x] T011 [FR-EVIDENCE] Record command outcomes and final `HEAD`.
+
+## Phase 4: Commit And PR
+
+- [ ] T012 [FR-PR] Commit with a conventional commit message.
+- [ ] T013 [FR-PR] Push branch and open a PR.


### PR DESCRIPTION
## Summary
- set DISCORD_REDIRECT_URI for onboard.petebeegle.com/oauth/callback
- add a GitOps-owned pod-template annotation to roll access-broker after homelab-access PR #5
- record SDD evidence and the remaining DISCORD_CLIENT_SECRET requirement

## Validation
- kubectl kustomize kubernetes/apps/access-broker
- kubectl kustomize kubernetes/clusters/production
- no Kubernetes Ingress scan
- plaintext Discord token/secret scan on kubernetes/apps/access-broker

## Manual smoke note
The callback route is now implemented upstream, but a successful OAuth code exchange still requires DISCORD_CLIENT_SECRET in the access-broker SOPS Secret. Bot token alone cannot complete Discord's code-grant install while bot_require_code_grant=true.
