### PR TITLE
fix: add access broker wg-easy password

### DIFF
--- a/kubernetes/apps/access-broker/secret.yaml
+++ b/kubernetes/apps/access-broker/secret.yaml
@@ -9,6 +9,7 @@ stringData:
     DISCORD_PUBLIC_KEY: ENC[AES256_GCM,data:GmWEKQ3MJjRba/bJwTo+pFWY9n5A8mZF5aVzziIIGiFETKlo8CX1RuzklHZfEsPnyql6XgpzcCq4CPyUiY0AeQ==,iv:+k3shLq+zuJ74gN7h8fRprGShHfhaHyyxKzJFH8u+L0=,tag:nfxEOl1wIjyVhb/REDXw/A==,type:str]
     DISCORD_CLIENT_SECRET: ENC[AES256_GCM,data:wVbkThRfuhoNMvzFZE+9Wl16zeODszJghsltl9klhl8=,iv:INYS6j/7V5pU3OMuTLAVEOG8uTLci1swytKEaQJZkCk=,tag:qe/8u5Y1HSw/Q5PT6W/9rQ==,type:str]
     AUTHENTIK_TOKEN: ENC[AES256_GCM,data:+BEHK6w/oxjsfkY7ojwTkbOPYi2/ZuXiWEfmyS0pxEiTk3FqR6QudpXrXuc=,iv:PrET7pREvNd7WgQQ4fcaCAKgNkY5NKYtq/nXB1tIRq8=,tag:MAU3TByHV13Fnbh8j5Vj8Q==,type:str]
+    WGEASY_PASSWORD: ENC[AES256_GCM,data:6TuHowHkJaKhF3GAKR/AXQ9pqw==,iv:D3Hfdc2OqaTxmUCUiDD+6o/vheujBNZoRFDBZlR6rms=,tag:jatkPQoMGvUKvW3rnAiBoA==,type:str]
 sops:
     age:
         - enc: |
@@ -21,6 +22,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1g4erccmqr8znqmhszfyq425l6dt9thq7vmllrn7z9yjfaug3putqlgs4ry
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-04T21:56:11Z"
-    mac: ENC[AES256_GCM,data:5sFDwseTKa7/RfdbGJPRyy2mCLSOrDmSrUXsff6vanwVn6MZVuSgFWVRf4aDCnZlPupfMBqztj1AiB9K6EocnCAQieBAwXyVqlnsdMUZmcr6VFX6FmEmKikazkul3IJEy6+o8lFECQzl058TQ9x3A1XFcaD2fF6az7rHM1AWnaw=,iv:7jaWBI2CtmJwiXDLXpw7nljvrr7jU1SiqWlOAdOUnj4=,tag:XVK46tQ9MEVcCzJ1OUH1BA==,type:str]
+    lastmodified: "2026-07-18T00:07:32Z"
+    mac: ENC[AES256_GCM,data:M7mH3j/8cgIcM15uIBAZf6CjJfRzht6IoIBqbEAvXZlFLgPFZoO6+vtPHAd0DXUOINuszYem53xD8P9t9yjyEiwsgZhZBIsmoiRfOzXXrMNjdqOCCQYPgEqQtpIW0XKDurOlXGN7JpUPGU1DR/FnkxmfQQwEYEMxpSL5ahj7AiM=,iv:8jPtQgrwP9NaxdanwfZcbNF7wDYEGx7/8zyrRLeyXRQ=,tag:sMWYpWhSaJRp2bEjss+sbg==,type:str]
     version: 3.13.0

--- a/specs/access-broker-wgeasy-password/evidence.md
+++ b/specs/access-broker-wgeasy-password/evidence.md
@@ -1,0 +1,30 @@
+# Evidence: access-broker-wgeasy-password
+
+**Branch**: `codex/access-broker-wgeasy-password`
+**Date**: 2026-07-18
+
+## Workflow
+
+- The encrypted secret edit was created by the operator before this branch.
+- Codex inspected only encrypted diff material and key names, not the plaintext
+  password.
+- Workflow exception: used the current checkout after branching because the
+  operator-created encrypted secret edit was already unstaged there.
+- Lightweight SDD exception: clarify/checklist/analyze/converge were skipped for
+  this single-key encrypted secret update; validation is recorded below.
+
+## Validation
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `sops filestatus kubernetes/apps/access-broker/secret.yaml` | PASS | Reported `{"encrypted":true}`. |
+| `kubectl kustomize kubernetes/apps/access-broker > /tmp/access-broker-wgeasy-password-render.yaml && rg -n 'WGEASY_PASSWORD\|WGEASY_USERNAME\|kind: Ingress' /tmp/access-broker-wgeasy-password-render.yaml \|\| true` | PASS | Render includes `WGEASY_USERNAME` and encrypted `WGEASY_PASSWORD`; no rendered `Ingress` line appeared. |
+| `kubectl kustomize kubernetes/clusters/production > /tmp/production-wgeasy-password-render.yaml && rg -n 'app-access-broker' /tmp/production-wgeasy-password-render.yaml` | PASS | Production render includes `app-access-broker`. |
+| `(rg -n 'kind: Ingress\|apiVersion: networking.k8s.io/v1' kubernetes/apps/access-broker kubernetes/clusters/production/apps/access-broker.yaml; test $? -eq 1)` | PASS | No Kubernetes `Ingress` introduced. |
+| `(rg -n 'WGEASY_PASSWORD: [^E]\|PrivateKey =\|password-1234\|MTUyMzA0\|GBtIrX\|6Q-TE01sDcEW2T5ual35fzkNFuMomRl8' kubernetes/apps/access-broker specs/access-broker-wgeasy-password; test $? -eq 1)` | PASS | No plaintext wg-easy password, test WireGuard config material, or previously exposed Discord token/client secret fragments found in touched files. |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Completed with no output. |
+
+## Final State
+
+- Final branch: `codex/access-broker-wgeasy-password`
+- Pull request: pending

--- a/specs/access-broker-wgeasy-password/plan.md
+++ b/specs/access-broker-wgeasy-password/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan: access-broker-wgeasy-password
+
+**Branch**: `codex/access-broker-wgeasy-password`
+**Date**: 2026-07-18
+**Spec**: `specs/access-broker-wgeasy-password/spec.md`
+
+## Summary
+
+Commit the already-created SOPS-encrypted `WGEASY_PASSWORD` key and validate the
+access-broker render path before opening a PR.
+
+## Technical Context
+
+**SDD tier**: medium
+**Workflow risk tier**: medium
+**Smoke strategy**: render and secret validation before PR; live `/access approve`
+smoke after Flux applies the merged secret.
+**Fanout targets**: render validation and plaintext scans are independent.
+**Workflow exception**: using the main checkout after branching because the
+operator-created encrypted secret edit was already unstaged there; moving it to
+a new worktree would increase secret-handling risk.
+
+## Validation
+
+- `sops filestatus kubernetes/apps/access-broker/secret.yaml`
+- `kubectl kustomize kubernetes/apps/access-broker`
+- `kubectl kustomize kubernetes/clusters/production`
+- plaintext secret scans
+- SDD context validation

--- a/specs/access-broker-wgeasy-password/spec.md
+++ b/specs/access-broker-wgeasy-password/spec.md
@@ -1,0 +1,27 @@
+# Feature Specification: access-broker-wgeasy-password
+
+**Feature Branch**: `codex/access-broker-wgeasy-password`
+**Date**: 2026-07-18
+**SDD Tier**: medium
+
+## Intent Brief
+
+Complete access-broker wg-easy provisioning by adding the operator-provided
+wg-easy password to the access-broker SOPS Secret without exposing the plaintext
+value to Codex or committing it unencrypted.
+
+## Requirements
+
+- **FR-001**: `kubernetes/apps/access-broker/secret.yaml` MUST include
+  `WGEASY_PASSWORD` as a SOPS-encrypted `stringData` key.
+- **FR-002**: No plaintext wg-easy password or WireGuard config material may be
+  committed.
+- **FR-003**: Rendered access-broker manifests MUST continue to use the existing
+  Gateway API route and MUST NOT introduce Kubernetes `Ingress`.
+
+## Acceptance Criteria
+
+- `sops filestatus kubernetes/apps/access-broker/secret.yaml` reports encrypted.
+- Access-broker package render includes `WGEASY_PASSWORD` only as encrypted
+  secret data.
+- Plaintext scans pass for known secret markers.

--- a/specs/access-broker-wgeasy-password/tasks.md
+++ b/specs/access-broker-wgeasy-password/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: access-broker-wgeasy-password
+
+**Input**: `specs/access-broker-wgeasy-password/spec.md` and
+`specs/access-broker-wgeasy-password/plan.md`
+
+- [x] T001 [FR-SPEC] Create SDD artifacts.
+- [x] T002 [FR-001] Confirm the operator-provided encrypted `WGEASY_PASSWORD`
+      key is present in `kubernetes/apps/access-broker/secret.yaml`.
+- [x] T003 [P] [FR-TEST] Run SOPS and render validation.
+- [x] T004 [P] [FR-TEST] Run plaintext secret scans.
+- [x] T005 [FR-EVIDENCE] Record validation and final state.
+- [ ] T006 [FR-PR] Commit, push, and open PR.


### PR DESCRIPTION
## Summary
- add operator-provided `WGEASY_PASSWORD` to the access-broker SOPS Secret
- keep the password encrypted; Codex did not inspect or receive the plaintext value
- add focused SDD artifacts and validation evidence

## Validation
- `sops filestatus kubernetes/apps/access-broker/secret.yaml`
- `kubectl kustomize kubernetes/apps/access-broker`
- `kubectl kustomize kubernetes/clusters/production`
- no-Ingress and plaintext secret scans
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts`
- pre-commit hooks passed during commit

## Notes
- after merge/Flux apply, `/access approve` should be ready for manual smoke through Authentik + wg-easy + one-time config download