### PR TITLE
Add access broker Authentik token

### DIFF
--- a/kubernetes/apps/access-broker/deployment.yaml
+++ b/kubernetes/apps/access-broker/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: access-broker
       annotations:
-        homelab.petebeegle.com/restarted-for: "discord-review-admins-2026-07-04"
+        homelab.petebeegle.com/restarted-for: "authentik-user-provisioning-2026-07-04"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: /metrics

--- a/kubernetes/apps/access-broker/secret.yaml
+++ b/kubernetes/apps/access-broker/secret.yaml
@@ -8,6 +8,7 @@ stringData:
     DISCORD_APP_ID: ENC[AES256_GCM,data:DLbJDLjT3FjruMtkfuPP/bZmFw==,iv:vUZZ5PWSW8xicAVOAyhbWviV2JLi6Ro2bpznWNsnfO8=,tag:3HI5xKbCwJ2PQSzzA/b0Iw==,type:str]
     DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:GmWEKQ3MJjRba/bJwTo+pFWY9n5A8mZF5aVzziIIGiFETKlo8CX1RuzklHZfEsPnyql6XgpzcCq4CPyUiY0AeQ==,iv:+k3shLq+zuJ74gN7h8fRprGShHfhaHyyxKzJFH8u+L0=,tag:nfxEOl1wIjyVhb/REDXw/A==,type:str]
     DISCORD_CLIENT_SECRET: ENC[AES256_GCM,data:wVbkThRfuhoNMvzFZE+9Wl16zeODszJghsltl9klhl8=,iv:INYS6j/7V5pU3OMuTLAVEOG8uTLci1swytKEaQJZkCk=,tag:qe/8u5Y1HSw/Q5PT6W/9rQ==,type:str]
+    AUTHENTIK_TOKEN: ENC[AES256_GCM,data:+BEHK6w/oxjsfkY7ojwTkbOPYi2/ZuXiWEfmyS0pxEiTk3FqR6QudpXrXuc=,iv:PrET7pREvNd7WgQQ4fcaCAKgNkY5NKYtq/nXB1tIRq8=,tag:MAU3TByHV13Fnbh8j5Vj8Q==,type:str]
 sops:
     age:
         - enc: |
@@ -20,6 +21,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-04T20:27:24Z"
-    mac: ENC[AES256_GCM,data:tS4hbL/w5u5PfQFIFTWR7QbLM2Gnh1sF3TkAuoUF45GFFRqC+Hl4WsZ4odaUYZuIAapxYZLEexAZs8vPuHmQzNbBo3Ux6MCm2XKgwHp4eE7lC8ov9tNh6Mg/ETMPsOX864e0SAZzm3fb2+gXvjPzxkwRZNubhlmAjOpVmAqty0o=,iv:lZNG1BuDqLR3UKMz/dIxRldueRNjjIE8ZtCHBsDw/Mo=,tag:pdekyfmEqhBYjj3bwMyK1A==,type:str]
+    lastmodified: "2026-07-04T21:56:11Z"
+    mac: ENC[AES256_GCM,data:5sFDwseTKa7/RfdbGJPRyy2mCLSOrDmSrUXsff6vanwVn6MZVuSgFWVRf4aDCnZlPupfMBqztj1AiB9K6EocnCAQieBAwXyVqlnsdMUZmcr6VFX6FmEmKikazkul3IJEy6+o8lFECQzl058TQ9x3A1XFcaD2fF6az7rHM1AWnaw=,iv:7jaWBI2CtmJwiXDLXpw7nljvrr7jU1SiqWlOAdOUnj4=,tag:XVK46tQ9MEVcCzJ1OUH1BA==,type:str]
     version: 3.13.0

--- a/specs/access-broker-authentik-token/evidence.md
+++ b/specs/access-broker-authentik-token/evidence.md
@@ -1,0 +1,38 @@
+# Evidence: access-broker-authentik-token
+
+**Branch**: `codex/access-broker-authentik-token`
+**Date**: 2026-07-04
+
+## Context
+
+- `homelab-access` PR #8 added Authentik user provisioning on approval.
+- Live access-broker config already has `AUTHENTIK_BASE_URL`, but its Secret did
+  not have `AUTHENTIK_TOKEN`.
+
+## Workflow Notes
+
+- Default worktree path `/workspaces/homelab-worktrees/...` failed with
+  permission denied.
+- Fallback worktree:
+  `/home/vscode/homelab-worktrees/access-broker-authentik-token`.
+- Clarify/checklist/analyze skipped because this is a focused secret/config
+  rollout for already-merged app behavior.
+- Development validation exception: production Discord/Authenik integration is
+  required.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `sops --decrypt --extract '["stringData"]["AUTHENTIK_BOOTSTRAP_TOKEN"]' kubernetes/infra/authentik/secret.yaml \| jq -Rsa . \| sops set --value-stdin kubernetes/apps/access-broker/secret.yaml '["stringData"]["AUTHENTIK_TOKEN"]'` | PASS | Copied the token between SOPS-managed files without printing the decrypted value. |
+| `sops filestatus kubernetes/apps/access-broker/secret.yaml` | PASS | Reported `{"encrypted":true}`. |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-authentik-token-render.yaml && rg -n 'AUTHENTIK_TOKEN\|authentik-user-provisioning\|kind: Ingress' /tmp/access-broker-authentik-token-render.yaml \|\| true` | PASS | Render includes encrypted `AUTHENTIK_TOKEN` and rollout annotation; no rendered `Ingress` line appeared. |
+| Plaintext scan for the copied token across `kubernetes/apps/access-broker/secret.yaml` and `specs/access-broker-authentik-token` | PASS | No plaintext match found. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-authentik-token-render.yaml && rg -n 'app-access-broker' /tmp/production-authentik-token-render.yaml` | PASS | Production render includes the access-broker Flux Kustomization. |
+| No-Ingress scan on access-broker/cloudflare tunnel manifests | PASS | No Kubernetes `Ingress` introduced. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Secret Handling
+
+- The token is copied between SOPS-encrypted files and must not appear in
+  plaintext in committed files or final output.

--- a/specs/access-broker-authentik-token/plan.md
+++ b/specs/access-broker-authentik-token/plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: access-broker-authentik-token
+
+**Branch**: `codex/access-broker-authentik-token` | **Date**: 2026-07-04 |
+**Spec**: `specs/access-broker-authentik-token/spec.md`
+
+## Summary
+
+Copy the existing Authentik bootstrap token into access-broker's SOPS Secret as
+`AUTHENTIK_TOKEN` and update the rollout annotation so the new app image/config
+is loaded.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes Secret, SOPS, Flux GitOps
+**Dependencies**: SOPS, Flux, kubectl/kustomize, homelab-access PR #8
+**Storage**: Existing PVC unchanged
+**Ingress**: Existing Gateway API unchanged
+**Secrets**: SOPS-encrypted `kubernetes/apps/access-broker/secret.yaml`
+**Smoke Strategy**: Manual Discord approve smoke after deploy
+**Fanout Targets**: SOPS/render scans are independent
+**Development Validation**: Exception; production Discord/Authenik integration
+is the tested surface.
+**Post-Implementation SDD Conformance**: Recorded in evidence.
+
+## Human Gates
+
+**Spec Gate**: Approved by ongoing user instruction.
+**Checklist Status**: Skipped; focused secret rollout.
+**Plan Gate**: Approved by ongoing user instruction.
+**Expected Task/Analyze Gate**: Analyze skipped with evidence rationale.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved.
+- [x] Development validation exception recorded.
+- [x] Gateway API invariant unaffected.
+- [x] SOPS invariant preserved; no plaintext secret committed.
+- [x] Branch/worktree mode recorded.
+
+## Project Structure
+
+```text
+specs/access-broker-authentik-token/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+
+kubernetes/apps/access-broker/secret.yaml
+kubernetes/apps/access-broker/deployment.yaml
+```
+
+## Tiered TDD And Validation Plan
+
+**Local checks**:
+
+- `sops filestatus kubernetes/apps/access-broker/secret.yaml`
+- `kubectl kustomize kubernetes/apps/access-broker`
+- plaintext token scan
+- no-`Ingress` scan
+
+**Development smoke**: Exception; production Discord/Authenik integration is
+required.
+
+**Evidence destination**: `specs/access-broker-authentik-token/evidence.md`.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Token committed in plaintext | Use `sops set --value-stdin`; scan before commit |
+| Mutable image rollout happens before image publish | Confirm `homelab-access:main` digest after app CI |

--- a/specs/access-broker-authentik-token/spec.md
+++ b/specs/access-broker-authentik-token/spec.md
@@ -1,0 +1,63 @@
+# Feature Specification: access-broker-authentik-token
+
+**Feature Branch**: `codex/access-broker-authentik-token`
+**Created**: 2026-07-04
+**Status**: Approved for implementation
+**Risk Tier**: medium
+**Input**: Wire access-broker with Authentik API credentials after
+homelab-access gained Authentik user provisioning on approval.
+
+## Human Gate Status
+
+**Intent Brief**: Let production access-broker call Authentik when an admin
+approves a Discord access request.
+
+**Clarify Status**: Skipped; the app behavior is merged and the missing runtime
+secret is known.
+
+**Spec Gate**: Approved by ongoing user instruction to continue implementation.
+
+## Summary
+
+Add `AUTHENTIK_TOKEN` to the SOPS-encrypted access-broker Secret by copying the
+existing Authentik bootstrap token, then roll access-broker so the new app image
+and token are loaded.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+
+## Scope
+
+### In Scope
+
+- Add encrypted `AUTHENTIK_TOKEN` to `access-broker-secret`.
+- Update access-broker rollout annotation.
+- Validate SOPS encryption and render output.
+
+### Out Of Scope
+
+- WireGuard peer/config provisioning.
+
+## Requirements
+
+- **FR-001**: `access-broker-secret` MUST include encrypted `AUTHENTIK_TOKEN`.
+- **FR-002**: The plaintext token MUST NOT be committed.
+- **FR-003**: The Deployment Pod template MUST change to roll the workload.
+
+## Success Criteria
+
+- **SC-001**: SOPS file status reports encrypted.
+- **SC-002**: Rendered access-broker manifests include encrypted
+  `AUTHENTIK_TOKEN` and the rollout annotation.
+
+## Assumptions
+
+- The existing Authentik bootstrap token is acceptable for this smoke-stage
+  provisioning integration.
+
+## Open Questions
+
+- None.

--- a/specs/access-broker-authentik-token/tasks.md
+++ b/specs/access-broker-authentik-token/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: access-broker-authentik-token
+
+**Input**: `specs/access-broker-authentik-token/spec.md` and
+`specs/access-broker-authentik-token/plan.md`
+**Risk Tier**: medium
+
+## Human Gate Status
+
+**Spec Gate**: Approved by ongoing user instruction.
+**Plan Gate**: Approved by ongoing user instruction.
+**Analyze Requirement**: Skipped with rationale in evidence.
+
+## Phase 1: Implementation
+
+- [x] T001 [FR-001] Add encrypted `AUTHENTIK_TOKEN` to
+      `kubernetes/apps/access-broker/secret.yaml`.
+- [x] T002 [FR-003] Update rollout annotation in
+      `kubernetes/apps/access-broker/deployment.yaml`.
+
+## Phase 2: Verification
+
+- [x] T003 [FR-TEST] Run SOPS file status check.
+- [x] T004 [FR-TEST] Run app render check.
+- [x] T005 [FR-TEST] Run plaintext token and no-Ingress scans.
+- [ ] T006 [FR-SMOKE] Verify live deployment after merge.
+- [x] T007 [FR-EVIDENCE] Record command outcomes.
+
+## Phase 3: Commit And PR
+
+- [ ] T008 [FR-PR] Commit, push, open PR, and merge after checks.


### PR DESCRIPTION
## Summary
- add encrypted AUTHENTIK_TOKEN to access-broker from the existing Authentik bootstrap token
- update access-broker rollout annotation for the Authentik provisioning app image/config
- record focused SDD evidence

## Validation
- sops filestatus kubernetes/apps/access-broker/secret.yaml
- kubectl kustomize kubernetes/apps/access-broker
- kubectl kustomize kubernetes/clusters/production
- plaintext token scan
- no Kubernetes Ingress scan
- git diff --check

## Notes
- This enables the homelab-access Authentik user provisioning merged in PR #8.
- WireGuard provisioning remains the next slice.
