### PR TITLE
fix: retarget homepage synthetic smoke

### DIFF
--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -11,7 +11,7 @@ The checks are intentionally deeper than pod readiness and lighter than full aut
 ## Targets
 
 - `whoami.${cluster_domain}` verifies the baseline Gateway TLS path.
-- `${cluster_domain}` verifies the Homepage dashboard route at the root lab domain.
+- `homepage.${cluster_domain}` verifies the Homepage dashboard route.
 - `authentik.${cluster_domain}` verifies the SSO start or login page.
 - `monitoring.${cluster_domain}` verifies the Grafana login or landing shell.
 - `jellyfin.${cluster_domain}` verifies the Jellyfin web shell.

--- a/kubernetes/apps/homepage/README.md
+++ b/kubernetes/apps/homepage/README.md
@@ -1,6 +1,6 @@
 # Homepage
 
-Homepage serves the LAN and WireGuard dashboard at `https://${cluster_domain}`. It is not exposed through the public Cloudflare Gateway.
+Homepage serves the LAN and WireGuard dashboard at `https://homepage.${cluster_domain}`. It is not exposed through the public Cloudflare Gateway.
 
 ## Configuration
 
@@ -30,4 +30,4 @@ data:
 
 ## DNS
 
-The root `${cluster_domain}` hostname must resolve to the Cilium Gateway service plane being used by the client. LAN DNS should point it at `gateway/internal`; WireGuard DNS points both the root name and wildcard names at `gateway/external`.
+The `homepage.${cluster_domain}` hostname must resolve to the Cilium Gateway service plane being used by the client. LAN DNS should point it at `gateway/internal`; WireGuard DNS points wildcard names at `gateway/external`.

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -27,8 +27,8 @@ async function expectNotHomeAssistantOnboarding(page) {
 }
 
 test.describe("homelab routed services", () => {
-  test("homepage serves the dashboard at the root domain", async ({ page }) => {
-    await gotoOk(page, urlFor(""));
+  test("homepage serves the dashboard at the homepage subdomain", async ({ page }) => {
+    await gotoOk(page, urlFor("homepage"));
     await expect(page.locator("body")).toContainText(/Home Lab|Core|Operations|Homepage/i);
   });
 

--- a/specs/fix-synthetic-tests/evidence.md
+++ b/specs/fix-synthetic-tests/evidence.md
@@ -1,0 +1,93 @@
+# Evidence: fix-synthetic-tests
+
+**Branch**: `codex/fix-synthetic-tests`
+**Risk Tier**: low
+**Started**: 2026-07-17
+
+## Spec Kit Initialization
+
+- Command: manual lightweight artifact bootstrap from repo templates
+- Outcome: PASS
+- Spec Kit version: not checked; no Spec Kit scaffolding changes
+- Integration: existing repository templates
+- Fallback: preferred `/workspaces/homelab-worktrees/fix-synthetic-tests` worktree path was unavailable due to permission denied, so `/tmp/homelab-worktrees/fix-synthetic-tests` is used
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | PASS | User requested: "fix the synthetic tests"; follow-up clarified the root route is intentionally absent. |
+| Spec approval | PASS | User request authorizes focused test fix. |
+| Clarify | PASS | Follow-up correction resolved route intent. |
+| Plan approval | PASS | User asked to fix the test instead. |
+| Checklist | SKIP | Focused low-risk repair; no separate checklist needed. |
+| Tasks/analyze approval | SKIP | Analyze skipped for lightweight work with direct tests. |
+| Converge | SKIP | Artifacts updated after user correction; no remaining drift. |
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"` | PASS | Required spec, plan, tasks, and evidence artifacts present; no stale recorded HEAD. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `npm test -- --reporter=list` from `tests/smoke/` | FAIL | Baseline after `npm ci`: root Homepage test failed with DNS `ERR_NAME_NOT_RESOLVED`; all eight subdomain route tests passed. |
+| `curl -kfsSIL --max-time 10 https://homepage.lab.petebeegle.com/` | PASS | Confirmed Homepage is healthy on the intended subdomain route. |
+| `python3 tools/architecture/render.py --write && python3 tools/architecture/render.py --check` | PASS | Generated architecture returned to subdomain-only Homepage route state. |
+| `kubectl kustomize kubernetes/apps/homepage` | PASS | Rendered Homepage route remains `homepage.${cluster_domain}` only. |
+| `kubectl kustomize kubernetes/apps/homepage/development` | PASS | Development render remains `homepage.${cluster_domain}` only. |
+| `python3 tools/policy/check_synthetic_smoke_mirroring.py` | PASS | Mirrored route specs and lockfiles synchronized. |
+| `python3 -m unittest tools.policy.tests.test_check_synthetic_smoke_mirroring` | PASS | 5 tests passed. |
+| `node --test kubernetes/apps/synthetics/smoke/*.test.js` | PASS | 5 Node helper/reporter tests passed. |
+| `npm test -- --reporter=list` from `tests/smoke/` | PASS | 9 Playwright route tests passed after retargeting Homepage to `homepage.${cluster_domain}`. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| Local smoke suite | Playwright | PASS | 9 passed against live routes from this environment. |
+| Homepage subdomain | curl | PASS | `https://homepage.lab.petebeegle.com/` returns 200. |
+
+## Deployment State
+
+- Source fetched SHA: N/A; final change is test/docs only
+- Target applied SHA: N/A
+- Live resource spec checked: rendered Homepage route remains subdomain-only
+- Gateway/listener/DNS/certificate checked: no desired-state Gateway change
+- Exact user-facing URL result: `https://homepage.lab.petebeegle.com/` returns 200
+
+## Development Validation
+
+- Profile: none
+- Branch slug: N/A
+- HEAD: branch commit created after validation
+- Report path: N/A
+- Cleanup: N/A
+- Result or exception: no development validation required for final test/docs-only scope; local Playwright smoke validates the intended live route.
+
+## Documentation Impact
+
+- Updated: `docs/runbooks/synthetic-smoke-tests.md`, `kubernetes/apps/homepage/README.md`
+- Generated docs: `docs/architecture.md` checked; no net generated architecture route change remains after correction
+- No-docs rationale: N/A
+
+## SDD Conformance
+
+- Local sources checked: `AGENTS.md`, `docs/runbooks/spec-driven-development.md`, `docs/runbooks/implementation-workflow.md`
+- Upstream Spec Kit sources checked: N/A; no workflow/template changes
+- Human-gated Spec Kit alignment: lightweight gate compression recorded; follow-up clarification captured
+- Artifact updates after implementation: spec, plan, tasks, and evidence updated after user clarified root route is intentionally absent
+
+## Exceptions And Follow-Ups
+
+- `/workspaces/homelab-worktrees` was not writable; fallback worktree under `/tmp/homelab-worktrees` used.
+- Standalone `kustomize` is not installed; `kubectl kustomize` was used as the renderer.
+
+## Final State
+
+- Final branch: codex/fix-synthetic-tests
+- Final HEAD: branch commit created after validation
+- Commit: pending amended commit

--- a/specs/fix-synthetic-tests/plan.md
+++ b/specs/fix-synthetic-tests/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: fix-synthetic-tests
+
+**Branch**: `codex/fix-synthetic-tests` | **Date**: 2026-07-17 | **Spec**:
+`specs/fix-synthetic-tests/spec.md`
+
+**Input**: Feature specification from `specs/fix-synthetic-tests/spec.md`
+
+## Summary
+
+Retarget the mirrored Homepage synthetic smoke probe from the bare root domain to `homepage.${cluster_domain}`, preserve the intentional subdomain-only route, update stale docs, and validate with mirror, helper, and Playwright checks.
+
+## Technical Context
+
+**Risk Tier**: low
+**Workflow Tier**: low
+**Primary Areas**: tests, synthetic smoke tooling, docs
+**Dependencies**: Python unittest, Node.js/npm, Playwright smoke package, architecture renderer
+**Storage**: N/A
+**Ingress**: No desired-state ingress changes
+**Secrets**: N/A
+**Smoke Strategy**: local Playwright smoke against configured `SMOKE_BASE_DOMAIN`
+**Fanout Targets**: read-only inspection and independent local validation commands
+**Development Validation**: none; final change is test/docs only
+**Post-Implementation SDD Conformance**: local docs only
+
+## Human Gates
+
+**Spec Gate**: approved by user request and follow-up correction.
+
+**Checklist Status**: skipped; low-risk focused repair with concrete failing checks.
+
+**Plan Gate**: approved by user request to proceed with the fix.
+
+**Expected Task/Analyze Gate**: analyze skipped with rationale in evidence; tasks are small and directly executable.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; no desired-state cluster change in final scope.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/fix-synthetic-tests`; fallback worktree mode is recorded in evidence.
+- [x] Documentation impact identified; stale smoke docs updated.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/fix-synthetic-tests/
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+tests/smoke/routes.spec.js
+kubernetes/apps/synthetics/smoke/routes.spec.js
+docs/runbooks/synthetic-smoke-tests.md
+kubernetes/apps/homepage/README.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Reproduce the failing root-domain Homepage smoke check, then fix the test target without changing routing.
+
+**Local checks**:
+
+- `python3 tools/policy/check_synthetic_smoke_mirroring.py`
+- `python3 -m unittest tools.policy.tests.test_check_synthetic_smoke_mirroring`
+- `node --test kubernetes/apps/synthetics/smoke/*.test.js`
+- `npm test -- --reporter=list`
+- `python3 tools/architecture/render.py --check`
+
+**Development smoke**: none; no Kubernetes desired-state or app behavior change is planned.
+
+**Automated smoke preference**: Local Playwright smoke is the strongest practical check for this low-risk test repair.
+
+**Completion evidence**: Record command outcomes and final PR state.
+
+**Fanout plan**: Independent policy/helper validations may run in parallel after edits; all results are recorded in one evidence file.
+
+**Evidence destination**: `specs/fix-synthetic-tests/evidence.md`.
+
+## Documentation Impact
+
+Update stale smoke and Homepage docs to identify `homepage.${cluster_domain}` as the intended dashboard URL.
+
+## Implementation Steps
+
+1. Reproduce failing synthetic tests locally.
+2. Retarget the Homepage smoke probe in both mirrored route spec files.
+3. Update stale docs that described the root-domain Homepage target.
+4. Run focused validation and record evidence.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Mirrored route specs drift | Run mirror policy check after edits. |
+| Docs continue to imply a root route | Update smoke runbook and Homepage README with subdomain target. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/fix-synthetic-tests/spec.md
+++ b/specs/fix-synthetic-tests/spec.md
@@ -1,0 +1,85 @@
+# Feature Specification: fix-synthetic-tests
+
+**Feature Branch**: `codex/fix-synthetic-tests`
+**Created**: 2026-07-17
+**Status**: Draft
+**Risk Tier**: low
+**Input**: User description: "fix the synthetic tests"
+
+## Human Gate Status
+
+**Intent Brief**: Fix the repository's synthetic smoke tests so operators can trust local and in-cluster smoke results. Preserve mirrored smoke sources and keep Homepage on the intentional `homepage.${cluster_domain}` route instead of adding a bare root-domain route.
+
+**Clarify Status**: resolved by follow-up user correction: the root route is intentionally absent and the test should target the Homepage subdomain.
+
+**Spec Gate**: approved by user request to fix the tests, with explicit follow-up to avoid adding a root route.
+
+## Summary
+
+Synthetic smoke validation should probe the deployed Homepage dashboard at `homepage.${cluster_domain}`. The bare `${cluster_domain}` route is intentionally not a Homepage route.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/synthetic-smoke-tests.md`
+
+## Scope
+
+### In Scope
+
+- Retarget the mirrored Homepage smoke probe to `homepage.${cluster_domain}`.
+- Keep local smoke files and in-cluster smoke files mirrored where policy requires exact copies.
+- Update nearby operator docs that incorrectly described Homepage as a root-domain route.
+- Run focused local validation for the smoke suite and mirroring policy.
+
+### Out Of Scope
+
+- Adding or restoring a bare `${cluster_domain}` Homepage route.
+- Changing Gateway resources, Flux wiring, storage, secrets, or production cluster state.
+- Broad redesign of synthetic monitoring dashboards or alerting.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reliable Synthetic Smoke Tests (Priority: P1)
+
+Operators can run synthetic smoke tests and see pass/fail results that reflect the intended routed services rather than a stale root-domain assumption.
+
+**Why this priority**: The smallest useful slice is making the existing smoke suite runnable and accurate without changing desired-state routing.
+
+**Independent Test**: Run the mirror policy check, focused helper tests, and the Playwright smoke tests against the configured base domain.
+
+**Acceptance Scenarios**:
+
+1. **Given** the synthetic smoke sources in the repository, **When** mirror validation runs, **Then** required shared smoke files match exactly.
+2. **Given** Homepage is intentionally routed at `homepage.${cluster_domain}`, **When** the smoke test visits Homepage, **Then** it reaches the dashboard on the subdomain.
+3. **Given** a smoke run fails before the reporter emits a summary, **When** the wrapper exits, **Then** exactly one fallback summary is emitted and the non-zero exit status is preserved.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST make the Homepage synthetic smoke probe use `homepage.${cluster_domain}`.
+- **FR-002**: The implementation MUST preserve exact mirrors for `tests/smoke/routes.spec.js` and `kubernetes/apps/synthetics/smoke/routes.spec.js`.
+- **FR-003**: The implementation MUST preserve synthetic summary behavior for in-cluster smoke jobs.
+- **FR-004**: Evidence MUST record focused local commands and final branch state.
+
+## Risk And Validation Expectations
+
+**Low**: Run relevant local checks. Add or update a small test when the change touches executable code and the repo has a reasonable test seam.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: `python3 tools/policy/check_synthetic_smoke_mirroring.py` passes.
+- **SC-002**: `python3 -m unittest tools.policy.tests.test_check_synthetic_smoke_mirroring` passes.
+- **SC-003**: Synthetic smoke Node helper tests pass.
+- **SC-004**: Local Playwright smoke tests pass against the current routed services.
+
+## Assumptions
+
+- The user's follow-up correction supersedes the earlier route-repair interpretation.
+- Development-cluster validation is not required because the final implementation does not change Kubernetes desired state.
+
+## Open Questions
+
+- None

--- a/specs/fix-synthetic-tests/tasks.md
+++ b/specs/fix-synthetic-tests/tasks.md
@@ -1,0 +1,67 @@
+# Tasks: fix-synthetic-tests
+
+**Input**: `specs/fix-synthetic-tests/spec.md` and
+`specs/fix-synthetic-tests/plan.md`
+**Risk Tier**: low
+**Prerequisites**: Branch `codex/fix-synthetic-tests` and matching
+`specs/fix-synthetic-tests/` artifacts. `spec.md` and `plan.md` are approved
+inputs to this task list, not implementation tasks.
+
+## Human Gate Status
+
+**Spec Gate**: approved by user request and follow-up correction.
+
+**Plan Gate**: approved by user request.
+
+**Analyze Requirement**: skipped; focused low-risk repair with direct failing checks, recorded in evidence.
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel or fan out to a helper lane because it touches
+  different files or performs read-only validation and has no dependency on
+  another incomplete task.
+- **[Req]**: Requirement or user story trace, such as `FR-001` or `US1`.
+- Include exact file paths in each task.
+- Keep fanout coordinated through this task list and consolidate all results
+  into `specs/fix-synthetic-tests/evidence.md`.
+
+## Phase 1: Setup
+
+- [x] T001 [FR-SETUP] Confirm branch, approved spec/plan, and documentation expectations in `specs/fix-synthetic-tests/`.
+- [x] T002 [FR-SETUP] Install or verify local Node dependencies in `tests/smoke/`.
+
+## Phase 2: Implementation
+
+- [x] T003 [FR-001] Reproduce and identify the failing root-domain Homepage smoke behavior in `tests/smoke/routes.spec.js`.
+- [x] T004 [FR-001] Retarget Homepage smoke to `homepage.${cluster_domain}` in `tests/smoke/routes.spec.js`.
+- [x] T005 [FR-002] Mirror the Homepage smoke target in `kubernetes/apps/synthetics/smoke/routes.spec.js`.
+- [x] T006 [FR-003] Re-check synthetic summary helper behavior in `kubernetes/apps/synthetics/smoke/`.
+- [x] T007 [FR-DOCS] Update stale route target docs in `docs/runbooks/synthetic-smoke-tests.md` and `kubernetes/apps/homepage/README.md`.
+
+## Phase 3: Verification
+
+- [x] T008 [FR-TEST] Run `python3 tools/policy/check_synthetic_smoke_mirroring.py`.
+- [x] T009 [P] [FR-TEST] Run `python3 -m unittest tools.policy.tests.test_check_synthetic_smoke_mirroring`.
+- [x] T010 [P] [FR-TEST] Run `node --test kubernetes/apps/synthetics/smoke/*.test.js`.
+- [x] T011 [FR-TEST] Run `npm test -- --reporter=list` from `tests/smoke/`.
+- [x] T012 [FR-TEST] Run `python3 tools/architecture/render.py --check`.
+- [x] T013 [FR-SMOKE] Record no-development-smoke rationale in `specs/fix-synthetic-tests/evidence.md`.
+- [x] T014 [FR-CONVERGE] Record skipped-converge rationale in `specs/fix-synthetic-tests/evidence.md`.
+- [x] T015 [FR-EVIDENCE] Record command outcomes and final state in `specs/fix-synthetic-tests/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [ ] T016 [FR-PR] Amend commit with a conventional commit message.
+- [ ] T017 [FR-PR] Force-push branch `codex/fix-synthetic-tests` and update PR #367.
+
+## Dependencies
+
+T001-T003 must complete before implementation edits. T008-T012 run after T004-T007.
+
+## Parallel Execution Examples
+
+After edits, T009 and T010 can run independently while T008 checks mirror state.
+
+## Implementation Strategy
+
+Fix the single failing smoke path first, then run mirrored policy and full Playwright smoke before updating the PR branch.

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -27,8 +27,8 @@ async function expectNotHomeAssistantOnboarding(page) {
 }
 
 test.describe("homelab routed services", () => {
-  test("homepage serves the dashboard at the root domain", async ({ page }) => {
-    await gotoOk(page, urlFor(""));
+  test("homepage serves the dashboard at the homepage subdomain", async ({ page }) => {
+    await gotoOk(page, urlFor("homepage"));
     await expect(page.locator("body")).toContainText(/Home Lab|Core|Operations|Homepage/i);
   });
 


### PR DESCRIPTION
## Summary

Retargets the Homepage synthetic smoke check to the intentional `homepage.${cluster_domain}` route instead of the bare root domain.

## Root Cause

The smoke suite still expected Homepage at `https://lab.petebeegle.com/`, but the root route is intentionally absent. Homepage is served at `https://homepage.lab.petebeegle.com/`, and the smoke test should reflect that contract rather than adding a root-domain route.

## Changes

- Update both mirrored smoke route specs to probe `homepage.${cluster_domain}`.
- Update the synthetic smoke runbook and Homepage README to describe the subdomain target.
- Preserve the existing Homepage/Gateway desired state; no root route is added.
- Refresh Spec Kit evidence under `specs/fix-synthetic-tests/`.

## Validation

- `npm test -- --reporter=list` from `tests/smoke/` — 9 passed
- `python3 tools/policy/check_synthetic_smoke_mirroring.py`
- `python3 -m unittest tools.policy.tests.test_check_synthetic_smoke_mirroring`
- `node --test kubernetes/apps/synthetics/smoke/*.test.js`
- `python3 tools/architecture/render.py --check`
- `kubectl kustomize kubernetes/apps/homepage`
- `kubectl kustomize kubernetes/apps/homepage/development`
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence --head "$(git rev-parse HEAD)"`
- Pre-commit hooks during amend, including `k8svalidate` and synthetic smoke mirroring

Corrected after review note: the root Homepage route is intentionally not desired.