### PR TITLE
feat: protect WireGuard UI with Authentik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ __pycache__/
 .mypy_cache/
 .venv/
 *.egg-info/
+
+# Node.js and browser-test artifacts
+node_modules/
+test-results/
+playwright-report/
+*.log

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/access-broker-manual-smoke"}
+{"feature_directory":"specs/wireguard-authentik"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `monitoring` | `./kubernetes/infra/monitoring` | (none) | `cluster-vars` | `sops` |
 | `production` | `nfs-csi` | `./kubernetes/infra/controllers/nfs-csi` | (none) | `cluster-vars` | `no` |
 | `production` | `otel-collector` | `./kubernetes/infra/monitoring/otel-collector` | `crds`, `gateway` | `cluster-vars` | `no` |
-| `production` | `vpn` | `./kubernetes/infra/network/vpn` | `cilium`, `nfs-csi`, `gateway` | `cluster-vars` | `sops` |
+| `production` | `vpn` | `./kubernetes/infra/network/vpn` | `cilium`, `nfs-csi`, `gateway`, `authentik` | `cluster-vars` | `sops` |
 | `development` | `cert-manager` | `./kubernetes/infra/controllers/cert-manager` | `crds` | `cluster-vars` | `sops` |
 | `development` | `certs` | `./kubernetes/infra/network/certs` | `cert-manager`, `cilium` | `cluster-vars` | `no` |
 | `development` | `cilium` | `./kubernetes/infra/network/cilium` | `crds` | `cluster-vars` | `no` |
@@ -107,7 +107,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
 | `production` | `private-source` | `./kubernetes/clusters/production/apps/private/source` | (none) | `(none)` | `sops` |
 | `production` | `app-renovate` | `./kubernetes/apps/renovate` | `gateway` | `cluster-vars` | `sops` |
-| `production` | `app-synthetics` | `./kubernetes/apps/synthetics` | `gateway`, `grafana`, `authentik`, `app-whoami`, `app-homepage`, `app-jellyfin`, `app-immich`, `app-home-assistant`, `app-pihole`, `app-foundryvtt` | `cluster-vars` | `no` |
+| `production` | `app-synthetics` | `./kubernetes/apps/synthetics` | `gateway`, `grafana`, `authentik`, `vpn`, `app-whoami`, `app-homepage`, `app-jellyfin`, `app-immich`, `app-home-assistant`, `app-pihole`, `app-foundryvtt` | `cluster-vars` | `no` |
 | `production` | `app-valheim` | `./kubernetes/apps/valheim` | `gateway`, `nfs-csi` | `cluster-vars` | `sops` |
 | `production` | `app-whoami` | `./kubernetes/apps/whoami` | `gateway` | `cluster-vars` | `no` |
 | `development` | `app-foundry-bluegreen-fixture` | `./kubernetes/apps/foundry-bluegreen-fixture` | `gateway`, `nfs-csi` | `cluster-vars` | `no` |
@@ -118,7 +118,7 @@ This document is generated for agentic repo navigation. It records relationships
 
 | Component path | Listed resources |
 | --- | --- |
-| `kubernetes/infra/authentik` | `namespace.yaml`, `app.yaml`, `secret.yaml`, `httproute.yaml`, `blueprints` |
+| `kubernetes/infra/authentik` | `namespace.yaml`, `app.yaml`, `secret.yaml`, `httproute.yaml`, `referencegrant.yaml`, `blueprints` |
 | `kubernetes/infra/controllers/cert-manager` | `app.yaml`, `secret.yaml` |
 | `kubernetes/infra/controllers/cloudnative-pg` | `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/controllers/grafana-operator` | `namespace.yaml`, `app.yaml` |
@@ -194,7 +194,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `HTTPRoute` | `pihole/pihole-httproute` | `pihole.${cluster_domain}` | `gateway/internal/https-gateway` | `pihole-web:80` |
 | `HTTPRoute` | `whoami-${branch_slug}/whoami-${branch_slug}` | `whoami-${branch_slug}.${cluster_domain}` | `gateway/internal/https-gateway` | `whoami-${branch_slug}:80` |
 | `HTTPRoute` | `whoami/whoami` | `whoami.${cluster_domain}` | `gateway/internal/https-gateway, gateway/external/https-gateway` | `whoami:80` |
-| `HTTPRoute` | `wireguard/wireguard-ui` | `vpn.${cluster_domain}` | `gateway/internal/https-gateway` | `wireguard-http:51821` |
+| `HTTPRoute` | `wireguard/wireguard-ui` | `vpn.${cluster_domain}` | `gateway/internal/https-gateway` | `authentik-server:80` |
 | `TLSRoute` | `external/pve01-route` | `pve01.petebeegle.com` | `gateway/passthrough` | `pve01:8006` |
 | `TLSRoute` | `external/pve02-route` | `pve02.petebeegle.com` | `gateway/passthrough` | `pve02:8006` |
 | `TLSRoute` | `external/pve03-route` | `pve03.petebeegle.com` | `gateway/passthrough` | `pve03:8006` |

--- a/docs/runbooks/synthetic-smoke-tests.md
+++ b/docs/runbooks/synthetic-smoke-tests.md
@@ -13,6 +13,8 @@ The checks are intentionally deeper than pod readiness and lighter than full aut
 - `whoami.${cluster_domain}` verifies the baseline Gateway TLS path.
 - `homepage.${cluster_domain}` verifies the Homepage dashboard route.
 - `authentik.${cluster_domain}` verifies the SSO start or login page.
+- `vpn.${cluster_domain}` verifies both the root and a representative wg-easy
+  API path reach Authentik before any wg-easy response.
 - `monitoring.${cluster_domain}` verifies the Grafana login or landing shell.
 - `jellyfin.${cluster_domain}` verifies the Jellyfin web shell.
 - `pihole.${cluster_domain}` verifies the root redirect reaches the Pi-hole admin/login shell.
@@ -98,6 +100,11 @@ sum by (failed_tests) (count_over_time({namespace="synthetics", app="synthetic-s
 7. Avoid raw `${...}` syntax in mirrored smoke files unless Flux should substitute it; Flux post-build substitution scans the generated ConfigMap data.
 8. Add the app Flux Kustomization to `app-synthetics` `dependsOn` when the probe requires that app to exist first.
 9. Run `python3 tools/policy/check_synthetic_smoke_mirroring.py` or `pre-commit run synthetic-smoke-mirroring --all-files`, run the suite locally when the route is reachable, then create a manual Job after Flux applies the change.
+
+For Authentik-proxied applications such as WireGuard, use a fresh unauthenticated
+browser context and assert the final URL and page shell belong to Authentik.
+Probe a representative non-mutating upstream path as well as `/` so a
+path-specific Gateway bypass cannot expose the application API.
 
 ## Dashboard And Alert
 

--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -2,6 +2,93 @@
 
 Use this runbook to check the `wg-easy` deployment that provides VPN access to the external `192.168.40.x` service plane.
 
+## Administration Authentication
+
+The human administration URL, `https://vpn.<cluster-domain>`, is LAN-only on
+`gateway/internal` and is protected by the Authentik embedded proxy outpost.
+The Authentik `wireguard-proxy` provider forwards authorized requests to
+`http://wireguard-http.wireguard.svc.cluster.local:51821`.
+
+Access is allowed to either of these Authentik groups:
+
+- `WireGuard Admins` for normal delegated administration.
+- Built-in `authentik Admins` for break-glass access and initial population of
+  `WireGuard Admins`.
+
+Users in neither group must receive an Authentik authorization denial. The
+provider does not configure unauthenticated paths or inject the wg-easy
+credential. After Authentik authorization, wg-easy's existing login remains as
+defense in depth.
+
+The Gateway route fails closed through Authentik. If Authentik or the embedded
+outpost is unavailable, do not add a durable direct-to-wg-easy backend as a
+workaround. Restore service through Git by fixing Authentik or reverting the
+change that introduced the proxy route.
+
+### Machine Access Boundary
+
+Trusted in-cluster automation, including access-broker, continues to use:
+
+```text
+http://wireguard-http.wireguard.svc.cluster.local:51821
+```
+
+That ClusterIP path uses the existing wg-easy username and SOPS-encrypted
+password. It does not traverse browser SSO. Do not expose the ClusterIP
+credential through Authentik headers or synthetic-test output.
+
+Authentik protects only the HTTP administration hostname. The WireGuard UDP
+Service, peer keys, tunnel routing, VPN DNS, and existing client configurations
+are unchanged.
+
+### Verify The Authentication Path
+
+First verify the reconciled resource chain:
+
+```bash
+. scripts/kube-aliases.sh
+fp get kustomizations authentik vpn app-synthetics
+kp -n authentik get helmrelease authentik
+kp -n authentik get referencegrant wireguard-routes-to-authentik-server -o yaml
+kp -n wireguard get httproute wireguard-ui -o yaml
+```
+
+The `wireguard-ui` route must report `Accepted=True` and
+`ResolvedRefs=True`, and its only backend must be
+`authentik/authentik-server:80`.
+
+Use separate browser contexts for the user-path checks:
+
+1. With no Authentik session, open both `/` and `/api/client` on the `vpn`
+   hostname. Both must reach Authentik before exposing wg-easy.
+2. With a user in neither authorized group, confirm Authentik denies access.
+3. With a `WireGuard Admins` or `authentik Admins` account, confirm Authentik
+   permits access and wg-easy presents its existing login/UI.
+
+After the blueprint first reconciles, use an existing `authentik Admins`
+account to populate `WireGuard Admins`. Keep at least one tested break-glass
+administrator.
+
+Then verify the unchanged non-browser paths:
+
+1. Connect one existing WireGuard peer and reach an already allowed
+   `192.168.40.0/24` service-plane destination.
+2. Run the existing credentialed access-broker/wg-easy API smoke through the
+   ClusterIP Service without logging the password or response secrets.
+3. Confirm neither check requires regenerating a peer or changing the wg-easy
+   database.
+
+Run the production synthetic suite after the user-path checks:
+
+```bash
+kp create job -n synthetics synthetic-smoke-manual-$(date +%Y%m%d%H%M%S) \
+  --from=cronjob/synthetic-smoke
+kp logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
+```
+
+The WireGuard root and API-path tests must pass and the run must emit one
+`SMOKE_RUN_SUMMARY` line with `status=success`.
+
 ## Client Routing Defaults
 
 Global wg-easy client defaults are managed in `kubernetes/infra/network/vpn/global-config.yaml`.

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -42,6 +42,18 @@ test.describe("homelab routed services", () => {
     await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
   });
 
+  test("wireguard reaches Authentik before the wg-easy UI", async ({ page }) => {
+    await gotoOk(page, urlFor("vpn"));
+    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
+  test("wireguard reaches Authentik before the wg-easy API", async ({ page }) => {
+    await gotoOk(page, urlFor("vpn", "/api/client"));
+    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
   test("grafana reaches the login or landing shell", async ({ page }) => {
     await gotoOk(page, urlFor("monitoring"));
     await expect(page.locator("body")).toContainText(/Grafana|Login|Sign in|Welcome/i);

--- a/kubernetes/clusters/production/apps/synthetics.yaml
+++ b/kubernetes/clusters/production/apps/synthetics.yaml
@@ -17,6 +17,7 @@ spec:
     - name: gateway
     - name: grafana
     - name: authentik
+    - name: vpn
     - name: app-whoami
     - name: app-homepage
     - name: app-jellyfin

--- a/kubernetes/clusters/production/infra/vpn.yaml
+++ b/kubernetes/clusters/production/infra/vpn.yaml
@@ -17,6 +17,7 @@ spec:
     - name: cilium
     - name: nfs-csi
     - name: gateway
+    - name: authentik
   decryption:
     provider: sops
     secretRef:

--- a/kubernetes/infra/authentik/app.yaml
+++ b/kubernetes/infra/authentik/app.yaml
@@ -41,6 +41,7 @@ spec:
         - jellyfin-oauth-blueprint
         - immich-oauth-blueprint
         - synology-oauth-blueprint
+        - wireguard-proxy-blueprint
       secrets:
         - private-authentik-blueprints
   valuesFrom:

--- a/kubernetes/infra/authentik/blueprints/kustomization.yaml
+++ b/kubernetes/infra/authentik/blueprints/kustomization.yaml
@@ -20,3 +20,6 @@ configMapGenerator:
   - name: synology-oauth-blueprint
     files:
       - synology-oauth.yaml
+  - name: wireguard-proxy-blueprint
+    files:
+      - wireguard-proxy.yaml

--- a/kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml
+++ b/kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+---
+version: 1
+metadata:
+  name: wireguard-proxy-setup
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+
+entries:
+  - model: authentik_core.group
+    identifiers:
+      name: WireGuard Admins
+    attrs:
+      name: WireGuard Admins
+
+  - model: authentik_providers_proxy.proxyprovider
+    identifiers:
+      name: wireguard-proxy
+    attrs:
+      name: WireGuard Proxy
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
+      mode: proxy
+      external_host: https://vpn.${cluster_domain}
+      internal_host: http://wireguard-http.wireguard.svc.cluster.local:51821
+      internal_host_ssl_validation: false
+      intercept_header_auth: true
+      basic_auth_enabled: false
+      skip_path_regex: ""
+
+  - model: authentik_core.application
+    identifiers:
+      slug: wireguard
+    attrs:
+      name: WireGuard
+      slug: wireguard
+      provider: !Find [authentik_providers_proxy.proxyprovider, [name, wireguard-proxy]]
+      policy_engine_mode: any
+      meta_launch_url: https://vpn.${cluster_domain}
+      meta_icon: https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/wireguard.png
+      meta_description: WireGuard peer administration
+      open_in_new_tab: true
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !Find [authentik_core.application, [slug, wireguard]]
+      order: 0
+    attrs:
+      group: !Find [authentik_core.group, [name, WireGuard Admins]]
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !Find [authentik_core.application, [slug, wireguard]]
+      order: 1
+    attrs:
+      group: !Find [authentik_core.group, [name, authentik Admins]]
+
+  - model: authentik_outposts.outpost
+    identifiers:
+      managed: goauthentik.io/outposts/embedded
+    attrs:
+      providers:
+        - !Find [authentik_providers_proxy.proxyprovider, [name, wireguard-proxy]]

--- a/kubernetes/infra/authentik/kustomization.yaml
+++ b/kubernetes/infra/authentik/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - app.yaml
   - secret.yaml
   - httproute.yaml
+  - referencegrant.yaml
   - blueprints
 
 configMapGenerator:

--- a/kubernetes/infra/authentik/referencegrant.yaml
+++ b/kubernetes/infra/authentik/referencegrant.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: wireguard-routes-to-authentik-server
+  namespace: authentik
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: wireguard
+  to:
+    - group: ""
+      kind: Service
+      name: authentik-server

--- a/kubernetes/infra/network/vpn/httproute.yaml
+++ b/kubernetes/infra/network/vpn/httproute.yaml
@@ -18,6 +18,7 @@ spec:
             value: /
 
       backendRefs:
-        - name: wireguard-http
-          port: 51821
+        - name: authentik-server
+          namespace: authentik
+          port: 80
           weight: 1

--- a/specs/wireguard-authentik/checklists/requirements.md
+++ b/specs/wireguard-authentik/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: WireGuard Authentik
+
+**Purpose**: Validate specification completeness and quality before proceeding
+to planning
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details beyond binding constraints and documented
+      assumptions
+- [x] Focused on user and operator value
+- [x] Written for technical and non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are outcome-focused
+- [x] All acceptance scenarios are defined
+- [x] Edge and failure cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] Implementation constraints are limited to binding repository decisions
+
+## Notes
+
+- Validation passed in one review iteration.
+- The explicit request to plan the fix is treated as approval to proceed from
+  the spec draft to a draft plan. The plan remains pending human approval before
+  task generation or implementation.

--- a/specs/wireguard-authentik/checklists/security.md
+++ b/specs/wireguard-authentik/checklists/security.md
@@ -1,0 +1,73 @@
+# Security Requirements Checklist: WireGuard Authentik
+
+**Purpose**: Review whether the authentication, authorization, failure, machine
+access, rollout, and recovery requirements are complete enough for a high-risk
+PR
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md)
+
+**Note**: This checklist reviews the requirements as written; it is not an
+implementation test plan. Depth is standard, and the intended user is a PR
+reviewer at the plan gate.
+
+## Authentication And Authorization Completeness
+
+- [x] CHK001 Are authentication requirements defined for every path on the
+      protected `vpn` hostname, including representative API paths?
+      [Completeness, Spec §FR-001]
+- [x] CHK002 Is the authorized population defined more narrowly than "all
+      authenticated users," with a stable group and explicit default-deny
+      behavior? [Clarity, Spec §FR-002]
+- [x] CHK003 Are the authorized-member and authenticated-non-member outcomes
+      both specified independently? [Coverage, Spec §User Story 2]
+- [x] CHK004 Is the relationship between the Authentik gate and wg-easy's own
+      authentication unambiguous for both humans and API clients?
+      [Consistency, Spec §FR-006]
+
+## Failure And Recovery Coverage
+
+- [x] CHK005 Is fail-closed behavior defined for Authentik and proxy-component
+      unavailability, with direct-to-wg-easy fallback explicitly prohibited?
+      [Exception Flow, Spec §FR-003]
+- [x] CHK006 Are requirements present for invalid Gateway backend references
+      and other partial rollout states? [Coverage, Plan §Risks]
+- [x] CHK007 Is recovery access defined without weakening the durable
+      user-facing policy or requiring plaintext credentials?
+      [Recovery, Spec §Scope]
+- [x] CHK008 Is Git-revert rollback distinguished from a temporary live
+      diagnostic mutation? [Consistency, Plan §Implementation Steps]
+
+## Boundary And Non-Goal Clarity
+
+- [x] CHK009 Is the protected browser boundary clearly separated from the
+      WireGuard UDP data plane and direct in-cluster machine boundary?
+      [Clarity, Spec §FR-005]
+- [x] CHK010 Are exposure changes to external/public Gateways explicitly
+      excluded? [Scope, Spec §Out Of Scope]
+- [x] CHK011 Is preservation of peers, persistent database contents, Service
+      identity, and access-broker behavior stated in objectively reviewable
+      terms? [Measurability, Spec §SC-003]
+- [x] CHK012 Are other non-Authentik apps and Valheim explicitly separated from
+      the implementation scope while retaining the audit as planning input?
+      [Scope, Spec §Out Of Scope]
+
+## Evidence And Acceptance Quality
+
+- [x] CHK013 Can the unauthenticated acceptance requirement be measured at the
+      exact root and API paths without exposing secrets?
+      [Acceptance Criteria, Spec §SC-001]
+- [x] CHK014 Are both authorization personas, Authentik outage, UDP peer
+      continuity, and direct API continuity covered by requirements?
+      [Scenario Coverage, Spec §User Scenarios]
+- [x] CHK015 Is the development-cluster gap documented with a reason,
+      substitute evidence, and a rule that real failures cannot be waived?
+      [Dependency, Plan §Development Validation]
+- [x] CHK016 Does completion require fetched/applied revision evidence and the
+      exact user path rather than route readiness alone?
+      [Acceptance Criteria, Spec §SC-005]
+
+## Notes
+
+- All 16 requirement-quality checks pass against the current spec and plan.
+- Task generation and implementation remain gated on human approval of the
+  chosen proxy-mode approach and rollout evidence.

--- a/specs/wireguard-authentik/contracts/access-path.md
+++ b/specs/wireguard-authentik/contracts/access-path.md
@@ -1,0 +1,51 @@
+# Access Contract: WireGuard Administration
+
+## Human Browser Contract
+
+**Entry point**: `https://vpn.${cluster_domain}/`
+
+- The hostname is available only through the existing LAN internal Gateway.
+- A request without a valid Authentik session must not reach wg-easy content.
+- Authentik starts its normal login flow and returns only users authorized by
+  the `WireGuard Admins` or built-in `authentik Admins` application bindings.
+- An authenticated user in neither group receives an Authentik denial.
+- An authorized user is proxied to wg-easy and still completes wg-easy's local
+  authentication.
+- If Authentik or its proxy provider cannot authorize the request, the path
+  fails closed. There is no direct Gateway fallback backend.
+
+Representative unauthenticated paths:
+
+- `/`
+- One non-mutating wg-easy API path selected during task design based on the
+  pinned v15 behavior
+
+## Machine Client Contract
+
+**Entry point**:
+`http://wireguard-http.wireguard.svc.cluster.local:51821`
+
+- Trusted in-cluster clients continue to use the existing wg-easy
+  authentication.
+- They do not follow browser SSO redirects and do not depend on an Authentik
+  session.
+- No Service name, port, or credential key changes in this implementation.
+
+## WireGuard Data-Plane Contract
+
+**Entry point**: existing `Service/wireguard` UDP port 30000
+
+- Existing peers, keys, DNS defaults, AllowedIPs, and tunnel behavior are
+  unchanged.
+- The Authentik gate applies only to HTTP traffic for the administration
+  hostname.
+
+## Observable Failure Contract
+
+| Failure | Expected observation |
+| ------- | -------------------- |
+| No Authentik session | Redirect or Authentik login response; no wg-easy shell |
+| Authenticated user in neither authorized group | Authentik authorization denial |
+| Authentik unavailable | Closed/failed request; never direct wg-easy fallback |
+| Cross-namespace reference invalid | HTTPRoute `ResolvedRefs=False`; rollout is not accepted |
+| wg-easy unavailable after authorization | Authentik proxy returns upstream failure; route does not bypass the gate |

--- a/specs/wireguard-authentik/data-model.md
+++ b/specs/wireguard-authentik/data-model.md
@@ -1,0 +1,79 @@
+# Data Model: WireGuard Authentik Gate
+
+This change adds no application database schema. The durable entities are
+declarative identity and routing objects.
+
+## Authentik Group: WireGuard Admins
+
+| Field | Value / rule |
+| ----- | ------------ |
+| Name | `WireGuard Admins` |
+| Purpose | Operators allowed to reach the wg-easy administration surface |
+| Membership | Explicit human assignment by an existing Authentik administrator |
+| Default | No ordinary Authentik user is implicitly included; built-in `authentik Admins` retain break-glass access |
+
+## Authentik Proxy Provider
+
+| Field | Value / rule |
+| ----- | ------------ |
+| Stable name | `wireguard-proxy` |
+| Mode | Proxy |
+| External host | `https://vpn.${cluster_domain}` |
+| Internal host | `http://wireguard-http.wireguard.svc.cluster.local:51821` |
+| Authorization flow | Existing default provider authorization flow |
+| Invalidation flow | Existing default invalidation flow |
+| Upstream TLS validation | Not applicable to the HTTP ClusterIP upstream |
+
+## Authentik Application
+
+| Field | Value / rule |
+| ----- | ------------ |
+| Name | `WireGuard` |
+| Slug | `wireguard` |
+| Provider | `wireguard-proxy` |
+| Launch URL | `https://vpn.${cluster_domain}` |
+| Authorization | Policy bindings allow `WireGuard Admins` or built-in `authentik Admins`; all other authenticated users are denied |
+
+## Embedded Outpost Assignment
+
+| Field | Value / rule |
+| ----- | ------------ |
+| Outpost | Existing `authentik Embedded Outpost` |
+| Provider membership | Includes `wireguard-proxy` and every other Git-managed proxy provider, if any are discovered before implementation |
+| Service endpoint | Existing `authentik-server` Service used by the Gateway backend |
+
+## Gateway HTTPRoute
+
+| Field | Value / rule |
+| ----- | ------------ |
+| Name / namespace | `wireguard-ui` / `wireguard` |
+| Hostname | `vpn.${cluster_domain}` |
+| Parent | `gateway/internal`, section `https-gateway` |
+| Backend | `authentik/authentik-server:80` |
+| Trust grant | Authentik-namespace ReferenceGrant allowing `wireguard` HTTPRoutes to reference only `authentik-server`; the API cannot scope the source by route name |
+
+## Existing Objects Preserved
+
+- `Service/wireguard` continues to expose UDP port 30000.
+- `Service/wireguard-http` remains a ClusterIP for the proxy upstream and
+  trusted automation.
+- `PersistentVolumeClaim/wireguard-pvc` and wg-easy database rows are unchanged.
+- Existing SOPS secrets and access-broker credentials are unchanged.
+
+## Access State Transitions
+
+```text
+No Authentik session
+  -> Authentik login
+  -> authenticated, in neither authorized group -> denied
+  -> authenticated, in WireGuard Admins or authentik Admins -> proxied to wg-easy
+  -> wg-easy local authentication -> administration UI
+
+Authentik unavailable
+  -> fail closed; no direct Gateway fallback to wg-easy
+
+Trusted in-cluster API client
+  -> wireguard-http ClusterIP
+  -> existing wg-easy authentication
+  -> supported API response
+```

--- a/specs/wireguard-authentik/evidence.md
+++ b/specs/wireguard-authentik/evidence.md
@@ -1,0 +1,139 @@
+# Evidence: wireguard-authentik
+
+**Branch**: `codex/wireguard-authentik`
+**Risk Tier**: high
+**Status**: implemented and locally validated; deployment verification pending
+
+## Human Gates
+
+- Intent/spec: approved by the request to plan the WireGuard Authentik fix.
+- Plan: approved by the 2026-07-25 instruction to implement.
+- Task/analyze: approved by the implementation instruction; Spec Kit analysis
+  found no critical or high issues before source edits.
+- Converge: complete with no remaining task.
+
+## Worktree
+
+- Preferred `/workspaces/homelab-worktrees/wireguard-authentik` could not be
+  created because its parent is not writable in this environment.
+- Allowed fallback:
+  `/home/vscode/homelab-worktrees/wireguard-authentik`.
+
+## TDD
+
+- Spec Kit analysis: PASS. Fifteen numbered requirements/success criteria and
+  all three user stories are covered by 18 correctly formatted tasks; no
+  ambiguity, duplication, constitution conflict, or unmapped task blocks
+  implementation.
+- `npm --prefix tests/smoke test -- --grep "wireguard reaches Authentik"`:
+  initial attempt could not start because dependencies were not installed.
+- `npm --prefix tests/smoke ci`: PASS; 3 packages installed, 0 vulnerabilities.
+- Re-run of the focused test: EXPECTED FAIL (2 tests). The root remained at
+  `https://vpn.lab.petebeegle.com/login`, and `/api/client` remained at the
+  direct `vpn` URL. Neither request reached Authentik, proving the test detects
+  the reported gap before route implementation.
+
+## Local Validation
+
+- `git diff --exit-code origin/main --` for the wg-easy Deployment, UDP/HTTP
+  Services, PVC, and access-broker ConfigMap: PASS. No changes.
+- `git diff --name-only origin/main -- kubernetes/infra/network/vpn
+  kubernetes/apps/access-broker/configmap.yaml`: PASS; only
+  `kubernetes/infra/network/vpn/httproute.yaml` is changed.
+- `python3 tools/architecture/render.py --write` followed by `--check`: PASS.
+- `diff -u tests/smoke/routes.spec.js
+  kubernetes/apps/synthetics/smoke/routes.spec.js`: PASS.
+- `python3 tools/policy/check_synthetic_smoke_mirroring.py`: PASS, including
+  wrapper/reporter unit checks.
+- `npm test -- --list --grep "wireguard reaches Authentik"` from
+  `tests/smoke`: PASS; both new tests are collected.
+- `kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict` with
+  `cluster_domain=lab.petebeegle.com`: PASS.
+- `kubectl kustomize kubernetes/infra/network/vpn | flux envsubst --strict`:
+  PASS.
+- `kubectl kustomize kubernetes/clusters/production | flux envsubst --strict`:
+  PASS.
+- Supplemental Authentik blueprint model/field comparison against the current
+  upstream `blueprints/schema.json`: PASS for group, proxy provider,
+  application, two policy bindings, and embedded outpost.
+- Sensitive-pattern scan for plaintext wg-easy credentials, private keys,
+  Basic Auth injection, unauthenticated proxy bypass, and traditional Ingress:
+  PASS.
+- `git diff --check`: PASS.
+- `pre-commit run --all-files`: PASS, including yamllint, k8svalidate,
+  generated architecture, and synthetic smoke mirroring.
+- Checklist status: `requirements.md` 16/16 and `security.md` 16/16.
+- Live read-only pre-change baseline: production `wireguard-ui` still uses
+  `gateway/internal` and direct `wireguard-http`; `authentik-server` exposes
+  Service port 80 to target port 9000. Production `authentik`, `vpn`, and
+  `app-synthetics` Kustomizations were Ready at
+  `main@sha1:46cb4fec04535bee28a4b3e1e9da85155c2ca205`.
+
+## Development Validation
+
+**smoke_profile**: `none`
+
+The development base deliberately omits Authentik and VPN, so it cannot
+represent the proxy provider, group policy, embedded outpost, wg-easy upstream,
+or exact `vpn` hostname. A live read-only query confirmed there are no
+`authentik` or `wireguard` namespaces and no `authentik` or `vpn` Flux
+Kustomizations. The development `gateway` and `app-whoami` Kustomizations were
+healthy at `main@sha1:46cb4fec04535bee28a4b3e1e9da85155c2ca205`.
+
+This is an unavailable-infrastructure exception, not a waived failure.
+Substitute evidence is the expected-failing production test, strict local
+renders, k8svalidate, blueprint schema comparison, and the required post-merge
+production checks below.
+
+## Post-Merge Verification Handoff
+
+Not run: the branch is not merged, pushed, or reconciled. Do not describe the
+change as deployed until all layers below are recorded:
+
+1. Record the merge SHA and confirm Flux source fetched that SHA.
+2. Confirm `authentik`, then `vpn`, then `app-synthetics` applied that revision.
+3. Confirm the Authentik blueprint is applied, the embedded outpost is healthy,
+   and `wireguard-proxy` is assigned.
+4. Confirm `wireguard-ui` has `Accepted=True` and `ResolvedRefs=True`, keeps only
+   `gateway/internal`, and targets only `authentik/authentik-server:80`.
+5. With no session, verify `/` and `/api/client` reach Authentik and expose no
+   wg-easy response.
+6. Verify a user in neither `WireGuard Admins` nor `authentik Admins` is denied.
+7. Verify a member of either authorized group reaches the existing wg-easy
+   login/UI; use built-in admins to populate `WireGuard Admins`.
+8. Verify one existing peer reaches an already allowed service-plane target.
+9. Verify the credentialed access-broker path still calls the unchanged
+   `wireguard-http` ClusterIP successfully without logging secrets.
+10. Run a one-off production synthetic Job and require one successful
+    `SMOKE_RUN_SUMMARY`.
+
+## Documentation Impact
+
+- Updated `docs/runbooks/wireguard.md` with the Authentik and direct-machine
+  boundaries, group policy, fail-closed behavior, validation, and rollback.
+- Updated `docs/runbooks/synthetic-smoke-tests.md` with the root/API Authentik
+  assertions.
+- Regenerated `docs/architecture.md` for Flux dependencies, component
+  resources, and the changed HTTPRoute backend.
+- Updated `.gitignore` for local Node/Playwright artifacts required by the
+  implementation test workflow.
+
+## SDD Conformance
+
+- Specify, plan, and both requirements/security checklists completed before
+  source implementation.
+- User approved implementation; tasks were generated and analyze found no
+  blocking issue before source edits.
+- High-risk validation and the development exception are recorded.
+- Converge checked 10 functional requirements, 5 success criteria, 7 acceptance
+  scenarios, the implementation-plan decisions, and all 7 constitution
+  principles. It found no missing, partial, contradictory, or unrequested work
+  requiring a task.
+- All 18 implementation tasks are complete.
+
+## Branch State
+
+- Worktree branch: `codex/wireguard-authentik`.
+- Base `HEAD`: `46cb4fec04535bee28a4b3e1e9da85155c2ca205`.
+- The implementation is committed only to the local feature branch. It is not
+  pushed, merged, applied, or user-path verified after reconciliation.

--- a/specs/wireguard-authentik/plan.md
+++ b/specs/wireguard-authentik/plan.md
@@ -1,0 +1,231 @@
+# Implementation Plan: wireguard-authentik
+
+**Branch**: `codex/wireguard-authentik` | **Date**: 2026-07-25 | **Spec**:
+`specs/wireguard-authentik/spec.md`
+
+**Input**: Feature specification from `specs/wireguard-authentik/spec.md`
+
+## Summary
+
+Protect the LAN-only wg-easy UI by replacing the `vpn.${cluster_domain}`
+HTTPRoute's direct backend with Authentik's embedded proxy outpost. Add a
+GitOps-managed proxy provider whose external host is the existing `vpn` URL and
+whose internal host is the existing wg-easy ClusterIP Service. Bind the
+Authentik application to a dedicated `WireGuard Admins` group with built-in
+`authentik Admins` retained for break-glass access, leave wg-easy's own
+authentication in place, and preserve direct in-cluster Service access for the
+access-broker. Add exact-host synthetic smoke, dependency ordering, and operator
+documentation.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Kubernetes, Flux dependency ordering, Gateway API,
+Authentik blueprints, synthetic smoke, generated architecture, runbook
+**Dependencies**: Kustomize, Flux envsubst/build, kubectl, Authentik 2026.5.0,
+wg-easy 15.3.0, npm/Playwright, architecture renderer
+**Storage**: Existing `wireguard-pvc` and Authentik PostgreSQL storage remain
+unchanged on `nfs-csi-storage`
+**Ingress**: Keep `gateway/internal` / `https-gateway`; route
+`vpn.${cluster_domain}` to `authentik/authentik-server:80` through an explicit
+cross-namespace backend reference authorized by a ReferenceGrant
+**Secrets**: No new secret is expected. Existing wg-easy and Authentik secrets
+remain SOPS-encrypted and are never copied into the proxy blueprint.
+**Smoke Strategy**: Add mirrored Playwright coverage that asserts the exact
+unauthenticated `vpn` URL reaches Authentik, then run a production one-off
+synthetic Job plus authorized and unauthorized browser checks
+**Fanout Targets**: Read-only routed-app audit (completed separately at user
+request); post-implementation manifest review and exact-path smoke may run as
+independent read-only lanes, with all evidence consolidated in `evidence.md`
+**Development Validation**: `smoke_profile: none` for the full path because the
+development base deliberately omits Authentik and VPN. Substitute local
+production renders, schema/policy checks, a pre-change expected-failing
+synthetic assertion, and post-reconcile production synthetic/user-path checks.
+If a safe temporary development deployment of both components becomes
+available during implementation, use it and supersede this exception.
+**Post-Implementation SDD Conformance**: local repository workflow review only;
+this does not change Spec Kit behavior or standards. The upstream plan workflow's
+agent-context update step is unavailable because this repository does not ship
+an `update-agent-context` script; no agent guidance changes are needed for this
+feature.
+
+## Human Gates
+
+**Spec Gate**: approved by the user's explicit request to plan the named
+WireGuard/Authentik fix; assumptions are documented in the spec
+
+**Checklist Status**: run; requirements checklist passed and focused security
+checklist is at `specs/wireguard-authentik/checklists/security.md`
+
+**Plan Gate**: approved by the user's 2026-07-25 instruction to implement
+
+**Expected Task/Analyze Gate**: task list approved by the implementation
+instruction, with analyze required and no unresolved critical or high finding
+before source implementation
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/wireguard-authentik`; the prescribed `/workspaces`
+      worktree parent was not writable, so the documented sibling fallback
+      `/home/vscode/homelab-worktrees/wireguard-authentik` is intentional.
+- [x] Documentation impact identified; update the WireGuard and synthetic smoke
+      runbooks and regenerate architecture documentation.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/wireguard-authentik/
+├── checklists/
+│   ├── requirements.md
+│   └── security.md
+├── contracts/
+│   └── access-path.md
+├── data-model.md
+├── quickstart.md
+├── research.md
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/
+├── clusters/production/
+│   ├── apps/synthetics.yaml
+│   └── infra/vpn.yaml
+├── infra/
+│   ├── authentik/
+│   │   ├── blueprints/
+│   │   │   ├── kustomization.yaml
+│   │   │   └── wireguard-proxy.yaml
+│   │   ├── kustomization.yaml
+│   │   └── referencegrant.yaml
+│   └── network/vpn/httproute.yaml
+└── apps/synthetics/smoke/routes.spec.js
+
+tests/smoke/routes.spec.js
+docs/runbooks/wireguard.md
+docs/runbooks/synthetic-smoke-tests.md
+docs/architecture.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: First add a mirrored Playwright assertion that requires an
+unauthenticated `vpn` request to land on Authentik. Against the current direct
+route, the assertion should fail because wg-easy responds. Then implement the
+blueprint/route change and retain the same assertion as regression coverage.
+Static render and cross-namespace reference checks supplement, but do not
+replace, the exact user-path test.
+
+**Local checks**:
+
+- `diff -u tests/smoke/routes.spec.js kubernetes/apps/synthetics/smoke/routes.spec.js`
+- `python3 tools/policy/check_synthetic_smoke_mirroring.py`
+- `npm --prefix tests/smoke test -- --grep "wireguard reaches Authentik"`
+- `kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict`
+- `kubectl kustomize kubernetes/infra/network/vpn | flux envsubst --strict`
+- `kubectl kustomize kubernetes/clusters/production | flux envsubst --strict`
+- `python3 tools/architecture/render.py --check`
+- `pre-commit run --all-files`
+
+**Development smoke**: No standard branch profile applies, and the development
+base intentionally omits both production-only components. Record
+`smoke_profile: none` with that blocker. If server-side dry-run can safely
+validate the rendered objects without introducing live state, run it as an
+additional schema/reference check. Completion still requires a post-merge
+production one-off synthetic Job, an authorized browser session, an
+authenticated non-member denial, an existing-peer tunnel check, and a
+credentialed in-cluster API probe.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization or HelmRelease applied SHA, live resource spec, Gateway/listener
+match when applicable, and exact user-facing URL result.
+
+**Fanout plan**: The user-requested separate read-only exposure audit is complete
+and summarized in `research.md`. During implementation, an independent
+read-only reviewer may inspect the blueprint, cross-namespace route, and
+fail-closed behavior while another lane runs local renders or post-reconcile
+smoke. No helper edits the same tracked files. The implementation owner records
+all results in `specs/wireguard-authentik/evidence.md`.
+
+**Evidence destination**: `specs/wireguard-authentik/evidence.md`.
+
+## Documentation Impact
+
+Update `docs/runbooks/wireguard.md` to describe the Authentik group, double-auth
+behavior, direct Service boundary, verification, and rollback. Update
+`docs/runbooks/synthetic-smoke-tests.md` to list the `vpn` target and its
+expected Authentik behavior. Regenerate `docs/architecture.md` because an
+HTTPRoute backend, Authentik blueprint, ReferenceGrant, and Flux dependency
+change affect generated architecture. No ADR is required because the design
+uses the existing GitOps, Gateway API, and evidence decisions without changing
+their authority.
+
+## Implementation Steps
+
+1. Add the failing mirrored synthetic smoke scenario for unauthenticated
+   `https://vpn.${cluster_domain}` and record the current direct-wg-easy result.
+2. Add `wireguard-proxy.yaml` to the Authentik blueprint set. Define the
+   `WireGuard Admins` group, proxy provider (`proxy` mode, external `vpn` host,
+   internal wg-easy Service URL), Authentik application, group policy binding,
+   the `WireGuard Admins` and break-glass `authentik Admins` policy bindings,
+   and embedded-outpost provider assignment without any embedded credential.
+3. Add an Authentik-namespace ReferenceGrant that permits HTTPRoutes from only
+   the `wireguard` namespace to reference only the `authentik-server` Service.
+   Gateway API ReferenceGrant cannot narrow the source to one HTTPRoute name.
+4. Change the WireGuard HTTPRoute backend from `wireguard-http:51821` to
+   `authentik-server:80` in namespace `authentik`, preserving the hostname and
+   LAN-only parentRef.
+5. Make the production `vpn` Flux Kustomization depend on `authentik`, and make
+   `app-synthetics` depend on `vpn`, so reconciliation and smoke ordering match
+   the traffic path.
+6. Update runbooks and regenerate architecture documentation.
+7. Run local render, mirror, focused test, architecture, and pre-commit checks;
+   record the development-cluster exception and any safe substitute dry-runs.
+8. After review, merge, and Flux reconciliation, verify the applied SHA, route
+   `Accepted`/`ResolvedRefs`, Authentik blueprint/outpost health,
+   unauthenticated redirect, authorized access, non-member denial, existing
+   WireGuard peer connectivity, direct access-broker/API behavior, and the
+   one-off synthetic Job.
+9. Roll back by reverting the Git commit if Authentik proxying blocks
+   authorized operations; do not bypass GitOps with a durable live route edit.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Embedded outpost/provider is not ready when the route reconciles | Make `vpn` depend on `authentik`, verify blueprint and outpost state before user-path acceptance, and fail closed meanwhile |
+| Cross-namespace backend is rejected | Add a least-privilege ReferenceGrant and require `ResolvedRefs=True` |
+| Proxy mode breaks websocket/API behavior | Use Authentik's supported proxy mode and exercise the UI plus a representative API path after login |
+| Authentik outage locks out wg-easy UI | Preserve wg-easy local authentication and direct ClusterIP access for trusted recovery; use a Git revert for durable rollback |
+| Over-broad Authentik membership exposes peer configs | Bind `WireGuard Admins`, retain only built-in Authentik admins for break-glass, and test a user in neither group |
+| Proxy protection breaks access-broker automation | Keep the in-cluster Service unchanged and verify the existing credentialed API path |
+| Development cannot represent the production path | Record the explicit exception, run all safe local checks, then require layered post-reconcile production evidence |
+| Blueprint outpost assignment overwrites an unmanaged live proxy provider | Treat Git as authoritative, inspect current outpost provider membership read-only before rollout, and include all Git-managed proxy providers in the declared assignment |
+
+## Complexity Tracking
+
+No constitution violations are planned.

--- a/specs/wireguard-authentik/quickstart.md
+++ b/specs/wireguard-authentik/quickstart.md
@@ -1,0 +1,94 @@
+# Quickstart: Validate The WireGuard Authentik Gate
+
+## Prerequisites
+
+- Branch `codex/wireguard-authentik`
+- `kubectl`, `flux`, Python 3, Node/npm, and pre-commit
+- Production kubeconfig for post-reconcile verification
+- One Authentik account in `WireGuard Admins` or built-in `authentik Admins`
+- One Authentik account in neither authorized group
+- An existing WireGuard peer and the existing credentialed in-cluster API probe
+- No credentials printed to terminal logs or committed evidence
+
+## 1. Render Desired State
+
+```bash
+export cluster_domain=lab.petebeegle.com
+kubectl kustomize kubernetes/infra/authentik | flux envsubst --strict
+kubectl kustomize kubernetes/infra/network/vpn | flux envsubst --strict
+kubectl kustomize kubernetes/clusters/production | flux envsubst --strict
+python3 tools/architecture/render.py --check
+```
+
+Expected: all commands exit zero; the rendered WireGuard HTTPRoute backend is
+the Authentik Service, and a matching ReferenceGrant is present.
+
+## 2. Validate Mirrored Smoke
+
+```bash
+diff -u tests/smoke/routes.spec.js kubernetes/apps/synthetics/smoke/routes.spec.js
+python3 tools/policy/check_synthetic_smoke_mirroring.py
+npm --prefix tests/smoke test -- --grep "wireguard reaches Authentik"
+```
+
+Before the route change reaches production, the focused user-path assertion is
+expected to fail against the direct wg-easy response. After Flux applies the
+change, it must pass.
+
+## 3. Review Applied State
+
+After merge, use the production-scoped aliases from `scripts/kube-aliases.sh`:
+
+```bash
+. scripts/kube-aliases.sh
+fp get kustomizations vpn authentik app-synthetics
+kp -n wireguard get httproute wireguard-ui -o yaml
+kp -n authentik get referencegrant
+kp -n authentik get helmrelease authentik
+```
+
+Expected: Flux has fetched/applied the merge revision; `wireguard-ui` reports
+`Accepted=True` and `ResolvedRefs=True`; Authentik is Ready.
+
+## 4. Exercise The Exact User Paths
+
+Use isolated browser contexts:
+
+1. No session: open `https://vpn.lab.petebeegle.com/`; expect Authentik, not
+   wg-easy.
+2. No session: request the selected representative API path; expect Authentik
+   or its denial, not a wg-easy API response.
+3. Session in neither authorized group: expect an Authentik authorization
+   denial.
+4. `WireGuard Admins` or `authentik Admins` session: expect proxy authorization,
+   then the existing wg-easy login/UI.
+
+Do not record session cookies, passwords, tokens, or client configurations.
+
+## 5. Run Synthetic Smoke
+
+```bash
+kp create job -n synthetics synthetic-smoke-manual-$(date +%Y%m%d%H%M%S) \
+  --from=cronjob/synthetic-smoke
+kp get jobs,pods -n synthetics -l app.kubernetes.io/name=synthetic-smoke
+kp logs -n synthetics -l app.kubernetes.io/name=synthetic-smoke --tail=200
+```
+
+Expected: the WireGuard Authentik test and the full suite pass, with one
+`SMOKE_RUN_SUMMARY ... status=success` line.
+
+## 6. Preserve VPN And Automation
+
+- Verify one existing peer can establish its tunnel and reach an already allowed
+  service-plane destination.
+- Run the existing credentialed in-cluster wg-easy API probe used by the
+  access-broker workflow.
+- Confirm neither check required peer recreation, database mutation, or a new
+  secret.
+
+## 7. Rollback
+
+If authorized users or trusted automation cannot operate, revert the Git commit
+and allow Flux to restore the previous desired state. Record which verification
+failed. A temporary live diagnostic may be used only under the GitOps runbook;
+do not leave a durable direct-to-wg-easy route outside Git.

--- a/specs/wireguard-authentik/research.md
+++ b/specs/wireguard-authentik/research.md
@@ -1,0 +1,140 @@
+# Research: WireGuard Authentik Gate
+
+## Decision 1: Use Authentik Proxy Mode
+
+**Decision**: Protect `vpn.${cluster_domain}` with an Authentik proxy provider in
+proxy mode, served by the embedded proxy outpost, and forward authorized
+requests to
+`http://wireguard-http.wireguard.svc.cluster.local:51821`.
+
+**Rationale**: The pinned wg-easy 15.3.0 deployment has local initialization and
+credential behavior but no documented native OIDC configuration in the current
+wg-easy v15 documentation. Authentik proxy mode is designed for an existing web
+application: the outpost receives the external request, authenticates and
+authorizes it, then forwards to the configured internal host. This keeps
+identity enforcement outside wg-easy and does not change its database.
+
+**Alternatives considered**:
+
+- Native wg-easy OIDC: rejected because no supported v15 configuration was
+  found and inventing undocumented environment variables is unsafe.
+- Gateway forward-auth filter: rejected because this repo has no established
+  Cilium/Gateway API external-auth policy and Authentik's documented
+  forward-auth examples assume a reverse proxy that implements the auth
+  subrequest contract.
+- Add a new sidecar reverse proxy: rejected because the embedded Authentik proxy
+  already owns this capability with less secret and lifecycle surface.
+
+## Decision 2: Route The Hostname To Authentik
+
+**Decision**: Keep the HTTPRoute in the `wireguard` namespace and its
+`gateway/internal` parent, but replace the direct wg-easy backend with
+`authentik-server` in namespace `authentik`. Add a target-namespace
+ReferenceGrant scoped to the WireGuard HTTPRoute.
+
+**Rationale**: The route remains owned with the app, uses the binding Gateway
+API architecture, and preserves the LAN-only exposure. The cross-namespace
+ReferenceGrant makes the trust relationship explicit and testable. The
+embedded outpost is available through the Authentik server Service and can
+select the proxy provider from the `vpn` Host header.
+
+**Alternatives considered**:
+
+- Move the HTTPRoute to the Authentik namespace: rejected because it separates
+  the app hostname from the WireGuard desired-state package and reverses the
+  cross-namespace trust direction.
+- Deploy a dedicated managed outpost: deferred because there are no existing
+  proxy providers or scaling/isolation requirements that justify a new
+  Deployment, Secret, and Service.
+- Keep the direct backend and route only `/outpost.goauthentik.io`: rejected
+  because Cilium HTTPRoute does not itself perform Authentik's forward-auth
+  subrequest and deny/redirect contract.
+
+## Decision 3: Require A Dedicated Administrator Group
+
+**Decision**: Create a `WireGuard Admins` group and bind it to the Authentik
+application while retaining built-in `authentik Admins` as a break-glass path.
+Preserve wg-easy's local login and API credential behind the outer gate.
+
+**Rationale**: wg-easy can create, revoke, download, and display VPN client
+configuration, so ordinary authenticated homelab membership is too broad. The
+built-in admin binding avoids a cutover lockout while the new group is initially
+empty. Keeping the inner credential provides defense in depth and preserves
+existing machine clients.
+
+**Alternatives considered**:
+
+- Allow every authenticated Authentik user: rejected as excessive privilege.
+- Remove wg-easy local authentication: rejected because it increases coupling
+  to the proxy, changes API clients, and weakens recovery.
+- Send the wg-easy password from Authentik as Basic Auth: rejected because it
+  adds secret distribution and removes the intentional second control without
+  a demonstrated requirement.
+
+## Decision 4: Preserve Machine-To-Machine Access
+
+**Decision**: Apply Authentik only at the user-facing Gateway hostname. Do not
+change `wireguard-http`, the wg-easy workload, or the access-broker's direct
+ClusterIP endpoint and credential.
+
+**Rationale**: Browser SSO redirects are inappropriate for automation. The
+ClusterIP boundary is already the intended trusted integration path, while the
+LAN hostname is the human entry point.
+
+**Alternatives considered**:
+
+- Force access-broker through the Gateway and Authentik: rejected because it
+  would require a new non-interactive OAuth client and changes outside the
+  stated fix.
+
+## Decision 5: Validation And Development Exception
+
+**Decision**: Add an exact-host unauthenticated Playwright regression, run
+production renders and repository checks, then require layered post-reconcile
+production verification. Record `smoke_profile: none` for development unless a
+safe temporary deployment of both Authentik and VPN becomes available.
+
+**Rationale**: The development base deliberately omits Authentik and VPN. A
+whoami-only branch smoke cannot prove the proxy provider, group policy, or
+wg-easy upstream. The strongest representative evidence is therefore a
+pre-change expected failure, local desired-state validation, production
+synthetic smoke, two authorization personas, the existing UDP peer path, and
+the direct API path.
+
+**Alternatives considered**:
+
+- Claim Gateway render/readiness as completion: rejected because repository
+  policy requires the exact user path for routed changes.
+- Add Authentik and VPN permanently to development in this PR: rejected as
+  substantial environment and secret scope expansion.
+
+## Separate Routed-App Audit
+
+The user-requested separate read-only audit excluded Valheim and found these
+desired-state surfaces without an Authentik application:
+
+| Surface | Exposure | Assessment |
+| ------- | -------- | ---------- |
+| WireGuard UI | LAN HTTPS | Sensitive admin UI; fix in this implementation |
+| Homepage | LAN and WireGuard HTTPS | Network restriction is explicit, but Authentik omission is not; highest-priority follow-up because dashboard/private config can reveal infrastructure details |
+| Pi-hole web UI | LAN HTTPS | Native admin password exists; likely intentional, but policy should decide whether native auth is sufficient |
+| Whoami | LAN and WireGuard HTTPS | Intentional Gateway diagnostic; review whether permanent header/source disclosure is worth the operational value |
+| Foundry VTT | LAN and internet-public HTTPS | Public exposure and native account/admin secrets are intentional; blanket Authentik could break players |
+| Access broker callback/download paths | Internet-public HTTPS | Anonymous Discord/OAuth callbacks and tokenized downloads are intentional; blanket Authentik is unsuitable |
+| OTLP collector | LAN HTTPS plus LoadBalancer | Authentik is unsuitable for agents, but unauthenticated telemetry and unspecified LoadBalancer placement need a separate network-auth review |
+
+Protocol-only WireGuard UDP, VPN DNS, and Pi-hole DNS use protocol/network
+controls and are not browser Authentik candidates. Dormant Proxmox/UniFi routes
+are not included by the current production Kustomization. Apps from the
+separate `homelab-private` repository were unavailable to this audit.
+
+## Documentation Sources Consulted
+
+- Authentik proxy provider modes:
+  `https://docs.goauthentik.io/add-secure-apps/providers/proxy/`
+- Authentik proxy provider creation:
+  `https://docs.goauthentik.io/add-secure-apps/providers/proxy/create-proxy-provider/`
+- Authentik embedded outpost configuration:
+  `https://docs.goauthentik.io/add-secure-apps/outposts/embedded/`
+- wg-easy v15 documentation:
+  `https://wg-easy.github.io/wg-easy/latest/`

--- a/specs/wireguard-authentik/spec.md
+++ b/specs/wireguard-authentik/spec.md
@@ -1,0 +1,227 @@
+# Feature Specification: wireguard-authentik
+
+**Feature Branch**: `codex/wireguard-authentik`
+**Created**: 2026-07-25
+**Status**: Draft
+**Risk Tier**: high
+**Input**: User description: "wireguard (vpn.lab.petebeegle.com) isn't behind
+authentik. plan a fix and in a separate agent find any other non-authentik apps
+(excluding valheim which is a game server)"
+
+## Human Gate Status
+
+**Intent Brief**: Protect the user-facing WireGuard administration UI at
+`https://vpn.lab.petebeegle.com` with Authentik, preserve VPN and automation
+behavior, exclude Valheim from the related exposure audit, and identify any
+other routed apps lacking Authentik. Authentication and a production traffic
+path make this high risk. Acceptance requires an unauthenticated browser to
+reach Authentik rather than wg-easy, an authorized operator to reach wg-easy,
+an unauthorized authenticated user to be denied, and existing WireGuard peers
+and in-cluster automation to remain functional.
+
+**Clarify Status**: skipped; repository conventions and the administrative
+nature of wg-easy support the conservative default of a dedicated authorized
+operator group while preserving wg-easy's own credential as defense in depth.
+
+**Spec Gate**: approved by the user's explicit request to plan this specific
+fix, with assumptions called out below; implementation remains gated on plan
+approval.
+
+## Summary
+
+The WireGuard administration hostname must require Authentik authentication and
+authorization before a user can reach wg-easy. The protection must apply to the
+browser-facing Gateway route without interrupting the WireGuard UDP service,
+existing client tunnels, or trusted in-cluster automation that talks directly
+to the wg-easy Service. Operators also need automated evidence that the
+unauthenticated URL can no longer expose the wg-easy login or administration
+shell.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/decisions/cilium-gateway-api-ingress.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/development-cluster.md`
+- `docs/runbooks/wireguard.md`
+- `docs/runbooks/synthetic-smoke-tests.md`
+
+## Scope
+
+### In Scope
+
+- Put `https://vpn.${cluster_domain}` behind an Authentik application and proxy
+  provider on the existing LAN HTTPS Gateway path.
+- Limit access to a dedicated WireGuard administrator group while preserving
+  built-in Authentik administrators for break-glass access.
+- Preserve wg-easy's internal authentication and direct cluster Service for
+  trusted automation as defense in depth.
+- Add user-path smoke coverage for the unauthenticated Authentik redirect/login
+  behavior.
+- Update the WireGuard runbook with the authentication path, authorization
+  model, validation, and recovery checks.
+- Record the separately requested read-only audit of other non-Authentik routed
+  apps, excluding Valheim, as planning input only.
+
+### Out Of Scope
+
+- Exposing the wg-easy administration UI on the WireGuard external Gateway or
+  the internet-public Gateway.
+- Changing WireGuard UDP transport, peer configuration, DNS, AllowedIPs, or
+  persistent database contents.
+- Replacing the access-broker's direct in-cluster wg-easy API integration.
+- Removing wg-easy's own credential or changing its local user database.
+- Remediating the other applications found by the exposure audit; each
+  materially different app should receive its own implementation decision.
+- Adding Authentik to Valheim or treating protocol-only game traffic as a web
+  authentication target.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Gate WireGuard Administration (Priority: P1)
+
+An unauthenticated person who opens the WireGuard administration URL must be
+sent to Authentik and must not see wg-easy content or APIs.
+
+**Why this priority**: The current direct route exposes a security-sensitive
+administration surface before the central identity and policy layer.
+
+**Independent Test**: Open the exact URL in a fresh browser context with no
+cookies and assert that the resulting page or redirect belongs to Authentik,
+with no wg-easy administration shell or API response exposed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a browser has no Authentik session, **When** it requests
+   `https://vpn.lab.petebeegle.com/`, **Then** it reaches the Authentik login
+   flow before any wg-easy UI content.
+2. **Given** a browser has no Authentik session, **When** it requests a wg-easy
+   API path through the `vpn` hostname, **Then** it cannot receive the upstream
+   wg-easy API response without first passing Authentik.
+3. **Given** Authentik is unavailable, **When** a new unauthenticated request
+   reaches the `vpn` hostname, **Then** access fails closed rather than routing
+   directly to wg-easy.
+
+### User Story 2 - Preserve Authorized Operations (Priority: P2)
+
+An authorized WireGuard operator can complete Authentik login and reach the
+existing wg-easy UI, while other authenticated users remain denied.
+
+**Why this priority**: Authentication alone is insufficient for an
+administrative surface; explicit authorization limits the blast radius of a
+normal homelab account.
+
+**Independent Test**: Verify one account in the WireGuard administrator group
+can reach the wg-easy login/UI after Authentik, and one authenticated account
+outside the group receives an authorization denial.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user belongs to the WireGuard administrator
+   group, **When** the user opens the `vpn` hostname, **Then** Authentik permits
+   the request and the existing wg-easy authentication/UI remains usable.
+2. **Given** an authenticated user does not belong to the WireGuard
+   administrator group, **When** the user opens the `vpn` hostname, **Then**
+   Authentik denies access without forwarding the request to wg-easy.
+
+### User Story 3 - Keep VPN And Automation Stable (Priority: P3)
+
+Existing WireGuard clients and trusted in-cluster automation continue to work
+without traversing browser SSO.
+
+**Why this priority**: The UI security fix must not interrupt the UDP data plane
+or access-broker peer provisioning.
+
+**Independent Test**: Confirm the UDP Service and wg-easy workload are unchanged,
+an existing peer can still use the VPN service plane, and an in-cluster
+credentialed API probe to `wireguard-http.wireguard.svc.cluster.local:51821`
+still receives the expected authenticated behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing WireGuard peer, **When** the route protection is
+   reconciled, **Then** the peer can still establish a tunnel and reach its
+   existing allowed service-plane destinations.
+2. **Given** trusted in-cluster automation uses the ClusterIP Service with the
+   existing wg-easy credential, **When** it performs its supported operation,
+   **Then** the request bypasses the browser Gateway only and continues to work.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The implementation MUST require Authentik authentication for
+  every HTTP path served through `https://vpn.${cluster_domain}`.
+- **FR-002**: The implementation MUST restrict the Authentik application to a
+  dedicated WireGuard administrator group, with the built-in Authentik
+  administrator group retained as a break-glass path.
+- **FR-003**: The `vpn` hostname MUST fail closed when Authentik or its proxy
+  component cannot authorize a request.
+- **FR-004**: The browser-facing HTTPRoute MUST continue to use Cilium Gateway
+  API and MUST NOT add a traditional Kubernetes Ingress.
+- **FR-005**: The implementation MUST preserve the WireGuard UDP Service,
+  existing peer configuration, wg-easy persistent data, and direct in-cluster
+  Service access.
+- **FR-006**: The implementation MUST preserve wg-easy's own authentication as
+  defense in depth and for existing API clients.
+- **FR-007**: The Authentik configuration and Gateway backend references MUST
+  be fully expressed in Git and reconciled by Flux.
+- **FR-008**: The implementation MUST add an automated unauthenticated smoke
+  assertion for the exact `vpn` hostname and keep mirrored synthetic smoke
+  sources synchronized.
+- **FR-009**: Evidence MUST distinguish local render checks, development
+  validation or its production-only exception, production synthetic smoke,
+  authorized/unauthorized account checks, UDP peer verification, and direct
+  automation verification.
+- **FR-010**: Documentation MUST describe normal access, group membership,
+  failure behavior, verification, and rollback without revealing credentials.
+
+## Risk And Validation Expectations
+
+This is a high-risk authentication and production traffic-path change. Use
+focused manifest tests, broad Kubernetes/Flux render checks, an independent
+read-only review lane, and development-cluster validation where the environment
+can represent the changed resources. Because the standard development base
+omits both Authentik and VPN, any untestable production-only layer requires an
+explicit exception plus substitute local, synthetic, and live read-only checks.
+Successful completion requires the exact user path; readiness and
+`Accepted=True` alone are insufficient.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: 100% of unauthenticated requests tested at the `vpn` hostname,
+  including `/` and a representative API path, reach Authentik or an
+  Authentik-generated denial and expose no wg-easy response.
+- **SC-002**: A WireGuard administrator or built-in Authentik administrator
+  reaches the existing wg-easy UI, while an authenticated user in neither group
+  is denied in the same release verification.
+- **SC-003**: At least one existing WireGuard peer and the credentialed
+  in-cluster wg-easy API path pass post-change verification with no peer
+  recreation or credential migration.
+- **SC-004**: Local policy/render checks and the production synthetic smoke
+  complete successfully, with every unavailable development layer explicitly
+  recorded.
+- **SC-005**: The `vpn` route has accepted and resolved backend references and
+  the exact browser URL demonstrates the intended Authentik behavior after Flux
+  applies the target revision.
+
+## Assumptions
+
+- The desired audience is `WireGuard Admins`, with the existing `authentik
+  Admins` group as a break-glass path rather than all Authentik users, because
+  wg-easy can create, revoke, and reveal VPN client configurations.
+- Authentik proxy mode is preferred over native wg-easy OIDC because the pinned
+  wg-easy v15 documentation exposes local initial credentials but no supported
+  native OIDC configuration.
+- The existing LAN-only `gateway/internal` exposure remains intentional; this
+  change does not add `gateway/external` or `gateway/public`.
+- The access-broker continues to use the direct ClusterIP Service and existing
+  wg-easy credentials, so browser SSO does not become a machine-to-machine
+  dependency.
+- The separately requested audit informs follow-up prioritization but does not
+  expand this implementation into a multi-app authentication migration.
+
+## Open Questions
+
+- None. Populate `WireGuard Admins` through an existing `authentik Admins`
+  account after the blueprint reconciles.

--- a/specs/wireguard-authentik/tasks.md
+++ b/specs/wireguard-authentik/tasks.md
@@ -1,0 +1,161 @@
+---
+description: "Implementation tasks for the WireGuard Authentik gate"
+---
+
+# Tasks: wireguard-authentik
+
+**Input**: `specs/wireguard-authentik/spec.md` and
+`specs/wireguard-authentik/plan.md`
+**Risk Tier**: high
+**Prerequisites**: Branch `codex/wireguard-authentik` and matching
+`specs/wireguard-authentik/` artifacts. The user approved the spec and plan by
+requesting implementation.
+
+## Human Gate Status
+
+**Spec Gate**: approved by the user's explicit request to plan the named fix
+
+**Plan Gate**: approved by the user's 2026-07-25 instruction to implement
+
+**Analyze Requirement**: run before source implementation; proceed only with no
+critical or high unresolved findings
+
+## Format: `[ID] [P?] [Req] Description`
+
+- **[P]**: Can run in parallel because it touches different files or performs
+  read-only validation with no dependency on another incomplete task.
+- **[Req]**: Requirement or user-story trace.
+- All helper results and command outcomes are consolidated in
+  `specs/wireguard-authentik/evidence.md`.
+
+## Phase 1: Setup
+
+**Goal**: Establish approved artifacts and implementation evidence.
+
+- [x] T001 [FR-009] Update human gate status in
+      `specs/wireguard-authentik/plan.md` and initialize
+      `specs/wireguard-authentik/evidence.md` from the repository template.
+- [x] T002 [FR-009] Run Spec Kit analysis across
+      `specs/wireguard-authentik/spec.md`,
+      `specs/wireguard-authentik/plan.md`, and
+      `specs/wireguard-authentik/tasks.md`; resolve no source files until the
+      analysis has no critical or high finding.
+
+## Phase 2: User Story 1 - Gate WireGuard Administration (P1)
+
+**Goal**: Every HTTP path on the LAN `vpn` hostname reaches Authentik before
+wg-easy and fails closed.
+
+**Independent test**: In a fresh browser context, `/` and `/api/client` on
+`https://vpn.lab.petebeegle.com` reach Authentik or an Authentik denial and
+expose no wg-easy UI/API response.
+
+- [x] T003 [US1] Add the root and representative API-path Authentik assertions
+      to `tests/smoke/routes.spec.js` and mirror them in
+      `kubernetes/apps/synthetics/smoke/routes.spec.js`.
+- [x] T004 [US1] Run the focused test from `tests/smoke/routes.spec.js` against
+      the current production route and record the expected pre-fix failure in
+      `specs/wireguard-authentik/evidence.md`.
+- [x] T005 [US1] Add the `wireguard-proxy` Proxy Provider, Authentik
+      application, and embedded-outpost assignment in
+      `kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml`, and register
+      the ConfigMap in
+      `kubernetes/infra/authentik/blueprints/kustomization.yaml`.
+- [x] T006 [US1] Add a least-privilege cross-namespace Service
+      `ReferenceGrant` in `kubernetes/infra/authentik/referencegrant.yaml` and
+      register it in `kubernetes/infra/authentik/kustomization.yaml`, allowing
+      only `wireguard`-namespace HTTPRoutes to reference only
+      `authentik-server`.
+- [x] T007 [US1] Replace the direct wg-easy backend with
+      `authentik/authentik-server:80` in
+      `kubernetes/infra/network/vpn/httproute.yaml`, preserving the LAN-only
+      Gateway parent and hostname.
+- [x] T008 [US1] Add `authentik` to the `vpn` dependency list in
+      `kubernetes/clusters/production/infra/vpn.yaml` and add `vpn` to
+      `app-synthetics` dependencies in
+      `kubernetes/clusters/production/apps/synthetics.yaml`.
+
+## Phase 3: User Story 2 - Preserve Authorized Operations (P2)
+
+**Goal**: Only dedicated WireGuard administrators or built-in Authentik
+administrators can pass Authentik, and wg-easy retains its existing inner
+authentication.
+
+**Independent test**: An authenticated member of either authorized group reaches
+the wg-easy login/UI, while a user in neither group receives an Authentik
+authorization denial.
+
+- [x] T009 [US2] Add the `WireGuard Admins` group plus group-policy bindings for
+      `WireGuard Admins` or built-in `authentik Admins` break-glass access, with
+      no Basic Auth injection or unauthenticated path bypass, in
+      `kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml`.
+- [x] T010 [US2] Document group membership, double authentication, failure
+      behavior, authorized/non-member verification, and Git-revert recovery in
+      `docs/runbooks/wireguard.md`.
+
+## Phase 4: User Story 3 - Keep VPN And Automation Stable (P3)
+
+**Goal**: Preserve the WireGuard UDP data plane and trusted direct ClusterIP API
+path.
+
+**Independent test**: The rendered UDP and HTTP Services and wg-easy Deployment
+remain unchanged, and the evidence handoff includes existing-peer and
+credentialed direct-API verification.
+
+- [x] T011 [US3] Review the implementation diff and rendered manifests to prove
+      no changes to `kubernetes/infra/network/vpn/service.yaml`,
+      `kubernetes/infra/network/vpn/deployment.yaml`, WireGuard persistent
+      storage, or `kubernetes/apps/access-broker/configmap.yaml`; record the
+      result in `specs/wireguard-authentik/evidence.md`.
+- [x] T012 [US3] Add the direct ClusterIP automation boundary and post-rollout
+      peer/API verification procedure to `docs/runbooks/wireguard.md`.
+
+## Phase 5: Polish And Cross-Cutting Validation
+
+**Goal**: Keep documentation, generated architecture, validation, and evidence
+coherent.
+
+- [x] T013 [P] [FR-008] Add the `vpn` Authentik target and expected behavior to
+      `docs/runbooks/synthetic-smoke-tests.md`.
+- [x] T014 [FR-007] Regenerate `docs/architecture.md` with
+      `python3 tools/architecture/render.py --write`.
+- [x] T015 [FR-009] Run smoke mirroring, focused Playwright, Authentik/VPN and
+      production renders, generated architecture, diff, secret scan, and full
+      pre-commit checks; record exact outcomes in
+      `specs/wireguard-authentik/evidence.md`.
+- [x] T016 [FR-009] Record `smoke_profile: none` and the development-cluster
+      Authentik/VPN omission as the unavailable-infrastructure exception, plus
+      the required post-merge Flux, route, persona, peer, direct-API, and
+      one-off synthetic verification handoff in
+      `specs/wireguard-authentik/evidence.md`.
+- [x] T017 [FR-CONVERGE] Run Spec Kit converge against the finished code; if it
+      appends tasks to `specs/wireguard-authentik/tasks.md`, complete them and
+      rerun convergence.
+- [x] T018 [FR-EVIDENCE] Re-check constitution gates, mark all completed tasks,
+      and finalize documentation impact, test layers, exceptions, and current
+      branch state in `specs/wireguard-authentik/evidence.md`.
+
+## Dependencies
+
+- Phase 1 blocks all source implementation.
+- User Story 1 is the MVP and blocks User Story 2 because the group policy binds
+  the application created in US1.
+- User Story 3 can be reviewed after the route and blueprint edits exist.
+- Cross-cutting validation follows all source and documentation edits.
+- Convergence follows implementation and may append a final remediation phase.
+
+## Parallel Opportunities
+
+- T013 can run independently after the smoke expectation is stable.
+- Read-only review of T011 can run independently of documentation edits.
+- Local render commands for Authentik, VPN, and production can run in parallel
+  once implementation files are complete.
+
+## Implementation Strategy
+
+1. Establish TDD evidence by adding the exact-path smoke first.
+2. Deliver the P1 proxy-mode gate and fail-closed route.
+3. Add P2 group authorization without weakening wg-easy's own login.
+4. Prove P3 data-plane and machine-client preservation.
+5. Complete broad local validation, document the development exception, and
+   converge before handoff.

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -42,6 +42,18 @@ test.describe("homelab routed services", () => {
     await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
   });
 
+  test("wireguard reaches Authentik before the wg-easy UI", async ({ page }) => {
+    await gotoOk(page, urlFor("vpn"));
+    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
+  test("wireguard reaches Authentik before the wg-easy API", async ({ page }) => {
+    await gotoOk(page, urlFor("vpn", "/api/client"));
+    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
+    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+  });
+
   test("grafana reaches the login or landing shell", async ({ page }) => {
     await gotoOk(page, urlFor("monitoring"));
     await expect(page.locator("body")).toContainText(/Grafana|Login|Sign in|Welcome/i);


### PR DESCRIPTION
## Summary

- route `vpn.${cluster_domain}` through an Authentik proxy provider and embedded outpost
- authorize `WireGuard Admins` with built-in `authentik Admins` retained for break-glass access
- preserve wg-easy local authentication, WireGuard UDP, persistent data, and access-broker's direct ClusterIP API path
- add root and `/api/client` synthetic coverage, Flux dependency ordering, runbooks, and generated architecture

## Why

The WireGuard administration hostname currently routes directly to wg-easy, bypassing the homelab's central Authentik authentication and authorization layer.

## Validation

- full `pre-commit run --all-files` passed, including yamllint and k8svalidate
- Authentik, VPN, and production Kustomize/Flux renders passed
- Authentik blueprint model fields validated against the current upstream schema
- smoke mirroring and test discovery passed
- expected-failing pre-change production smoke proved both `/` and `/api/client` currently bypass Authentik
- development smoke exception documented because the development base intentionally omits Authentik and VPN

## Deployment verification

After merge and Flux reconciliation, verify the applied SHA, Authentik blueprint/outpost state, `Accepted=True` and `ResolvedRefs=True`, unauthenticated root/API redirects, authorized and unauthorized personas, an existing WireGuard peer, the access-broker API path, and a one-off production synthetic Job. Full handoff is in `specs/wireguard-authentik/evidence.md`.