### PR TITLE
fix: retain the WireGuard Authentik proxy

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/wireguard-authentik"}
+{"feature_directory":"specs/wireguard-authentik-outpost"}

--- a/docs/runbooks/authentik-proxy-apps.md
+++ b/docs/runbooks/authentik-proxy-apps.md
@@ -1,0 +1,221 @@
+---
+status: current
+scope:
+  - authentik
+  - proxy-providers
+  - embedded-outpost
+authority: operational
+created: 2026-07-25
+last_verified: 2026-07-25
+---
+
+# Add An Authentik Proxy Application
+
+Use this runbook when an HTTP application cannot implement OAuth or OIDC and
+Authentik must authenticate users before proxying requests to the application.
+This procedure applies to Authentik proxy-mode providers served by the embedded
+outpost.
+
+## Ownership Rule
+
+Exactly one blueprint owns the embedded outpost's `providers` attribute.
+Authentik treats that attribute as the complete desired list, not an additive
+patch. If two blueprints set it, the last blueprint to apply removes providers
+that appear only in the other list.
+
+The authoritative list is `private-app-proxy.yaml` in the SOPS-encrypted
+two-key Secret:
+
+```text
+homelab-private/kubernetes/infra/authentik/blueprints/private-authentik-blueprint-secret.yaml
+```
+
+Public application blueprints may create a proxy provider, application, groups,
+and policy bindings. They must not contain an
+`authentik_outposts.outpost` entry. Every proxy provider, public or private,
+must also be added to the authoritative private list.
+
+That Secret is owned only by the private Authentik blueprint Kustomization and
+contains both `private-app-proxy.yaml` and `private-app-icons.yaml`. Never
+generate or apply another Secret with the same name from an application
+Kustomization; one Flux apply can remove the other owner's data key.
+
+## Before You Start
+
+Confirm the application is suitable for a reverse proxy:
+
+- It uses HTTP or HTTPS; protocol-only TCP/UDP services need a different
+  control.
+- Authentik may proxy every browser and API path needed by the application.
+- The upstream Service is reachable from the `authentik` namespace.
+- WebSockets, large uploads, and streaming behavior are identified for smoke
+  coverage.
+- An authorization group and a tested break-glass administrator are defined.
+
+Use one named implementation and coordinate the public and private repository
+changes. Do not apply the Authentik objects manually as the durable fix.
+
+## Add The Provider And Application
+
+Create a blueprint under `kubernetes/infra/authentik/blueprints/` in the public
+homelab repository. A proxy-mode provider needs:
+
+- a unique provider name;
+- `mode: proxy`;
+- the externally routed HTTPS hostname;
+- an in-cluster upstream URL;
+- authorization and invalidation flows;
+- an Authentik application that references the provider;
+- explicit application policy bindings.
+
+Use a stable Service DNS name for `internal_host`. Keep application credentials
+in the upstream application's SOPS Secret; do not put them in headers or
+blueprints unless the integration explicitly requires that behavior.
+
+Register the blueprint ConfigMap in
+`kubernetes/infra/authentik/blueprints/kustomization.yaml` and mount it through
+`kubernetes/infra/authentik/app.yaml`.
+
+Do not add this block to an application blueprint:
+
+```yaml
+- model: authentik_outposts.outpost
+  identifiers:
+    managed: goauthentik.io/outposts/embedded
+  attrs:
+    providers: []
+```
+
+Even a one-provider list replaces the existing assignments when it applies.
+
+## Add The Provider To The Embedded Outpost
+
+In the private repository, decrypt only the `private-app-proxy.yaml` value into
+ignored runtime scratch. Do not print its content:
+
+```bash
+mkdir -p .codex/tmp/implementation-secrets/<implementation>
+sops --decrypt \
+  --extract '["stringData"]["private-app-proxy.yaml"]' \
+  kubernetes/infra/authentik/blueprints/private-authentik-blueprint-secret.yaml \
+  > .codex/tmp/implementation-secrets/<implementation>/private-app-proxy.yaml
+```
+
+Add one `!Find` entry to the existing embedded-outpost `providers` list:
+
+```yaml
+- !Find [authentik_providers_proxy.proxyprovider, [name, <provider-name>]]
+```
+
+Preserve every existing entry. Re-encrypt the value without sending plaintext
+to the terminal:
+
+```bash
+jq -Rsa . \
+  < .codex/tmp/implementation-secrets/<implementation>/private-app-proxy.yaml |
+  sops set --value-stdin \
+    kubernetes/infra/authentik/blueprints/private-authentik-blueprint-secret.yaml \
+    '["stringData"]["private-app-proxy.yaml"]'
+```
+
+Verify `sops filestatus` reports `encrypted: true`, then remove the decrypted
+scratch after validation. Never commit the scratch file.
+
+## Route The Hostname
+
+Use Gateway API. For full proxy mode, the application `HTTPRoute` sends the
+hostname to `authentik/authentik-server:80`; a cross-namespace backend also
+requires a narrowly scoped `ReferenceGrant` in `authentik`.
+
+Keep machine-only ClusterIP access separate when trusted automation must bypass
+browser SSO. Do not expose that Service through another human-facing route.
+
+## Validate Before Merge
+
+At minimum:
+
+1. Render the Authentik, application, synthetics, and target cluster
+   Kustomizations.
+2. Validate the public blueprint against the deployed Authentik version.
+3. Confirm no public blueprint writes
+   `authentik_outposts.outpost.attrs.providers`.
+4. Decrypt only for a non-content-emitting check that the authoritative list
+   contains all previous providers plus the new provider exactly once.
+5. Confirm the private production render contains exactly one
+   `private-authentik-blueprints` Secret with both expected keys.
+6. Confirm every changed Secret reports encrypted and scan the diff for
+   plaintext.
+7. Add unauthenticated UI and API-path smoke tests that identify Authentik and
+   explicitly reject upstream application content.
+8. Plan an authenticated smoke that proves the original hostname reaches the
+   upstream application after authorization.
+
+An unauthenticated Authentik page, a route with `Accepted=True`, and a ready
+Kustomization do not prove the proxy handoff.
+
+## Post-Merge Verification
+
+Verify each layer in order:
+
+```bash
+. scripts/kube-aliases.sh
+fp get gitrepository homelab
+fp get kustomizations authentik vpn app-synthetics
+kp -n <app-namespace> get httproute <route> -o yaml
+```
+
+Then inspect Authentik read-only state. The embedded outpost must contain the new
+provider and every previous provider. Requests for the application hostname
+must be logged by `authentik.outpost.proxyv2.application` with the new provider
+name; requests logged only by `authentik.asgi` are reaching Authentik itself,
+not its proxy engine.
+
+Complete three browser checks:
+
+1. No session: UI and sensitive API paths enter Authentik and reveal no upstream
+   content.
+2. Unauthorized session: Authentik denies the application.
+3. Authorized session: the original application hostname serves the upstream
+   application and its essential API/WebSocket paths.
+
+## Troubleshooting
+
+### Authentication Ends At Authentik
+
+Query the proxy provider and embedded-outpost assignments. If the provider
+exists but is absent from the outpost, compare blueprint `last_applied` times.
+A later blueprint with a shorter `providers` list has replaced the assignment.
+
+Fix the authoritative private list and remove all competing outpost entries.
+Do not repeatedly restart Authentik; the same blueprints will reproduce the
+same state.
+
+If the mounted directory lacks either private blueprint file, inspect the
+rendered Secret and Flux ownership. Consolidate both keys under the private
+Authentik blueprint Kustomization; do not create a second same-named Secret.
+
+### Existing Proxy Applications Stop Working
+
+Treat this as a provider-list regression. Revert the private-list change or
+restore the omitted entries in Git, then allow Flux and the blueprint worker to
+reconcile. Verify all previous applications before accepting the repair.
+
+### Provider Cannot Reach The Upstream
+
+Check Service DNS, port, NetworkPolicy, endpoints, and application logs from the
+cluster. Do not change the human route to bypass Authentik as a diagnostic
+shortcut.
+
+## Rollback
+
+Revert both halves of the implementation:
+
+1. Remove the provider reference from the authoritative private outpost list
+   while preserving all other entries.
+2. Revert the public route/provider/application resources to their previous
+   desired state.
+
+Merge the coordinated rollback and verify Flux, outpost membership, the route,
+and the exact user path. A direct application backend is acceptable only when
+it restores the previously approved exposure; never introduce a new
+unauthenticated exposure as an emergency workaround.

--- a/docs/runbooks/wireguard.md
+++ b/docs/runbooks/wireguard.md
@@ -8,6 +8,8 @@ The human administration URL, `https://vpn.<cluster-domain>`, is LAN-only on
 `gateway/internal` and is protected by the Authentik embedded proxy outpost.
 The Authentik `wireguard-proxy` provider forwards authorized requests to
 `http://wireguard-http.wireguard.svc.cluster.local:51821`.
+See `docs/runbooks/authentik-proxy-apps.md` before adding or changing proxy
+providers; the embedded outpost provider list has a single authoritative owner.
 
 Access is allowed to either of these Authentik groups:
 

--- a/kubernetes/apps/synthetics/smoke/routes.spec.js
+++ b/kubernetes/apps/synthetics/smoke/routes.spec.js
@@ -26,6 +26,19 @@ async function expectNotHomeAssistantOnboarding(page) {
   ).toBe(false);
 }
 
+async function expectAuthentikGate(page, response) {
+  const headers = await response.allHeaders();
+  const body = page.locator("body");
+
+  expect(
+    /authentik/i.test(headers["x-powered-by"] || "") ||
+      /authentik\.|\/(?:if\/flow|flows\/-|outpost\.goauthentik\.io)\//i.test(page.url()),
+    "request should be handled by Authentik"
+  ).toBe(true);
+  await expect(body).toContainText(/authentik|Sign in|Login|Username/i);
+  await expect(body).not.toContainText(/wg-easy|WireGuard Easy|New Client/i);
+}
+
 test.describe("homelab routed services", () => {
   test("homepage serves the dashboard at the homepage subdomain", async ({ page }) => {
     await gotoOk(page, urlFor("homepage"));
@@ -43,15 +56,13 @@ test.describe("homelab routed services", () => {
   });
 
   test("wireguard reaches Authentik before the wg-easy UI", async ({ page }) => {
-    await gotoOk(page, urlFor("vpn"));
-    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
-    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+    const response = await gotoOk(page, urlFor("vpn"));
+    await expectAuthentikGate(page, response);
   });
 
   test("wireguard reaches Authentik before the wg-easy API", async ({ page }) => {
-    await gotoOk(page, urlFor("vpn", "/api/client"));
-    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
-    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+    const response = await gotoOk(page, urlFor("vpn", "/api/client"));
+    await expectAuthentikGate(page, response);
   });
 
   test("grafana reaches the login or landing shell", async ({ page }) => {

--- a/kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml
+++ b/kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml
@@ -54,10 +54,3 @@ entries:
       order: 1
     attrs:
       group: !Find [authentik_core.group, [name, authentik Admins]]
-
-  - model: authentik_outposts.outpost
-    identifiers:
-      managed: goauthentik.io/outposts/embedded
-    attrs:
-      providers:
-        - !Find [authentik_providers_proxy.proxyprovider, [name, wireguard-proxy]]

--- a/specs/wireguard-authentik-outpost/evidence.md
+++ b/specs/wireguard-authentik-outpost/evidence.md
@@ -1,0 +1,71 @@
+# Evidence: wireguard-authentik-outpost
+
+**Branch**: `codex/wireguard-authentik-outpost`
+**Date**: 2026-07-25
+
+## Diagnosis
+
+- Live `ProxyProvider` state contains `wireguard-proxy` with external host
+  `https://vpn.lab.petebeegle.com` and the wg-easy internal Service URL.
+- Live embedded-outpost membership contains the six pre-existing proxy
+  providers but not `wireguard-proxy`.
+- `wireguard-proxy-setup` applied successfully at `16:33:47Z`.
+- `private-app-proxy-setup` applied successfully at `16:34:24Z`, after which
+  WireGuard was absent from the full provider list.
+- Requests for the VPN hostname are logged by `authentik.asgi`, while working
+  proxy applications are logged by `authentik.outpost.proxyv2.application`.
+- Post-merge verification of the first private correction found a second race:
+  `private-apps` and `app-sabnzbd` both wrote
+  `Secret/private-authentik-blueprints`. The later apply left only
+  `private-app-icons.yaml`, removing the mounted proxy blueprint key.
+
+## Workflow
+
+- The user explicitly approved the desired corrective outcome by reporting that
+  the merged behavior did not hand off to WireGuard.
+- Clarify found no material ambiguity.
+- Checklist is represented by the explicit requirements and validation tasks
+  for this narrow production regression.
+- Default `/workspaces/homelab-worktrees` is unavailable; the established
+  writable fallback `/home/vscode/homelab-worktrees` is used.
+- Development exception: development does not deploy the production
+  Authentik/private proxy blueprint or VPN application.
+
+## Analyze
+
+- 9 functional requirements and 5 success criteria map to T001-T014.
+- No critical ambiguity, duplicate requirement, unmapped task, or constitution
+  conflict was found before implementation.
+
+## Command Evidence
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| Live Authentik read-only Django query | FAIL before fix | Provider existed, but embedded outpost contained six other providers and omitted `wireguard-proxy`. |
+| Live blueprint instance query | PASS diagnosis | Public WireGuard blueprint applied at `16:33:47Z`; private full-list blueprint applied later at `16:34:24Z`. |
+| Public Authentik, VPN, synthetics, and production `kubectl kustomize` renders | PASS | All affected desired-state entrypoints render. |
+| Private production apps `kubectl kustomize` render | PASS | Encrypted private blueprint Secret renders. |
+| `sops filestatus kubernetes/apps/sabnzbd/private-authentik-blueprint-secret.yaml` | PASS | Reported `encrypted: true`. |
+| Non-content-emitting decrypted provider count | PASS | Seven total embedded-outpost provider references; WireGuard appears exactly once. |
+| Unified private blueprint Secret render | PASS | Exactly one Secret document contains both `private-app-proxy.yaml` and `private-app-icons.yaml`. |
+| `cmp tests/smoke/routes.spec.js kubernetes/apps/synthetics/smoke/routes.spec.js` | PASS | Smoke source and deployed mirror are identical. |
+| `npm test -- --grep 'wireguard reaches Authentik'` | PASS | Two focused unauthenticated browser tests passed against the current live path. |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture remains current. |
+| `pre-commit run --all-files` | PASS | All public repository checks passed. |
+| `git diff --check` in both repositories | PASS | No whitespace errors. |
+
+## Convergence
+
+Clean: the implementation satisfies FR-001 through FR-008 and SC-001,
+SC-004, and SC-005 at render/test level. SC-001 through SC-004 require
+post-merge live verification; SC-003 specifically requires an authorized
+operator browser session.
+
+No additional convergence tasks were required.
+
+## Development Validation Exception
+
+Development does not deploy the production Authentik instance, private proxy
+blueprint, or VPN application. Substitute evidence consists of both repository
+renders, SOPS validation, provider-list preservation/count checks, the exact
+production unauthenticated browser smoke, and required post-merge live checks.

--- a/specs/wireguard-authentik-outpost/plan.md
+++ b/specs/wireguard-authentik-outpost/plan.md
@@ -1,0 +1,97 @@
+# Implementation Plan: wireguard-authentik-outpost
+
+**Branch**: `codex/wireguard-authentik-outpost` | **Date**: 2026-07-25 |
+**Spec**: `specs/wireguard-authentik-outpost/spec.md`
+
+## Summary
+
+The public WireGuard blueprint and the existing private proxy blueprint both
+write the embedded outpost's full many-to-many provider list. Live evidence
+shows the public blueprint adds WireGuard, then the private blueprint reapplies
+37 seconds later and removes it. Make the existing private blueprint the sole
+owner of that list by adding WireGuard there and removing the competing outpost
+entry from the public blueprint.
+
+## Technical Context
+
+**SDD Tier**: high
+**Workflow Risk Tier**: high
+**Primary Areas**: Authentik blueprints, SOPS Secret, synthetic browser tests
+**Ingress**: Existing Gateway API route remains unchanged
+**Secrets**: Edit only through SOPS; never log decrypted content
+**Smoke Strategy**: Exact unauthenticated URL checks plus live authenticated
+operator verification after merge
+**Fanout Targets**: None; the provider-list edit and tests share one critical
+authentication path
+**Development Validation**: Exception expected because development omits the
+production Authentik/private blueprint and VPN application. Use render,
+blueprint schema, encryption, and production post-merge user-path checks.
+
+## Human Gates
+
+**Spec Gate**: Approved by the user's explicit report of incorrect behavior.
+**Clarify Gate**: No questions required; expected handoff behavior is explicit.
+**Plan Gate**: Consolidated with the corrective implementation instruction.
+**Task/Analyze Gate**: Consolidated for the narrow production regression;
+analysis must show complete requirement coverage before editing behavior.
+
+## Technical Approach
+
+1. Keep provider/application/policy definitions in the public WireGuard
+   blueprint.
+2. Remove its embedded-outpost mutation so it cannot race the authoritative
+   full provider list.
+3. Decrypt the existing SOPS Secret only into ignored runtime scratch, append
+   the WireGuard provider reference to the private blueprint's existing outpost
+   list, consolidate the proxy and icon blueprints under one Secret owner, and
+   re-encrypt the tracked manifest.
+4. Correct synthetic assertions to accept Authentik's current flow paths and
+   explicitly reject wg-easy content before login.
+5. Add an Authentik proxy runbook that makes the private blueprint the sole
+   embedded-outpost provider-list owner and documents safe addition,
+   verification, troubleshooting, and rollback.
+6. Validate renders, encryption, blueprint ownership, existing provider
+   preservation, and the exact URL.
+
+## Constitution Check
+
+- [x] Git remains the source of durable state.
+- [x] Gateway API remains the ingress contract.
+- [x] Secret plaintext remains outside Git and command output.
+- [x] High-risk evidence and development exception are explicit.
+- [x] A dedicated branch, worktree, spec directory, and PR are used.
+
+## Project Structure
+
+```text
+kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml
+kubernetes/infra/authentik/secret.yaml
+kubernetes/apps/synthetics/smoke/routes.spec.js
+tests/smoke/routes.spec.js
+docs/runbooks/authentik-proxy-apps.md
+specs/wireguard-authentik-outpost/
+```
+
+## Validation
+
+- SOPS `filestatus` and no-plaintext scans.
+- Authentik blueprint parse/schema validation.
+- Render Authentik, VPN, synthetics, and production entrypoint.
+- Verify only the private blueprint mutates embedded-outpost providers.
+- Verify its provider list preserves the six live assignments and WireGuard.
+- Verify one rendered Secret contains both private blueprint keys and is owned
+  by the private Authentik blueprint Kustomization.
+- Run mirrored smoke checks.
+- Review runbook commands and links against the implemented manifests.
+- After merge, confirm Flux revision, live outpost membership, proxy log
+  ownership, unauthenticated denial, and authenticated wg-easy landing.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Existing providers are removed | Preserve and validate the complete authoritative list |
+| One Flux apply removes another blueprint key | Render one Secret from one Kustomization with both keys |
+| Decrypted secret material leaks | Use ignored scratch, suppress content output, re-encrypt immediately |
+| Blueprint ordering regresses | Give one blueprint sole ownership of the outpost list |
+| Smoke passes on Authentik 404 | Assert both auth handling and successful authenticated wg-easy content |

--- a/specs/wireguard-authentik-outpost/spec.md
+++ b/specs/wireguard-authentik-outpost/spec.md
@@ -1,0 +1,102 @@
+# Feature Specification: wireguard-authentik-outpost
+
+**Feature Branch**: `codex/wireguard-authentik-outpost`
+**Created**: 2026-07-25
+**Status**: Approved for implementation
+**Risk Tier**: high
+**Input**: Correct the merged WireGuard Authentik proxy so successful
+authentication reaches the wg-easy UI instead of leaving users at Authentik.
+
+## Human Gate Status
+
+**Intent Brief**: The user reported that `https://vpn.lab.petebeegle.com/`
+terminates at Authentik instead of authenticating and proxying to WireGuard.
+
+**Clarify Status**: No critical ambiguity. The expected behavior is explicit:
+unauthenticated requests enter Authentik, authorized sessions reach wg-easy,
+and direct unauthenticated access remains blocked.
+
+**Spec Gate**: Approved by the user's correction of the deployed behavior.
+
+## User Scenarios
+
+### User Story 1 - Authorized administrator reaches wg-easy (P1)
+
+After authenticating with an allowed Authentik identity, a WireGuard
+administrator reaches the wg-easy application at the original VPN URL.
+
+**Independent Test**: Confirm an authenticated request is handled by the
+WireGuard proxy provider and returns wg-easy rather than Authentik's application
+UI or a 404.
+
+### User Story 2 - Unauthenticated access remains denied (P1)
+
+An unauthenticated request to either the UI or its API cannot reach wg-easy
+without completing Authentik authentication and authorization.
+
+**Independent Test**: Request `/` and `/api/client` without a session and
+confirm the response is an Authentik authorization path, never a wg-easy
+response.
+
+## Requirements
+
+- **FR-001**: The WireGuard proxy provider MUST be assigned to the active
+  embedded Authentik outpost after every blueprint reconciliation.
+- **FR-002**: The authoritative outpost provider list MUST preserve every
+  existing proxy provider while adding WireGuard.
+- **FR-003**: Authenticated, authorized traffic MUST proxy to the existing
+  wg-easy Service.
+- **FR-004**: Unauthenticated UI and API traffic MUST remain unable to reach
+  wg-easy.
+- **FR-005**: Durable state MUST be GitOps-managed and any affected secret
+  manifest MUST remain SOPS-encrypted.
+- **FR-006**: Automated smoke assertions MUST recognize the current Authentik
+  flow and distinguish Authentik handling from successful wg-easy proxying.
+- **FR-007**: Operators MUST have a runbook for adding an Authentik proxy
+  application without creating competing ownership of the embedded-outpost
+  provider list.
+- **FR-008**: The runbook MUST cover blueprint design, safe SOPS editing,
+  required render and smoke validation, post-merge reconciliation checks, and
+  rollback/troubleshooting for provider-list races.
+- **FR-009**: Exactly one Flux Kustomization MUST own the
+  `private-authentik-blueprints` Secret, and that Secret MUST retain both the
+  proxy and icon blueprint keys.
+
+## Success Criteria
+
+- **SC-001**: Live embedded-outpost state contains WireGuard and all previously
+  assigned proxy providers.
+- **SC-002**: Live proxy logs identify the WireGuard provider when serving the
+  VPN hostname.
+- **SC-003**: An authorized browser reaches wg-easy at the VPN URL.
+- **SC-004**: Unauthenticated checks for `/` and `/api/client` do not expose
+  wg-easy.
+- **SC-005**: An operator can follow one documented procedure to add a proxy
+  while preserving all existing embedded-outpost assignments.
+
+## Edge Cases
+
+- A later blueprint reconciliation must not remove WireGuard from the outpost.
+- Existing proxy applications must not lose their outpost assignments.
+- A fresh Authentik worker start must converge to the same provider list.
+- Reconciliation of an application Kustomization must not remove another
+  Authentik blueprint key from the mounted Secret.
+
+## Out of Scope
+
+- Replacing wg-easy's application or changing WireGuard tunnel traffic.
+- Reworking unrelated Authentik proxy applications.
+
+## Assumptions
+
+- The existing private proxy blueprint is the authoritative owner of the
+  embedded outpost's complete provider list.
+- Existing administrators remain the break-glass authorization path.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/decisions/flux-gitops-source-of-truth.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/runbooks/implementation-workflow.md`

--- a/specs/wireguard-authentik-outpost/tasks.md
+++ b/specs/wireguard-authentik-outpost/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: wireguard-authentik-outpost
+
+**Input**: `spec.md` and `plan.md`
+**Risk Tier**: high
+
+## Phase 1: Regression Evidence
+
+- [x] T001 [US1] Record live proof that WireGuard exists as a proxy provider but
+      is absent from the embedded outpost in `evidence.md`.
+- [x] T002 [US1] Record blueprint apply ordering that demonstrates the
+      competing provider-list ownership in `evidence.md`.
+- [x] T003 [US2] Correct the focused unauthenticated smoke contract in
+      `tests/smoke/routes.spec.js` and its deployed mirror.
+
+## Phase 2: Implementation
+
+- [x] T004 [US1] Remove embedded-outpost ownership from
+      `kubernetes/infra/authentik/blueprints/wireguard-proxy.yaml`.
+- [x] T005 [US1] Add the WireGuard provider to the complete outpost provider
+      list inside SOPS-encrypted `kubernetes/infra/authentik/secret.yaml`.
+- [x] T006 [US1] Verify all six existing provider assignments remain present
+      alongside WireGuard and consolidate both private blueprint keys under one
+      encrypted Secret owner without emitting secret plaintext.
+
+## Phase 3: Verification
+
+- [x] T007 [US1] Validate Authentik blueprint structure and rendered manifests.
+- [x] T008 [US2] Validate SOPS encryption and scan for plaintext leakage.
+- [x] T009 [US2] Run local synthetic smoke lint/list checks and mirror checks.
+- [x] T010 Record development-cluster exception and substitute evidence in
+      `evidence.md`.
+- [x] T011 [US1] Add the proxy onboarding, SOPS, validation, troubleshooting,
+      and rollback procedure to `docs/runbooks/authentik-proxy-apps.md`.
+- [x] T012 Run convergence analysis and close any remaining requirements.
+
+## Phase 4: Delivery
+
+- [ ] T013 Commit, push, open a PR, and merge after required checks.
+- [ ] T014 Verify Flux reconciliation, live outpost membership, unauthenticated
+      denial, and authenticated wg-easy landing after merge.

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -26,6 +26,19 @@ async function expectNotHomeAssistantOnboarding(page) {
   ).toBe(false);
 }
 
+async function expectAuthentikGate(page, response) {
+  const headers = await response.allHeaders();
+  const body = page.locator("body");
+
+  expect(
+    /authentik/i.test(headers["x-powered-by"] || "") ||
+      /authentik\.|\/(?:if\/flow|flows\/-|outpost\.goauthentik\.io)\//i.test(page.url()),
+    "request should be handled by Authentik"
+  ).toBe(true);
+  await expect(body).toContainText(/authentik|Sign in|Login|Username/i);
+  await expect(body).not.toContainText(/wg-easy|WireGuard Easy|New Client/i);
+}
+
 test.describe("homelab routed services", () => {
   test("homepage serves the dashboard at the homepage subdomain", async ({ page }) => {
     await gotoOk(page, urlFor("homepage"));
@@ -43,15 +56,13 @@ test.describe("homelab routed services", () => {
   });
 
   test("wireguard reaches Authentik before the wg-easy UI", async ({ page }) => {
-    await gotoOk(page, urlFor("vpn"));
-    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
-    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+    const response = await gotoOk(page, urlFor("vpn"));
+    await expectAuthentikGate(page, response);
   });
 
   test("wireguard reaches Authentik before the wg-easy API", async ({ page }) => {
-    await gotoOk(page, urlFor("vpn", "/api/client"));
-    await expect(page).toHaveURL(/authentik\.|vpn\.[^/]+\/outpost\.goauthentik\.io\//i);
-    await expect(page.locator("body")).toContainText(/authentik|Sign in|Login|Username/i);
+    const response = await gotoOk(page, urlFor("vpn", "/api/client"));
+    await expectAuthentikGate(page, response);
   });
 
   test("grafana reaches the login or landing shell", async ({ page }) => {


### PR DESCRIPTION
## What changed

- stop the public WireGuard blueprint from competing for embedded-outpost provider-list ownership
- correct WireGuard unauthenticated smoke assertions for current Authentik flow URLs
- add an operator runbook for safely adding Authentik proxy applications
- record the cross-repository diagnosis, plan, tasks, and evidence

## Root cause

Two successful blueprints owned Authentik's complete embedded-outpost provider list. The WireGuard blueprint added itself, then the private proxy blueprint reconciled 37 seconds later and removed it. Post-merge verification also found two private Flux Kustomizations racing on the same blueprint Secret.

## Validation

- Authentik, VPN, synthetics, and production Kustomize renders passed
- focused Playwright checks passed (2/2)
- smoke mirror and generated architecture checks passed
- `pre-commit run --all-files` passed
- private #40 adds WireGuard to the seven-provider authoritative list
- private #41 consolidates both private blueprint keys under one encrypted Secret owner

Private #40 is merged. Private #41 should merge and reconcile before this public cleanup.