### PR TITLE
Configure access broker review admins

### DIFF
--- a/kubernetes/apps/access-broker/configmap.yaml
+++ b/kubernetes/apps/access-broker/configmap.yaml
@@ -8,6 +8,7 @@ data:
   HTTP_ADDR: ":8080"
   PUBLIC_BASE_URL: "https://onboard.petebeegle.com"
   DISCORD_REDIRECT_URI: "https://onboard.petebeegle.com/oauth/callback"
+  DISCORD_ADMIN_USER_IDS: "252951660027052033"
   AUTHENTIK_BASE_URL: "http://authentik-server.authentik.svc.cluster.local"
   WGEASY_BASE_URL: "http://wireguard-http.wireguard.svc.cluster.local:51821"
   ACCESS_STORE_PATH: "/data/homelab-access.json"

--- a/kubernetes/apps/access-broker/deployment.yaml
+++ b/kubernetes/apps/access-broker/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: access-broker
       annotations:
-        homelab.petebeegle.com/restarted-for: "discord-oauth-callback-2026-07-04"
+        homelab.petebeegle.com/restarted-for: "discord-review-admins-2026-07-04"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: /metrics

--- a/specs/access-broker-review-admins/evidence.md
+++ b/specs/access-broker-review-admins/evidence.md
@@ -1,0 +1,29 @@
+# Evidence: access-broker-review-admins
+
+**Branch**: `codex/access-broker-review-admins`
+**Date**: 2026-07-04
+
+## Context
+
+- `homelab-access` PR #7 adds server-side review admin allowlisting.
+- The successful `/access request` smoke identified Discord user
+  `252951660027052033` as the initial admin user.
+
+## Workflow Notes
+
+- Default worktree path `/workspaces/homelab-worktrees/...` failed with
+  permission denied.
+- Fallback worktree:
+  `/home/vscode/homelab-worktrees/access-broker-review-admins`.
+- Clarify/checklist/analyze skipped because this is a narrow config rollout for
+  already-merged app behavior.
+- Development validation exception: production Discord guild/app is required.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-review-admins-render.yaml && rg -n 'DISCORD_ADMIN_USER_IDS\|discord-review-admins\|kind: Ingress' /tmp/access-broker-review-admins-render.yaml \|\| true` | PASS | Render includes admin user ID and rollout annotation; no rendered `Ingress` line appeared. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-review-admins-render.yaml && rg -n 'app-access-broker' /tmp/production-review-admins-render.yaml` | PASS | Production render includes the access-broker Flux Kustomization. |
+| `(rg -n 'kind: Ingress' kubernetes/apps/access-broker kubernetes/apps/cloudflare-tunnels kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1)` | PASS | No Kubernetes `Ingress` introduced. |
+| `git diff --check` | PASS | No whitespace errors. |

--- a/specs/access-broker-review-admins/plan.md
+++ b/specs/access-broker-review-admins/plan.md
@@ -1,0 +1,70 @@
+# Implementation Plan: access-broker-review-admins
+
+**Branch**: `codex/access-broker-review-admins` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-review-admins/spec.md`
+
+## Summary
+
+Add `DISCORD_ADMIN_USER_IDS` to the access-broker ConfigMap and update the
+Deployment rollout annotation to load the new image/config.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes app config, Flux GitOps
+**Dependencies**: Flux, kubectl/kustomize, homelab-access PR #7
+**Storage**: Existing PVC unchanged
+**Ingress**: Existing Gateway API unchanged
+**Secrets**: No secret change; Discord user ID is not secret
+**Smoke Strategy**: Manual Discord command smoke after deploy
+**Fanout Targets**: Render and live verification are independent after merge
+**Development Validation**: Exception; production Discord guild/app is the test
+surface.
+**Post-Implementation SDD Conformance**: Recorded in evidence.
+
+## Human Gates
+
+**Spec Gate**: Approved by ongoing user instruction.
+**Checklist Status**: Skipped; narrow config rollout.
+**Plan Gate**: Approved by ongoing user instruction.
+**Expected Task/Analyze Gate**: Analyze skipped with evidence rationale.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved.
+- [x] Development validation exception recorded.
+- [x] Gateway API invariant unaffected.
+- [x] SOPS invariant unaffected.
+- [x] Branch/worktree mode recorded.
+
+## Project Structure
+
+```text
+specs/access-broker-review-admins/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+
+kubernetes/apps/access-broker/configmap.yaml
+kubernetes/apps/access-broker/deployment.yaml
+```
+
+## Tiered TDD And Validation Plan
+
+**Local checks**:
+
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/clusters/production`
+- no-`Ingress` scan
+
+**Development smoke**: Exception; production Discord guild/app is required.
+
+**Evidence destination**: `specs/access-broker-review-admins/evidence.md`.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Mutable `main` image not updated at rollout time | Wait for homelab-access image CI before restarting pod |

--- a/specs/access-broker-review-admins/spec.md
+++ b/specs/access-broker-review-admins/spec.md
@@ -1,0 +1,62 @@
+# Feature Specification: access-broker-review-admins
+
+**Feature Branch**: `codex/access-broker-review-admins`
+**Created**: 2026-07-04
+**Status**: Approved for implementation
+**Risk Tier**: medium
+**Input**: Configure production access-broker so only approved Discord admins can
+approve or deny access requests.
+
+## Human Gate Status
+
+**Intent Brief**: Wire the new homelab-access admin allowlist config into the
+production access-broker deployment before continuing toward provisioning.
+
+**Clarify Status**: Skipped; the approved admin user ID is known from the
+successful Discord smoke request.
+
+**Spec Gate**: Approved by ongoing user instruction to continue implementation.
+
+## Summary
+
+Set `DISCORD_ADMIN_USER_IDS` for access-broker and roll the Pod template so the
+new app image and config are loaded.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+
+## Scope
+
+### In Scope
+
+- Configure Discord user ID `252951660027052033` as an access reviewer admin.
+- Force access-broker to repull the mutable `main` image after homelab-access
+  PR #7.
+
+### Out Of Scope
+
+- Authentik user creation and WireGuard provisioning.
+
+## Requirements
+
+- **FR-001**: `access-broker-config` MUST set `DISCORD_ADMIN_USER_IDS`.
+- **FR-002**: The Deployment Pod template MUST change to roll the workload.
+- **FR-003**: The change MUST preserve Gateway API and SOPS invariants.
+
+## Success Criteria
+
+- **SC-001**: Rendered access-broker manifests include the admin user ID and
+  rollout annotation.
+- **SC-002**: After merge, Flux applies the change and `/access approve` remains
+  usable for the configured admin.
+
+## Assumptions
+
+- Discord user ID `252951660027052033` is the intended initial access reviewer.
+
+## Open Questions
+
+- None.

--- a/specs/access-broker-review-admins/tasks.md
+++ b/specs/access-broker-review-admins/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: access-broker-review-admins
+
+**Input**: `specs/access-broker-review-admins/spec.md` and
+`specs/access-broker-review-admins/plan.md`
+**Risk Tier**: medium
+
+## Human Gate Status
+
+**Spec Gate**: Approved by ongoing user instruction.
+**Plan Gate**: Approved by ongoing user instruction.
+**Analyze Requirement**: Skipped with rationale in evidence.
+
+## Phase 1: Implementation
+
+- [x] T001 [FR-001] Add `DISCORD_ADMIN_USER_IDS` to
+      `kubernetes/apps/access-broker/configmap.yaml`.
+- [x] T002 [FR-002] Update rollout annotation in
+      `kubernetes/apps/access-broker/deployment.yaml`.
+
+## Phase 2: Verification
+
+- [x] T003 [FR-TEST] Run app render check.
+- [x] T004 [FR-TEST] Run production render check.
+- [x] T005 [FR-TEST] Run no-Ingress scan.
+- [ ] T006 [FR-SMOKE] Verify live deployment after merge.
+- [x] T007 [FR-EVIDENCE] Record command outcomes.
+
+## Phase 3: Commit And PR
+
+- [ ] T008 [FR-PR] Commit, push, open PR, and merge after checks.


### PR DESCRIPTION
## Summary
- set DISCORD_ADMIN_USER_IDS for access-broker
- update access-broker rollout annotation so the merged admin-allowlist app image/config is loaded
- record focused SDD evidence

## Validation
- kubectl kustomize kubernetes/apps/access-broker
- kubectl kustomize kubernetes/clusters/production
- no Kubernetes Ingress scan
- git diff --check
