### PR TITLE
feat: roll access broker WireGuard provisioning

### DIFF
--- a/kubernetes/apps/access-broker/configmap.yaml
+++ b/kubernetes/apps/access-broker/configmap.yaml
@@ -11,5 +11,6 @@ data:
   DISCORD_ADMIN_USER_IDS: "252951660027052033"
   AUTHENTIK_BASE_URL: "http://authentik-server.authentik.svc.cluster.local"
   WGEASY_BASE_URL: "http://wireguard-http.wireguard.svc.cluster.local:51821"
+  WGEASY_USERNAME: "admin"
   ACCESS_STORE_PATH: "/data/homelab-access.json"
   DOWNLOAD_TOKEN_TTL: "15m"

--- a/kubernetes/apps/access-broker/deployment.yaml
+++ b/kubernetes/apps/access-broker/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app.kubernetes.io/name: access-broker
       annotations:
-        homelab.petebeegle.com/restarted-for: "authentik-user-provisioning-2026-07-04"
+        homelab.petebeegle.com/restarted-for: "wgeasy-provisioning-2026-07-17"
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: /metrics

--- a/specs/access-broker-wgeasy-provisioning/evidence.md
+++ b/specs/access-broker-wgeasy-provisioning/evidence.md
@@ -1,0 +1,39 @@
+# Evidence: access-broker-wgeasy-provisioning
+
+**Branch**: `codex/access-broker-wgeasy-provisioning`
+**Date**: 2026-07-17
+
+## Workflow
+
+- Worktree fallback: used `/home/vscode/homelab-worktrees/access-broker-wgeasy-provisioning`
+  because `/workspaces/homelab-worktrees` is unavailable.
+- homelab-access PR #9 merged at `6c3af6aed110720efa8fe223026dd44326f23238`.
+- homelab-access main image workflow `29621599620` passed before the rollout
+  annotation update.
+- Lightweight SDD exception: clarify/checklist/analyze/converge were skipped for
+  this narrow manifest rollout; the required decisions and validation are
+  captured in spec, plan, tasks, and this evidence file.
+
+## Validation
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `gh run watch 29621599620 --repo petebeegle/homelab-access --interval 10` | PASS | Main image workflow for merged PR #9 completed successfully. |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-wgeasy-render.yaml && rg -n 'WGEASY_USERNAME\|wgeasy-provisioning-2026-07-17\|kind: Ingress' /tmp/access-broker-wgeasy-render.yaml \|\| true` | PASS | Render includes `WGEASY_USERNAME` and the new rollout annotation; no rendered `Ingress` line appeared. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-wgeasy-render.yaml && rg -n 'app-access-broker\|WGEASY_USERNAME\|wgeasy-provisioning-2026-07-17' /tmp/production-wgeasy-render.yaml` | PASS | Production render includes `app-access-broker`; app package content is applied by Flux from its path. |
+| `(rg -n 'kind: Ingress\|apiVersion: networking.k8s.io/v1' kubernetes/apps/access-broker kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1)` | PASS | No Kubernetes `Ingress` introduced. |
+| `(rg -n 'WGEASY_PASSWORD: [^E]\|password-1234\|PrivateKey =\|MTUyMzA0\|GBtIrX\|6Q-TE01sDcEW2T5ual35fzkNFuMomRl8' kubernetes/apps/access-broker specs/access-broker-wgeasy-provisioning; test $? -eq 1)` | PASS | No plaintext wg-easy password, test WireGuard key material, or previously exposed Discord token/client secret fragments in tracked rollout files. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed with no output. |
+
+## Live Smoke
+
+- Status: blocked until `WGEASY_PASSWORD` is added to
+  `kubernetes/apps/access-broker/secret.yaml` as a SOPS-encrypted key.
+- Substitute checks: app image CI passed, app package rendered, production Flux
+  Kustomization rendered, no Ingress introduced, and plaintext scans passed.
+
+## Final State
+
+- Final branch: `codex/access-broker-wgeasy-provisioning`
+- Final HEAD: branch head at PR creation
+- Pull request: pending

--- a/specs/access-broker-wgeasy-provisioning/plan.md
+++ b/specs/access-broker-wgeasy-provisioning/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: access-broker-wgeasy-provisioning
+
+**Branch**: `codex/access-broker-wgeasy-provisioning`
+**Date**: 2026-07-17
+**Spec**: `specs/access-broker-wgeasy-provisioning/spec.md`
+
+## Summary
+
+Apply the smallest Kubernetes desired-state change needed after
+`homelab-access` PR #9: explicit wg-easy username config plus a pod-template
+annotation bump to pull the newly published mutable `main` image.
+
+## Technical Context
+
+**SDD tier**: medium
+**Workflow risk tier**: medium
+**Smoke strategy**: render checks plus documented live-smoke blocker; manual
+approval smoke requires a SOPS-encrypted `WGEASY_PASSWORD`.
+**Fanout targets**: read-only image workflow verification and manifest render
+validation can run independently; tracked edits stay sequential.
+**Worktree exception**: `/workspaces/homelab-worktrees` is unavailable; using
+`/home/vscode/homelab-worktrees/access-broker-wgeasy-provisioning`.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Mutable `main` image not published when Flux rolls | Confirm main image workflow passed before annotation bump |
+| Missing wg-easy password makes approval fail at VPN step | Record as live-smoke blocker and do not invent a secret value |
+| Secret leakage | Do not print or commit plaintext credentials; scan tracked files |
+
+## Validation
+
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/clusters/production`
+- plaintext scan for `WGEASY_PASSWORD` and known secret-shaped values
+- SDD context validation
+
+## Exceptions
+
+Clarify, checklist, analyze, and converge are treated as lightweight/skipped
+because this is a narrow manifest rollout after a merged app PR; rationale and
+results are recorded in `evidence.md`.

--- a/specs/access-broker-wgeasy-provisioning/spec.md
+++ b/specs/access-broker-wgeasy-provisioning/spec.md
@@ -1,0 +1,44 @@
+# Feature Specification: access-broker-wgeasy-provisioning
+
+**Feature Branch**: `codex/access-broker-wgeasy-provisioning`
+**Date**: 2026-07-17
+**SDD Tier**: medium
+
+## Intent Brief
+
+Deploy the merged `homelab-access` WireGuard provisioning support to the
+production access-broker so `/access approve` can create or reuse a wg-easy peer
+and return a single-use config download link after Authentik user provisioning.
+
+## Scope
+
+- Roll the production access-broker pod so it pulls `ghcr.io/petebeegle/homelab-access:main`
+  after homelab-access PR #9.
+- Make the wg-easy username configuration explicit in the access-broker
+  ConfigMap.
+- Preserve existing public Gateway API routing and Cloudflare Tunnel exposure.
+
+## Non-Goals
+
+- Do not expose wg-easy directly to the internet.
+- Do not commit plaintext wg-easy credentials.
+- Do not change WireGuard server defaults, AllowedIPs, DNS, or Gateway routes.
+
+## Requirements
+
+- **FR-001**: The access-broker ConfigMap MUST set `WGEASY_USERNAME`.
+- **FR-002**: The access-broker Deployment MUST roll after the merged
+  `homelab-access` PR #9 image publish.
+- **FR-003**: Manifests MUST continue to use Gateway API and MUST NOT introduce
+  Kubernetes `Ingress`.
+- **FR-004**: Live manual approval smoke MUST be recorded as blocked until
+  `WGEASY_PASSWORD` is added to `access-broker-secret`.
+
+## Acceptance Criteria
+
+- `kubectl kustomize kubernetes/apps/access-broker` renders with
+  `WGEASY_USERNAME` and the new rollout annotation.
+- Production render still includes `app-access-broker`.
+- Plaintext scans show no wg-easy password in tracked manifests or artifacts.
+- If the secret remains unavailable, evidence records the exact live-smoke
+  blocker and substitute checks.

--- a/specs/access-broker-wgeasy-provisioning/tasks.md
+++ b/specs/access-broker-wgeasy-provisioning/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: access-broker-wgeasy-provisioning
+
+**Input**: `specs/access-broker-wgeasy-provisioning/spec.md` and
+`specs/access-broker-wgeasy-provisioning/plan.md`
+
+- [x] T001 [FR-SPEC] Create SDD artifacts for the rollout.
+- [x] T002 [P] [FR-002] Confirm homelab-access PR #9 is merged and the main
+      image workflow passed.
+- [x] T003 [FR-001] Add `WGEASY_USERNAME` to
+      `kubernetes/apps/access-broker/configmap.yaml`.
+- [x] T004 [FR-002] Bump the access-broker rollout annotation in
+      `kubernetes/apps/access-broker/deployment.yaml`.
+- [x] T005 [P] [FR-TEST] Run access-broker and production render checks.
+- [x] T006 [P] [FR-TEST] Run plaintext secret scans.
+- [x] T007 [FR-EVIDENCE] Record validation, live-smoke blocker, and final HEAD
+      in `specs/access-broker-wgeasy-provisioning/evidence.md`.
+- [x] T008 [FR-PR] Commit, push, and open PR.


### PR DESCRIPTION
## Summary
- roll access-broker onto the merged homelab-access WireGuard provisioning image
- set `WGEASY_USERNAME=admin` explicitly in the access-broker ConfigMap
- add SDD artifacts and evidence for the rollout

## Validation
- `gh run watch 29621599620 --repo petebeegle/homelab-access --interval 10`
- `kubectl kustomize kubernetes/apps/access-broker`
- `kubectl kustomize kubernetes/clusters/production`
- no-Ingress and plaintext secret scans
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- pre-commit hooks passed during commit

## Smoke blocker
Full manual `/access approve` VPN smoke is blocked until `WGEASY_PASSWORD` is added to `kubernetes/apps/access-broker/secret.yaml` as a SOPS-encrypted key. I did not invent or commit a credential value.