### PR TITLE
Add access broker Discord client secret

### DIFF
--- a/kubernetes/apps/access-broker/secret.yaml
+++ b/kubernetes/apps/access-broker/secret.yaml
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
     DISCORD_APP_ID: ENC[AES256_GCM,data:DLbJDLjT3FjruMtkfuPP/bZmFw==,iv:vUZZ5PWSW8xicAVOAyhbWviV2JLi6Ro2bpznWNsnfO8=,tag:3HI5xKbCwJ2PQSzzA/b0Iw==,type:str]
     DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:GmWEKQ3MJjRba/bJwTo+pFWY9n5A8mZF5aVzziIIGiFETKlo8CX1RuzklHZfEsPnyql6XgpzcCq4CPyUiY0AeQ==,iv:+k3shLq+zuJ74gN7h8fRprGShHfhaHyyxKzJFH8u+L0=,tag:nfxEOl1wIjyVhb/REDXw/A==,type:str]
+    DISCORD_CLIENT_SECRET: ENC[AES256_GCM,data:wVbkThRfuhoNMvzFZE+9Wl16zeODszJghsltl9klhl8=,iv:INYS6j/7V5pU3OMuTLAVEOG8uTLci1swytKEaQJZkCk=,tag:qe/8u5Y1HSw/Q5PT6W/9rQ==,type:str]
 sops:
     age:
         - enc: |
@@ -19,6 +20,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-04T19:20:39Z"
-    mac: ENC[AES256_GCM,data:AyVweCaTh5JYDtXN8d261q9aDBriRDIaoD8v6K+hf6FIkCjRNpA74JX66KltxKCMk47hgmOPaDxRv4UduAv3MkegB9xtwdzmSJE547QeDLIE0q6LoHWdfp0JGCwv32jKItki+LV4u/vU65YMDSexL+nj9oy6nx+rgYiF95/EL8g=,iv:80O4HcyGQ3+lwfKJkBJBRCusohkONbI1ZEhoSODYRK4=,tag:rG11BVHfDi7fjMx6UejtUQ==,type:str]
+    lastmodified: "2026-07-04T20:27:24Z"
+    mac: ENC[AES256_GCM,data:tS4hbL/w5u5PfQFIFTWR7QbLM2Gnh1sF3TkAuoUF45GFFRqC+Hl4WsZ4odaUYZuIAapxYZLEexAZs8vPuHmQzNbBo3Ux6MCm2XKgwHp4eE7lC8ov9tNh6Mg/ETMPsOX864e0SAZzm3fb2+gXvjPzxkwRZNubhlmAjOpVmAqty0o=,iv:lZNG1BuDqLR3UKMz/dIxRldueRNjjIE8ZtCHBsDw/Mo=,tag:pdekyfmEqhBYjj3bwMyK1A==,type:str]
     version: 3.13.0

--- a/specs/access-broker-discord-client-secret/evidence.md
+++ b/specs/access-broker-discord-client-secret/evidence.md
@@ -1,0 +1,37 @@
+# Evidence: access-broker-discord-client-secret
+
+**Branch**: `codex/access-broker-discord-client-secret`
+**Date**: 2026-07-04
+
+## Context
+
+- Public `/oauth/callback` already routes to access-broker.
+- Latest smoke returns broker JSON error `discord client secret is not
+  configured`.
+- The user provided the Discord Client Secret out-of-band in chat.
+
+## Workflow Notes
+
+- Default worktree path `/workspaces/homelab-worktrees/...` failed with
+  permission denied.
+- Fallback worktree:
+  `/home/vscode/homelab-worktrees/access-broker-discord-client-secret`.
+- Clarify/checklist/analyze skipped because this is a focused SOPS secret
+  unblock with direct user approval.
+- Development validation exception: production Discord OAuth app and public
+  callback hostname are the tested integration.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `sops set --value-stdin kubernetes/apps/access-broker/secret.yaml '["stringData"]["DISCORD_CLIENT_SECRET"]'` | PASS | Added the provided value as SOPS-encrypted data. Initial PTY attempt echoed stdin and failed because SOPS expects JSON; successful run used a JSON string. |
+| `sops filestatus kubernetes/apps/access-broker/secret.yaml` | PASS | Reported `{"encrypted":true}`. |
+| `kubectl kustomize kubernetes/apps/access-broker >/tmp/access-broker-secret-render.yaml && rg -n 'DISCORD_CLIENT_SECRET\|kind: Ingress' /tmp/access-broker-secret-render.yaml \|\| true` | PASS | Render includes encrypted `DISCORD_CLIENT_SECRET`; no rendered `Ingress` line appeared. |
+| Plaintext scan for provided client secret across `kubernetes/apps/access-broker/secret.yaml` and `specs/access-broker-discord-client-secret` | PASS | No plaintext match found. |
+| `git diff -- kubernetes/apps/access-broker/secret.yaml` | PASS | Diff shows only encrypted `DISCORD_CLIENT_SECRET` plus SOPS metadata updates. |
+
+## Secret Handling
+
+- The secret value was added with SOPS and must not appear in plaintext in the
+  committed manifest or final answer.

--- a/specs/access-broker-discord-client-secret/plan.md
+++ b/specs/access-broker-discord-client-secret/plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan: access-broker-discord-client-secret
+
+**Branch**: `codex/access-broker-discord-client-secret` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-discord-client-secret/spec.md`
+
+## Summary
+
+Use `sops set --value-stdin` to add `DISCORD_CLIENT_SECRET` to the access-broker
+Secret, then validate that the committed manifest remains encrypted and deploy
+through Flux.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes Secret, SOPS, Flux GitOps
+**Dependencies**: SOPS, Flux, kubectl/kustomize
+**Storage**: N/A
+**Ingress**: Existing Gateway API unchanged
+**Secrets**: SOPS-encrypted `kubernetes/apps/access-broker/secret.yaml`
+**Smoke Strategy**: Scriptable public callback smoke after deployment
+**Fanout Targets**: Render and SOPS scans are independent
+**Development Validation**: Exception; production Discord OAuth app and callback
+hostname are the tested integration.
+**Post-Implementation SDD Conformance**: Recorded in evidence.
+
+## Human Gates
+
+**Spec Gate**: Approved by direct user instruction.
+**Checklist Status**: Skipped; focused secret unblock.
+**Plan Gate**: Approved by direct user instruction.
+**Expected Task/Analyze Gate**: Analyze skipped with evidence rationale.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved.
+- [x] Development validation exception recorded.
+- [x] Gateway API invariant unaffected.
+- [x] SOPS invariant preserved; no plaintext Secret committed.
+- [x] Branch/worktree mode recorded.
+
+## Project Structure
+
+```text
+specs/access-broker-discord-client-secret/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+
+kubernetes/apps/access-broker/secret.yaml
+```
+
+## Tiered TDD And Validation Plan
+
+**Local checks**:
+
+- `sops filestatus kubernetes/apps/access-broker/secret.yaml`
+- `kubectl kustomize kubernetes/apps/access-broker`
+- plaintext secret scan
+
+**Development smoke**: Exception; use production callback smoke after merge.
+
+**Evidence destination**:
+`specs/access-broker-discord-client-secret/evidence.md`.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Secret committed in plaintext | Use `sops set --value-stdin`; scan manifest before commit |

--- a/specs/access-broker-discord-client-secret/spec.md
+++ b/specs/access-broker-discord-client-secret/spec.md
@@ -1,0 +1,77 @@
+# Feature Specification: access-broker-discord-client-secret
+
+**Feature Branch**: `codex/access-broker-discord-client-secret`
+**Created**: 2026-07-04
+**Status**: Approved for implementation
+**Risk Tier**: medium
+**Input**: Add the Discord Client Secret to access-broker so manual OAuth smoke
+can complete.
+
+## Human Gate Status
+
+**Intent Brief**: Store the Discord Client Secret in the SOPS-encrypted
+access-broker Secret and deploy it through GitOps.
+
+**Clarify Status**: Skipped; the user provided the exact secret value and prior
+smoke proved this is the remaining blocker.
+
+**Spec Gate**: Approved by direct user instruction.
+
+## Summary
+
+Add `DISCORD_CLIENT_SECRET` to the access-broker SOPS Secret without committing
+plaintext secret material.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+
+## Scope
+
+### In Scope
+
+- Add encrypted `DISCORD_CLIENT_SECRET` to
+  `kubernetes/apps/access-broker/secret.yaml`.
+- Validate the manifest remains SOPS-encrypted.
+- Deploy via PR and Flux, then smoke the Discord callback path.
+
+### Out Of Scope
+
+- Changing app code, routes, Authentik provisioning, or WireGuard provisioning.
+
+## User Scenarios & Testing
+
+### User Story 1 - OAuth Code Exchange Can Run (Priority: P1)
+
+**Independent Test**: After Flux applies the secret, a Discord install redirect
+can reach `/oauth/callback` with `DISCORD_CLIENT_SECRET` present.
+
+**Acceptance Scenarios**:
+
+1. **Given** Discord redirects with an authorization code, **When** the callback
+   handler runs, **Then** it can authenticate to Discord's token endpoint using
+   the configured client secret.
+
+## Requirements
+
+- **FR-001**: `access-broker-secret` MUST include encrypted
+  `DISCORD_CLIENT_SECRET`.
+- **FR-002**: The secret value MUST NOT appear in plaintext in committed files.
+- **FR-003**: Evidence MUST record SOPS and render validation.
+
+## Success Criteria
+
+- **SC-001**: `sops filestatus kubernetes/apps/access-broker/secret.yaml`
+  reports encrypted.
+- **SC-002**: Secret manifest contains the `DISCORD_CLIENT_SECRET` key only as
+  encrypted SOPS data.
+
+## Assumptions
+
+- PR #354 has routed `/oauth/callback` to access-broker.
+
+## Open Questions
+
+- None.

--- a/specs/access-broker-discord-client-secret/tasks.md
+++ b/specs/access-broker-discord-client-secret/tasks.md
@@ -1,0 +1,28 @@
+# Tasks: access-broker-discord-client-secret
+
+**Input**: `specs/access-broker-discord-client-secret/spec.md` and
+`specs/access-broker-discord-client-secret/plan.md`
+**Risk Tier**: medium
+
+## Human Gate Status
+
+**Spec Gate**: Approved by direct user instruction.
+**Plan Gate**: Approved by direct user instruction.
+**Analyze Requirement**: Skipped with rationale in evidence.
+
+## Phase 1: Implementation
+
+- [x] T001 [FR-001] Add encrypted `DISCORD_CLIENT_SECRET` to
+      `kubernetes/apps/access-broker/secret.yaml`.
+- [x] T002 [FR-002] Confirm no plaintext secret is present.
+
+## Phase 2: Verification
+
+- [x] T003 [FR-TEST] Run SOPS file status check.
+- [x] T004 [FR-TEST] Run access-broker render check.
+- [ ] T005 [FR-SMOKE] Verify public callback behavior after merge.
+- [x] T006 [FR-EVIDENCE] Record command outcomes.
+
+## Phase 3: Commit And PR
+
+- [ ] T007 [FR-PR] Commit, push, open PR, and merge after checks.


### PR DESCRIPTION
## Summary
- add DISCORD_CLIENT_SECRET to the SOPS-encrypted access-broker Secret
- record focused SDD evidence for the secret unblock

## Validation
- sops filestatus kubernetes/apps/access-broker/secret.yaml
- kubectl kustomize kubernetes/apps/access-broker
- plaintext scan for the provided client secret
- pre-commit hooks via git commit

## Smoke note
After this applies, the Discord OAuth callback should be able to exchange a real authorization code. The previously pasted bot token and this client secret should be rotated after manual smoke if you want to eliminate chat-history exposure risk.
