### PR TITLE
Route access broker OAuth callback

### DIFF
--- a/kubernetes/apps/access-broker/httproute.yaml
+++ b/kubernetes/apps/access-broker/httproute.yaml
@@ -19,6 +19,9 @@ spec:
         - path:
             type: Exact
             value: /discord/interactions
+        - path:
+            type: Exact
+            value: /oauth/callback
       backendRefs:
         - name: access-broker
           port: 80

--- a/specs/access-broker-oauth-route/evidence.md
+++ b/specs/access-broker-oauth-route/evidence.md
@@ -1,0 +1,34 @@
+# Evidence: access-broker-oauth-route
+
+**Branch**: `codex/access-broker-oauth-route`
+**Date**: 2026-07-04
+
+## Context
+
+- PR #353 deployed callback-capable access-broker config and rolled the pod.
+- Public smoke still returned Cloudflare 404 for `/oauth/callback`.
+- Live HTTPRoute inspection showed matches only for `/download/` and
+  `/discord/interactions`.
+
+## Workflow Notes
+
+- Fallback worktree:
+  `/home/vscode/homelab-worktrees/access-broker-oauth-route`.
+- Clarify/checklist/analyze skipped because this is a one-path route correction
+  discovered during live smoke.
+- Development validation exception: production Cloudflare hostname/Gateway path
+  is the tested surface.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-route-render.yaml && rg -n "/oauth/callback\|kind: Ingress" /tmp/access-broker-route-render.yaml \|\| true` | PASS | Render includes `/oauth/callback`; no rendered `Ingress` line appeared. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-route-render.yaml && rg -n "app-access-broker" /tmp/production-route-render.yaml` | PASS | Production render includes the access-broker Flux Kustomization. |
+| `(rg -n "kind: Ingress" kubernetes/apps/access-broker kubernetes/apps/cloudflare-tunnels kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1)` | PASS | No Kubernetes `Ingress` introduced. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Remaining Requirement
+
+After routing is fixed, `DISCORD_CLIENT_SECRET` is still required for a real
+Discord OAuth code exchange.

--- a/specs/access-broker-oauth-route/plan.md
+++ b/specs/access-broker-oauth-route/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: access-broker-oauth-route
+
+**Branch**: `codex/access-broker-oauth-route` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-oauth-route/spec.md`
+
+## Summary
+
+Add the missing Gateway API HTTPRoute match for `/oauth/callback` and verify the
+public path reaches access-broker.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes Gateway API, Flux GitOps
+**Dependencies**: Flux, kubectl/kustomize
+**Storage**: N/A
+**Ingress**: Gateway API HTTPRoute only
+**Secrets**: No secret changes
+**Smoke Strategy**: Scriptable public URL smoke
+**Fanout Targets**: Render and public smoke are independent after merge
+**Development Validation**: Exception; the failing path is production
+Cloudflare/Gateway routing for `onboard.petebeegle.com`.
+**Post-Implementation SDD Conformance**: Recorded in evidence.
+
+## Human Gates
+
+**Spec Gate**: Approved by ongoing user implementation instruction.
+**Checklist Status**: Skipped; one-path route fix.
+**Plan Gate**: Approved by ongoing user implementation instruction.
+**Expected Task/Analyze Gate**: Analyze skipped with evidence rationale.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved.
+- [x] Development validation exception recorded.
+- [x] Gateway API invariant preserved; no Kubernetes `Ingress`.
+- [x] SOPS invariant preserved; no secret edits.
+- [x] Branch/worktree mode recorded.
+
+## Project Structure
+
+```text
+specs/access-broker-oauth-route/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+
+kubernetes/apps/access-broker/httproute.yaml
+```
+
+## Tiered TDD And Validation Plan
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/clusters/production`
+- no-`Ingress` scan
+
+**Development smoke**: Exception; use production public URL smoke after merge.
+
+**Evidence destination**: `specs/access-broker-oauth-route/evidence.md`.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Public smoke still fails due stale Gateway status | Verify Flux apply and live HTTPRoute generation/status |

--- a/specs/access-broker-oauth-route/spec.md
+++ b/specs/access-broker-oauth-route/spec.md
@@ -1,0 +1,72 @@
+# Feature Specification: access-broker-oauth-route
+
+**Feature Branch**: `codex/access-broker-oauth-route`
+**Created**: 2026-07-04
+**Status**: Approved for implementation
+**Risk Tier**: medium
+**Input**: Public smoke showed `/oauth/callback` still returns Cloudflare 404
+because the access-broker HTTPRoute does not match that path.
+
+## Human Gate Status
+
+**Intent Brief**: Route Discord OAuth callback traffic for
+`onboard.petebeegle.com` to access-broker.
+
+**Clarify Status**: Skipped; live route inspection identified the missing match.
+
+**Spec Gate**: Approved by ongoing user instruction to do the implementation.
+
+## Summary
+
+Add `/oauth/callback` to the public access-broker HTTPRoute so Discord install
+redirects reach the broker callback handler.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+
+## Scope
+
+### In Scope
+
+- Add an exact `/oauth/callback` HTTPRoute match.
+- Validate render, no Ingress, Flux apply, and public callback behavior.
+
+### Out Of Scope
+
+- Adding `DISCORD_CLIENT_SECRET`; the real secret is still required separately.
+
+## User Scenarios & Testing
+
+### User Story 1 - OAuth Callback Reaches Broker (Priority: P1)
+
+**Independent Test**: Public curl to
+`https://onboard.petebeegle.com/oauth/callback?code=fake-code` returns the
+broker's configured-secret error rather than Cloudflare 404.
+
+**Acceptance Scenarios**:
+
+1. **Given** Discord redirects to `/oauth/callback`, **When** the request enters
+   Cloudflare Tunnel and Gateway, **Then** Cilium routes it to access-broker.
+
+## Requirements
+
+- **FR-001**: `access-broker-public` MUST route exact path `/oauth/callback`.
+- **FR-002**: The change MUST preserve Gateway API and avoid Kubernetes
+  `Ingress`.
+- **FR-003**: Evidence MUST record public URL behavior after merge.
+
+## Success Criteria
+
+- **SC-001**: Access-broker package render includes `/oauth/callback`.
+- **SC-002**: Public callback URL no longer returns Cloudflare 404.
+
+## Assumptions
+
+- PR #353 has already deployed the callback-capable application code.
+
+## Open Questions
+
+- None.

--- a/specs/access-broker-oauth-route/tasks.md
+++ b/specs/access-broker-oauth-route/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: access-broker-oauth-route
+
+**Input**: `specs/access-broker-oauth-route/spec.md` and
+`specs/access-broker-oauth-route/plan.md`
+**Risk Tier**: medium
+
+## Human Gate Status
+
+**Spec Gate**: Approved by ongoing user implementation instruction.
+**Plan Gate**: Approved by ongoing user implementation instruction.
+**Analyze Requirement**: Skipped with rationale in evidence.
+
+## Phase 1: Implementation
+
+- [x] T001 [FR-001] Add `/oauth/callback` to
+      `kubernetes/apps/access-broker/httproute.yaml`.
+- [x] T002 [FR-002] Confirm no Ingress or secret edits.
+
+## Phase 2: Verification
+
+- [x] T003 [FR-TEST] Run app render check.
+- [x] T004 [FR-TEST] Run production render check.
+- [ ] T005 [FR-SMOKE] Verify public callback behavior after merge.
+- [x] T006 [FR-EVIDENCE] Record command outcomes.
+
+## Phase 3: Commit And PR
+
+- [ ] T007 [FR-PR] Commit, push, open PR, and merge after checks.


### PR DESCRIPTION
## Summary
- add exact /oauth/callback match to access-broker public HTTPRoute
- keep Gateway API path, no Ingress or secret changes
- add focused SDD evidence for the route smoke fix

## Validation
- kubectl kustomize kubernetes/apps/access-broker
- kubectl kustomize kubernetes/clusters/production
- no Kubernetes Ingress scan
- git diff --check

## Manual smoke note
After this applies, /oauth/callback should reach access-broker. A real Discord code exchange still requires DISCORD_CLIENT_SECRET.
