### PR TITLE
feat(jellyfin): move config to local storage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-home-assistant` | `./kubernetes/apps/home-assistant` | `gateway`, `nfs-csi`, `authentik` | `cluster-vars` | `sops` |
 | `production` | `app-homepage` | `./kubernetes/apps/homepage` | `gateway`, `metrics-server` | `cluster-vars` | `no` |
 | `production` | `app-immich` | `./kubernetes/apps/immich` | `gateway`, `nfs-csi`, `local-path-provisioner`, `cloudnative-pg`, `authentik` | `cluster-vars` | `sops` |
-| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `intel-gpu-device-plugin` | `cluster-vars` | `no` |
+| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `local-path-provisioner`, `intel-gpu-device-plugin` | `cluster-vars` | `no` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
 | `production` | `private-source` | `./kubernetes/clusters/production/apps/private/source` | (none) | `(none)` | `sops` |
@@ -215,11 +215,11 @@ This document is generated for agentic repo navigation. It records relationships
 | PVC | `home-assistant/home-assistant-config` | `nfs-csi-storage` | `kubernetes/apps/home-assistant/pvc.yaml` |
 | PVC | `immich/immich-library` | `nfs-csi-media-storage` | `kubernetes/apps/immich/base/pvc.yaml` |
 | PVC | `jellyfin-${branch_slug}/jellyfin-config-${branch_slug}` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/branch/jellyfin.yaml` |
+| PVC | `jellyfin/jellyfin-config-local-v1` | `local-path` | `kubernetes/apps/jellyfin/pvc.yaml` |
 | PVC | `jellyfin/jellyfin-config-v2` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/pvc.yaml` |
 | PVC | `wireguard/wireguard-pvc` | `nfs-csi-storage` | `kubernetes/infra/network/vpn/pvc.yaml` |
 | Values file | `authentik` | `nfs-csi-storage` | `kubernetes/infra/authentik/values.yaml` |
 | Values file | `immich` | `nfs-csi-storage` | `kubernetes/apps/immich/base/values.yaml` |
-| Values file | `jellyfin` | `nfs-csi-storage` | `kubernetes/apps/jellyfin/values.yaml` |
 
 ## Secret Manifests
 

--- a/docs/decisions/jellyfin-local-config-storage.md
+++ b/docs/decisions/jellyfin-local-config-storage.md
@@ -1,0 +1,87 @@
+---
+id: ADR-0015
+status: accepted
+scope:
+  - jellyfin
+  - storage
+  - local-path
+  - authentication
+authority: binding
+created: 2026-08-08
+last_verified: 2026-08-08
+supersedes: []
+superseded_by:
+---
+
+# Jellyfin Local Config Storage
+
+## Decision
+
+Use the `local-path` StorageClass for Jellyfin's `/config` volume while keeping
+media on the existing Synology NFS export.
+
+Migrate the complete existing `jellyfin-config-v2` PVC into a new
+`jellyfin-config-local-v1` PVC before Jellyfin starts. The migration source is
+mounted read-only, the Deployment uses the `Recreate` strategy, and an init
+container validates the copied Jellyfin databases, SSO plugin, SSO
+configuration, branding, and system configuration before creating a completion
+marker.
+
+The existing NFS PVC remains declared and retained as a point-in-time rollback
+source. The Authentik blueprint, OAuth client ID, encrypted client secret,
+redirect URI, group names, and native Jellyfin login behavior are not changed by
+the storage migration.
+
+This decision is an app-specific exception to the default persistent-app storage
+rule in `docs/decisions/synology-nfs-storage.md`.
+
+## Rationale
+
+- Jellyfin performs latency-sensitive SQLite, metadata, and plugin-state I/O
+  under `/config` while discovering and ingesting media.
+- Those operations currently traverse NFS and compete with media reads and
+  Sonarr/Radarr imports on the NAS.
+- Node-local storage removes NFS latency from the Jellyfin database and metadata
+  path without moving the media library.
+- Copying the complete config tree preserves Jellyfin user identities, native
+  credentials, permissions, plugins, and SSO state together.
+- A fail-closed init sequence is safer than allowing Jellyfin to initialize an
+  empty or partially copied config volume.
+- `Recreate` prevents two Jellyfin processes from accessing the SQLite state
+  during the cutover.
+
+## Constraints
+
+- Jellyfin remains a single replica.
+- Jellyfin must continue to select nodes labeled
+  `homelab.petebeegle.com/jellyfin-igpu=true`.
+- The `local-path-provisioner` Flux Kustomization must be ready before Jellyfin.
+- The migration must run before the existing SSO bootstrap init container.
+- The migration source must be mounted read-only.
+- The migration must validate at least one non-empty Jellyfin database plus the
+  pinned SSO plugin and configuration files.
+- The main Jellyfin container must not start after a failed migration or failed
+  SSO bootstrap.
+- Media remains on `/volume1/Media/Jellyfin` through Synology NFS.
+- The Jellyfin and migration resource requests do not increase the pod's
+  effective scheduling request above the existing 2 GiB application request.
+- Production cutover must not proceed while the selected iGPU worker reports
+  Kubernetes `MemoryPressure=True`.
+
+## Consequences
+
+- The config volume becomes node-affine. Jellyfin cannot automatically move to
+  another worker after the local PVC binds.
+- A failed or unavailable bound worker can make Jellyfin unavailable until the
+  node returns, the local volume is recovered, or the workload is deliberately
+  rolled back to the retained NFS PVC.
+- The retained NFS PVC becomes stale after cutover. It is suitable for immediate
+  rollback, but later rollback can lose settings, users, and metadata created
+  after migration.
+- Backups of the local config volume require an explicit host-level or
+  application-level strategy; Synology snapshots no longer protect live
+  `/config`.
+- The media library and therefore normal playback remain dependent on Synology
+  availability.
+- Authentication acceptance is release-blocking: existing SSO users, admin
+  mapping, and native administrator recovery must be verified during cutover.

--- a/docs/runbooks/jellyfin-authentik-sso.md
+++ b/docs/runbooks/jellyfin-authentik-sso.md
@@ -4,7 +4,7 @@ scope:
   - jellyfin
   - authentik
   - sso
-last_verified: 2026-05-23
+last_verified: 2026-08-08
 ---
 
 # Jellyfin Authentik SSO
@@ -32,3 +32,46 @@ After reconcile, acceptance should confirm:
 3. The Jellyfin login page shows the SSO button and starts at `/sso/OID/start/authentik`.
 4. A `Jellyfin Users` member can sign in.
 5. A `Jellyfin Admins` member receives Jellyfin administrator access.
+
+## Local Config Storage Migration
+
+Jellyfin's live `/config` volume is migrated from the retained
+`jellyfin-config-v2` NFS PVC to `jellyfin-config-local-v1` on `local-path`.
+Media remains on Synology NFS. The storage decision and its availability
+tradeoffs are documented in
+`docs/decisions/jellyfin-local-config-storage.md`.
+
+The Deployment uses `Recreate`. The `migrate-config` init container runs before
+`install-sso-auth`, copies the complete config tree from the read-only NFS source,
+validates the copied databases and authentication artifacts, and only then
+creates `.homelab-config-migration-v1`. A target without that marker is treated
+as incomplete and replaced from the source. Either init-container failure blocks
+the Jellyfin container from starting.
+
+Before merge or manual reconciliation:
+
+1. Confirm `jellyfin-config-v2` is `Bound`.
+2. Confirm both iGPU workers have `MemoryPressure=False`.
+3. Confirm the intended worker and its Proxmox host have safe memory headroom.
+4. Confirm a native local administrator credential is available.
+5. Confirm the encrypted `JELLYFIN_OAUTH_CLIENT_SECRET` and Authentik blueprint
+   are unchanged in the diff.
+6. Confirm the old NFS PVC will remain declared after cutover.
+
+Authentication is a release-blocking acceptance gate. Do not consider the
+migration complete from pod readiness or the login page alone. Verify:
+
+1. `/sso/OID/start/authentik` redirects to the Authentik authorization endpoint
+   without `Provider does not exist`.
+2. The callback remains
+   `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`.
+3. An existing `Jellyfin Users` member reaches the same existing Jellyfin user.
+4. An existing `Jellyfin Admins` member retains Jellyfin administrator access.
+5. A native local administrator can still sign in without Authentik.
+6. The old NFS PVC remains present for immediate rollback.
+
+For immediate rollback, point `persistence.config.existingClaim` back to
+`jellyfin-config-v2`, remove or disable the migration init container, and
+reconcile through Flux. The retained source is a point-in-time copy; after the
+local volume has been in service, rollback can lose changes made since the
+migration.

--- a/kubernetes/apps/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/jellyfin/kustomization.yaml
@@ -12,5 +12,11 @@ configMapGenerator:
     namespace: jellyfin
     files:
       - values.yaml=values.yaml
+  - name: jellyfin-config-migration
+    namespace: jellyfin
+    files:
+      - migrate.sh=migrate-config.sh
+    options:
+      disableNameSuffixHash: true
 configurations:
   - kustomizeconfig.yaml

--- a/kubernetes/apps/jellyfin/migrate-config.sh
+++ b/kubernetes/apps/jellyfin/migrate-config.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+set -eu
+
+source_root="${SOURCE_ROOT:-/config-source}"
+target_root="${TARGET_ROOT:-/config-target}"
+marker="${target_root}/.homelab-config-migration-v1"
+plugin_dir="plugins/SSO Authentication_4.0.0.4"
+
+fail() {
+  echo "Jellyfin config migration failed: $*" >&2
+  exit 1
+}
+
+require_file() {
+  path="$1"
+  [ -s "${path}" ] || fail "required non-empty file is missing: ${path}"
+}
+
+validate_config_root() {
+  root="$1"
+
+  [ -d "${root}" ] || fail "config root does not exist: ${root}"
+  require_file "${root}/config/system.xml"
+  require_file "${root}/config/branding.xml"
+  require_file "${root}/plugins/configurations/SSO-Auth.xml"
+  require_file "${root}/${plugin_dir}/SSO-Auth.dll"
+  require_file "${root}/${plugin_dir}/Duende.IdentityModel.dll"
+  require_file "${root}/${plugin_dir}/Duende.IdentityModel.OidcClient.dll"
+  require_file "${root}/${plugin_dir}/meta.json"
+
+  database_found=false
+  for database in "${root}"/data/*.db; do
+    if [ -s "${database}" ]; then
+      database_found=true
+      break
+    fi
+  done
+  [ "${database_found}" = "true" ] || fail "no non-empty Jellyfin database was found under ${root}/data"
+}
+
+compare_file() {
+  relative_path="$1"
+  source_file="${source_root}/${relative_path}"
+  target_file="${target_root}/${relative_path}"
+
+  [ -f "${target_file}" ] || fail "copied file is missing: ${target_file}"
+  cmp -s "${source_file}" "${target_file}" ||
+    fail "copied file does not match source: ${relative_path}"
+}
+
+compare_authentication_state() {
+  compare_file "config/system.xml"
+  compare_file "config/branding.xml"
+  compare_file "plugins/configurations/SSO-Auth.xml"
+  compare_file "${plugin_dir}/SSO-Auth.dll"
+  compare_file "${plugin_dir}/Duende.IdentityModel.dll"
+  compare_file "${plugin_dir}/Duende.IdentityModel.OidcClient.dll"
+  compare_file "${plugin_dir}/meta.json"
+
+  file_list="/tmp/jellyfin-config-data-files"
+  find "${source_root}/data" -type f -print > "${file_list}"
+  while IFS= read -r source_file; do
+    relative_path="${source_file#${source_root}/}"
+    compare_file "${relative_path}"
+  done < "${file_list}"
+  rm -f "${file_list}"
+}
+
+if [ -f "${marker}" ]; then
+  validate_config_root "${target_root}"
+  echo "Jellyfin local config migration already completed; target validation passed"
+  exit 0
+fi
+
+validate_config_root "${source_root}"
+
+# A target without the marker is an incomplete or untrusted attempt. Replace it
+# from the stopped, read-only source rather than allowing Jellyfin to start from
+# partial state.
+find "${target_root}" -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
+
+cp -a "${source_root}/." "${target_root}/"
+sync
+
+validate_config_root "${target_root}"
+compare_authentication_state
+
+{
+  echo "source=pvc:jellyfin-config-v2"
+  echo "completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "${marker}"
+sync
+
+echo "Jellyfin config migration completed and authentication state validated"

--- a/kubernetes/apps/jellyfin/pvc.yaml
+++ b/kubernetes/apps/jellyfin/pvc.yaml
@@ -11,3 +11,19 @@ spec:
   resources:
     requests:
       storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jellyfin-config-local-v1
+  namespace: jellyfin
+  labels:
+    app.kubernetes.io/name: jellyfin
+    app.kubernetes.io/component: config
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -1,10 +1,12 @@
 persistence:
   config:
     enabled: true
-    existingClaim: jellyfin-config-v2
-    storageClass: nfs-csi-storage
+    existingClaim: jellyfin-config-local-v1
+    storageClass: local-path
   media:
     enabled: false
+deploymentStrategy:
+  type: Recreate
 nodeSelector:
   homelab.petebeegle.com/jellyfin-igpu: "true"
 resources:
@@ -46,6 +48,28 @@ readinessProbe:
   periodSeconds: 10
   timeoutSeconds: 5
 extraInitContainers:
+  - name: migrate-config
+    image: alpine:3.22
+    imagePullPolicy: IfNotPresent
+    command:
+      - /bin/sh
+      - /opt/jellyfin-config-migration/migrate.sh
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    volumeMounts:
+      - name: config-source
+        mountPath: /config-source
+        readOnly: true
+      - name: config
+        mountPath: /config-target
+      - name: jellyfin-config-migration
+        mountPath: /opt/jellyfin-config-migration
+        readOnly: true
   - name: install-sso-auth
     image: python:3.14-alpine
     imagePullPolicy: IfNotPresent
@@ -62,6 +86,13 @@ extraInitContainers:
     command:
       - python3
       - /opt/jellyfin-sso/bootstrap-sso.py
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
     volumeMounts:
       - name: config
         mountPath: /config
@@ -69,6 +100,13 @@ extraInitContainers:
         mountPath: /opt/jellyfin-sso
         readOnly: true
 volumes:
+  - name: config-source
+    persistentVolumeClaim:
+      claimName: jellyfin-config-v2
+      readOnly: true
+  - name: jellyfin-config-migration
+    configMap:
+      name: jellyfin-config-migration
   - name: custom-media
     nfs:
       server: ${nfs_server}

--- a/kubernetes/clusters/production/apps/jellyfin.yaml
+++ b/kubernetes/clusters/production/apps/jellyfin.yaml
@@ -16,6 +16,7 @@ spec:
   dependsOn:
     - name: gateway
     - name: nfs-csi
+    - name: local-path-provisioner
     - name: intel-gpu-device-plugin
   postBuild:
     substituteFrom:

--- a/specs/jellyfin-local-config/checklists/authentication.md
+++ b/specs/jellyfin-local-config/checklists/authentication.md
@@ -1,0 +1,43 @@
+# Authentication Preservation Checklist: Jellyfin Local Config
+
+**Purpose**: Make authentication preservation release-blocking for the Jellyfin
+config storage migration.
+**Created**: 2026-08-08
+**Feature**: [spec.md](../spec.md)
+
+## Desired-State Review
+
+- [x] The PR does not edit
+      `kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml`.
+- [x] The PR does not edit `kubernetes/apps/jellyfin/secret.yaml`.
+- [x] Client ID remains `jellyfin`.
+- [x] Provider name remains `authentik`.
+- [x] Redirect URI remains
+      `https://jellyfin.${cluster_domain}/sso/OID/redirect/authentik`.
+- [x] Scope and role claim remain `groups`.
+- [x] Authorization groups remain `Jellyfin Users` and `Jellyfin Admins`.
+- [x] HTTPS scheme override remains enabled by the existing SSO bootstrap.
+- [x] Native Jellyfin login remains enabled.
+
+## Migration Integrity
+
+- [x] The source config PVC is retained and mounted read-only.
+- [x] The old Jellyfin process is stopped before copy through `Recreate`.
+- [x] All Jellyfin database files under `/config/data` are copied and compared.
+- [x] `SSO-Auth.xml`, `branding.xml`, and `system.xml` are copied and compared.
+- [x] All expected pinned plugin files are copied and compared.
+- [x] The completion marker is written only after validation.
+- [x] An unmarked target is replaced rather than trusted.
+- [x] A failed migration or SSO bootstrap prevents application startup.
+
+## Cutover Acceptance
+
+- [ ] `/sso/OID/start/authentik` reaches Authentik without
+      `Provider does not exist`.
+- [ ] The generated callback is HTTPS and exactly matches the strict Authentik
+      redirect URI.
+- [ ] An existing `Jellyfin Users` member reaches the same Jellyfin account.
+- [ ] An existing `Jellyfin Admins` member retains administrator access.
+- [ ] A known native local administrator can sign in without Authentik.
+- [ ] The old NFS PVC remains present for immediate rollback.
+- [ ] The selected iGPU worker has `MemoryPressure=False`.

--- a/specs/jellyfin-local-config/checklists/requirements.md
+++ b/specs/jellyfin-local-config/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Specification Quality Checklist: Jellyfin Local Config
+
+**Purpose**: Validate requirement completeness, clarity, consistency, and
+measurability before implementation.
+**Created**: 2026-08-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] The problem and desired user/operator outcome are stated without assuming a
+      specific implementation beyond approved storage constraints.
+- [x] Scope distinguishes config storage from media storage.
+- [x] Authentication preservation is a first-class user outcome.
+- [x] Node-affinity and rollback consequences are explicit.
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+
+## Requirement Completeness
+
+- [x] The target and retained source PVCs are named.
+- [x] Init ordering and Deployment strategy are specified.
+- [x] Complete-tree copy, hidden files, database validation, plugin validation,
+      and completion-marker behavior are covered.
+- [x] Authentik and secret non-change requirements are covered.
+- [x] Resource bounds and memory preflight are covered.
+- [x] Development, production, and authentication acceptance layers are
+      distinguished.
+- [x] Documentation and binding ADR requirements are included.
+
+## Consistency
+
+- [x] The app-specific local-path exception is reconciled with the default NFS
+      ADR.
+- [x] `Recreate` is consistent with the requirement for a quiescent SQLite
+      source.
+- [x] Retaining the old PVC is consistent with immediate rollback.
+- [x] The old PVC is described as stale after cutover rather than as a current
+      backup.
+- [x] Existing media, ingress, GPU, and SSO architecture remain unchanged.
+
+## Measurability
+
+- [x] Unit tests can prove success, retry, and fail-closed migration behavior.
+- [x] Render checks can prove the target PVC, source mount, init order, and
+      `Recreate`.
+- [x] Diff review can prove the Authentik blueprint and encrypted secret remain
+      unchanged.
+- [x] Live acceptance names exact user, administrator, native login, callback,
+      PVC, and memory signals.

--- a/specs/jellyfin-local-config/evidence.md
+++ b/specs/jellyfin-local-config/evidence.md
@@ -4,115 +4,142 @@
 **Risk Tier**: medium
 **Started**: 2026-08-08
 
-## Spec Kit Initialization
+## Spec Kit And Workflow
 
-- Command: Repo-local Spec Kit templates and workflow guidance reviewed through
-  the connected GitHub repository.
-- Outcome: PASS for artifact creation; no Spec Kit scaffolding changes.
-- Spec Kit version: Existing repository version; not changed by this
-  implementation.
-- Integration: `codex`
-- Fallback: The execution environment had no mounted repository checkout,
-  kubeconfig, authenticated `gh`, `kubectl`, or `kustomize`. Connector-backed
-  branch and commit operations were used. Repository-local and cluster checks
-  remain explicit draft-PR gates rather than being represented as passed.
+- Repository-local Spec Kit artifacts and workflow guidance were reused; no
+  scaffolding or integration change was required.
+- Integration: `codex`.
+- The preferred `/workspaces/homelab-worktrees/jellyfin-local-config` path was
+  not writable. Work continued in the allowed fallback
+  `/home/vscode/homelab-worktrees/jellyfin-local-config`.
+- The main checkout's unrelated modified
+  `.devcontainer/devcontainer-lock.json` was not touched.
+- `.specify/feature.json` points at another active implementation in the shared
+  checkout. Prerequisite resolution used the explicit
+  `SPECIFY_FEATURE_DIRECTORY=specs/jellyfin-local-config` override; the tracked
+  selector file was restored unchanged.
+- The PR branch was merged with current `origin/main` before validation.
 
 ## Human Gates
 
 | Gate | Result | Notes |
 | ---- | ------ | ----- |
-| Intent brief | PASS | User reported severe ingest degradation and approved moving config I/O off NFS. |
-| Spec approval | PASS | User reviewed the proposed artifacts and added critical authentication and memory constraints. |
-| Clarify | PASS | Authentication preservation, native fallback, migration ordering, rollback, and low-memory behavior were clarified in conversation. |
-| Plan approval | PASS | User instructed "Ok let's open the PR" after reviewing the bounded plan. |
-| Checklist | PASS | Requirements and authentication checklists completed; live cutover items remain intentionally unchecked. |
-| Tasks/analyze approval | PASS | All functional requirements map to implementation or explicit acceptance tasks; no unresolved critical conflict. |
-| Converge | PASS | ADR, runbook, spec, plan, tasks, tests, and manifests agree on node affinity, stale rollback source, authentication, and memory gates. |
+| Intent brief | PASS | User requested an engineering audit, fixes, and development validation for draft PR #380. |
+| Spec approval | PASS | Existing approved spec preserves authentication and bounds the storage migration. |
+| Clarify | PASS | The prior conversation resolved authentication, rollback, node affinity, and memory constraints. |
+| Plan approval | PASS | Existing plan was approved when the draft PR was opened; this audit corrects its validation assumptions. |
+| Checklist | PARTIAL | Requirements are 21/21 complete. Authentication desired-state and migration-integrity checks are complete; seven live cutover checks remain intentionally open. |
+| Tasks/analyze approval | PASS | The user explicitly requested execution of the existing PR and development test work. |
+| Converge | PASS | Plan, tasks, tests, generated architecture, and evidence now distinguish migration validation, routed app smoke, and production-only acceptance. |
 
-## Workflow Validation
+## Audit Findings And Fixes
 
-| Command | Result | Notes |
-| ------- | ------ | ----- |
-| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence` | PENDING | Requires a repository checkout; draft PR CI/local owner check must run it. |
+1. GitHub Actions run `31278257350` failed only in `Pre-commit`; the architecture
+   hook reported that `docs/architecture.md` omitted Jellyfin's new
+   `local-path-provisioner` dependency and local PVC. The generated document was
+   regenerated.
+2. The draft evidence pinned obsolete commit
+   `9a8ccf75133aad2013fcaa82383ed4de69d13d56`, causing the SDD harness to reject
+   every later commit. The obsolete self-referential final-HEAD claim was
+   removed; exact tested SHAs are recorded only for smoke runs.
+3. The proposed existing Jellyfin branch profile still uses a fresh
+   `nfs-csi-storage` config PVC. A pass cannot prove the production NFS-to-local
+   migration. Development validation was split into an exact-script migration
+   Job and the routed app profile.
+4. Current `main` includes the `immich` smoke profile, while the verifier's
+   profile-discovery unit test still expected four apps. The one-line inherited
+   expectation was corrected to include `immich` so the current suite passes.
+5. The migration suite lacked a restart case for lost critical authentication
+   state. A fourth test now proves that an already-marked target fails closed if
+   `SSO-Auth.xml` disappears.
 
 ## Local Checks
 
 | Command | Result | Notes |
 | ------- | ------ | ----- |
-| `python3 -m unittest tools/development/tests/test_jellyfin_config_migration.py` | PASS (isolated) | The exact proposed shell script and test were executed in a reconstructed repository path; 3 tests passed for copy/integrity, completed restart, and missing SSO fail-closed behavior. Repository-environment rerun is pending. |
-| PyYAML parse of proposed `pvc.yaml`, `values.yaml`, `kustomization.yaml`, and production Flux Kustomization | PASS | All proposed YAML documents parsed successfully. |
-| `pre-commit run yamllint ...` | PENDING | No mounted checkout/pre-commit environment. |
-| `pre-commit run k8svalidate ...` | PENDING | No mounted checkout/pre-commit environment. |
-| `kubectl kustomize kubernetes/apps/jellyfin` | PENDING | `kubectl`/`kustomize` unavailable in the connector execution environment. |
-| `python3 tools/policy/check_decision_metadata.py` | REVIEWED/PENDING | ADR metadata follows the required schema and uses the next unused ID `ADR-0015`; repository execution pending. |
-| `python3 tools/architecture/render.py --check` | PENDING | Generated architecture must not be edited manually; repository execution pending. |
-
-## Automated Smoke And Live Verification
-
-| Target | Method | Result | Notes |
-| ------ | ------ | ------ | ----- |
-| Jellyfin development branch environment | Existing `jellyfin` smoke profile | PENDING | Requires development kubeconfig. The fixture proves routed startup but not production-equivalent existing-user OIDC. |
-| `https://jellyfin.${cluster_domain}/sso/OID/start/authentik` | Controlled cutover request | PENDING | Must redirect to Authentik without provider errors. |
-| Existing SSO user/admin and native administrator | Interactive acceptance | PENDING | Release-blocking; pod readiness alone is insufficient. |
-
-## Deployment State
-
-- Source fetched SHA: Pending merge.
-- Target applied SHA: Pending merge.
-- Live resource spec checked: Pending.
-- Gateway/listener/DNS/certificate checked: Existing route is unchanged; live
-  callback behavior pending.
-- Exact user-facing URL result: Pending.
+| `python3 -m unittest tools/development/tests/test_jellyfin_config_migration.py` | PASS | 4 tests cover complete copy/integrity, completed restart without stale-source comparison, completed-target authentication loss, and missing-source SSO fail-closed behavior. |
+| `python3 -m unittest tools/development/tests/test_verify_branch_deploy.py` | PASS | 32 tests passed after correcting the inherited `immich` profile expectation. |
+| `python3 -m unittest discover -s tools/codex-harness/tests` | PASS | 73 tests passed. |
+| `kubectl kustomize kubernetes/apps/jellyfin` | PASS | Rendered 664 lines before later evidence-only edits. |
+| `helm template jellyfin jellyfin/jellyfin --version 3.2.0 -f kubernetes/apps/jellyfin/values.yaml` | PASS | Rendered `Recreate`, ordered `migrate-config` then `install-sso-auth`, target claim `jellyfin-config-local-v1`, and read-only source claim `jellyfin-config-v2`. |
+| Production and development cluster renders plus kubeconform `0.7.0` | PASS | 119 resources; 44 valid, 0 invalid, 0 errors, 75 skipped for unavailable schemas. |
+| `python3 tools/policy/check_decision_metadata.py` | PASS | ADR metadata accepted. |
+| `python3 tools/architecture/render.py --check` | PASS after regeneration | Initial failure reproduced CI and required the generated-document update. |
+| `pre-commit run --all-files` | PASS | All configured hooks pass after regeneration. |
+| `python3 tools/codex-harness/validate_sdd_context.py ... --require-plan-artifacts --require-evidence` | PASS | Matching branch and complete SDD artifacts accepted after stale SHA removal. |
 
 ## Development Validation
 
-- Profile: existing `jellyfin` profile plus manual storage/init inspection
-- Branch slug: Pending
-- HEAD: `9a8ccf75133aad2013fcaa82383ed4de69d13d56` at draft PR creation
-- Report path: Pending
-- Cleanup: Pending
-- Result or exception: Not run because this connector session has no development
-  kubeconfig. This is an unavailable-infrastructure exception for opening the
-  draft PR only, not approval to merge.
+### Exact Migration Job
+
+- Timestamp: `2026-08-08T22:13:00Z` (UTC).
+- Kubeconfig: `/home/vscode/.kube/homelab-development.config`.
+- Namespace: `jellyfin-migration-pr380` (ephemeral).
+- Script blob: `07acf46c970cc1b5d54eff0e28169199b1b74474` from
+  `kubernetes/apps/jellyfin/migrate-config.sh`.
+- Source PVC: `config-source`, `nfs-csi-storage`, `Bound`.
+- Target PVC: `config-target`, `local-path`, `Bound` on
+  `k8s-premium-martin`.
+- Workload: Alpine `3.22` with the production migration command, read-only source
+  mount, writable target, and production request/limit bounds.
+- Result: PASS. `seed-source=0`, `migrate-config=0`, `verify=0`; marker,
+  databases, hidden state, and authentication files copied and byte-matched.
+- Cleanup: PASS. The namespace was deleted, both exact test PV reclaim policies
+  were changed to `Delete`, and PVs
+  `pvc-e647dd86-81d1-47f5-b941-80cd96defdcf` and
+  `pvc-da6669cf-8edd-404b-a4e9-7dbf90c0df23` were confirmed deleted.
+
+### Routed Jellyfin Branch Profile
+
+- Profile: `jellyfin`.
+- Branch slug: `jellyfin-local-config`.
+- Exact command and tested HEAD: pending final branch publication and verifier
+  run.
+- Expected coverage: Flux branch fetch/reconcile, namespace and pod readiness,
+  HelmRelease readiness, fresh branch config PVC, Service, HTTPRoute, and
+  in-cluster Jellyfin web-shell response.
+- Deliberate limitation: the branch fixture uses a fresh NFS config PVC and a
+  placeholder OAuth secret. It is app-regression evidence, not migration or
+  production-equivalent OIDC evidence.
+
+## Read-Only Production Preflight
+
+- `jellyfin-config-v2` is `Bound`, `5Gi`, `RWO`, and
+  `nfs-csi-storage`.
+- Both iGPU workers were `Ready` with `MemoryPressure=False` at inspection time.
+  This does not replace the time-sensitive cutover check.
+- The running source config was approximately `794376 KiB`, below the proposed
+  `10Gi` target size.
+- The source contains non-empty `system.xml`, `branding.xml`, `SSO-Auth.xml`, all
+  four pinned SSO plugin files, and non-empty `data/jellyfin.db`. Only paths and
+  byte sizes were read; no secret contents were printed.
+- Safe Proxmox host headroom and possession of a working native administrator
+  credential remain unverified and release-blocking.
+
+## Production Acceptance Still Required
+
+- Confirm the selected iGPU worker still has `MemoryPressure=False` and its
+  Proxmox host has safe headroom immediately before cutover.
+- Confirm `/sso/OID/start/authentik` redirects with the exact HTTPS callback.
+- Confirm an existing `Jellyfin Users` member reaches the same account.
+- Confirm an existing `Jellyfin Admins` member retains administrator access.
+- Confirm a known native local administrator can sign in.
+- Confirm the retained NFS PVC remains available after cutover.
+
+These are intentionally not inferred from unit tests, PVC binding, pod
+readiness, route status, or the development placeholder identity provider.
 
 ## Documentation Impact
 
-- Updated:
-  `docs/runbooks/jellyfin-authentik-sso.md`
-- Added:
-  `docs/decisions/jellyfin-local-config-storage.md`
-- Generated docs:
-  `docs/architecture.md` check pending; no manual edit made.
-- No-docs rationale: N/A.
-
-## SDD Conformance
-
-- Local sources checked: `AGENTS.md`, SDD and implementation runbooks, storage
-  ADR, TDD/development evidence ADR, templates, existing Jellyfin SSO runbook.
-- Upstream Spec Kit sources checked: N/A; no Spec Kit behavior changed.
-- Human-gated Spec Kit alignment: Intent, spec, plan, and task/analyze approvals
-  are recorded from the conversation.
-- Artifact updates after implementation: Node affinity, stale rollback source,
-  memory preflight, and non-representative development OIDC fixture were
-  reconciled into all artifacts.
-
-## Exceptions And Follow-Ups
-
-- Repository-local validators and development smoke are pending because the
-  connector environment has no checkout or kubeconfig.
-- Production authentication acceptance is intentionally pending and
-  release-blocking.
-- The local PVC needs an explicit long-term backup/recovery follow-up after
-  successful cutover.
-- The retained NFS PVC is immediate rollback state, not a continuously updated
-  backup.
+- Added binding ADR `docs/decisions/jellyfin-local-config-storage.md`.
+- Updated `docs/runbooks/jellyfin-authentik-sso.md`.
+- Regenerated `docs/architecture.md`; it was not edited by hand.
+- No Spec Kit behavior or standards changed, so an upstream conformance audit is
+  not required.
 
 ## Final State
 
-- Final branch: `codex/jellyfin-local-config`
-- Implementation commit: `59726adf68f23d5cd7b70c2767acb8db575690fc`
-- Draft PR: `#380` (`https://github.com/petebeegle/homelab/pull/380`)
-- PR creation HEAD: `9a8ccf75133aad2013fcaa82383ed4de69d13d56`
-- Final HEAD: Use the current draft PR head; it is intentionally not embedded
-  because an evidence update itself creates a new HEAD.
-- Commit: `feat(jellyfin): move config to local storage`
+- Branch: `codex/jellyfin-local-config`.
+- Draft PR: `#380` (`https://github.com/petebeegle/homelab/pull/380`).
+- Final published HEAD and GitHub Actions result: pending publication.
+- Production authentication acceptance: pending and release-blocking.

--- a/specs/jellyfin-local-config/evidence.md
+++ b/specs/jellyfin-local-config/evidence.md
@@ -93,11 +93,25 @@
 
 - Profile: `jellyfin`.
 - Branch slug: `jellyfin-local-config`.
-- Exact command and tested HEAD: pending final branch publication and verifier
-  run.
-- Expected coverage: Flux branch fetch/reconcile, namespace and pod readiness,
-  HelmRelease readiness, fresh branch config PVC, Service, HTTPRoute, and
-  in-cluster Jellyfin web-shell response.
+- Command:
+  `python3 tools/development/verify_branch_deploy.py --app jellyfin --branch codex/jellyfin-local-config --slug jellyfin-local-config --push --timeout 20m`.
+- Tested HEAD: `3122efc3304db0414c7f4784507c205d2e4053b9`.
+- Initial attempt: PRECHECK BLOCKED because the isolated worktree did not contain
+  ignored `terraform/development/terraform.tfvars`. The repository staging
+  script installed it without logging contents, and the same command was rerun.
+- Rerun result: DEVELOPMENT INFRASTRUCTURE EXCEPTION. Flux fetched the exact
+  tested SHA; the branch PVC bound, and the Deployment, Service, and HTTPRoute
+  rendered. The pod remained Pending because the only development node has
+  neither `homelab.petebeegle.com/jellyfin-igpu=true` nor allocatable
+  `gpu.intel.com/i915`. No Jellyfin container started, so workload readiness and
+  the web-shell response were not verified.
+- Resolution: intentionally deferred. Applying Terraform would create the
+  missing Proxmox mapping and development VM state and is outside this PR's
+  authorized scope; the user confirmed the GPU-pinning limitation should not be
+  resolved here.
+- Cleanup: PASS after interrupting the wait. The branch Kustomization,
+  namespace, GitRepository, PVC, and retained test PV
+  `pvc-366dd362-3891-4ca7-a450-e3ba1c5a48da` were confirmed deleted.
 - Deliberate limitation: the branch fixture uses a fresh NFS config PVC and a
   placeholder OAuth secret. It is app-regression evidence, not migration or
   production-equivalent OIDC evidence.
@@ -141,5 +155,7 @@ readiness, route status, or the development placeholder identity provider.
 
 - Branch: `codex/jellyfin-local-config`.
 - Draft PR: `#380` (`https://github.com/petebeegle/homelab/pull/380`).
-- Final published HEAD and GitHub Actions result: pending publication.
+- Audit-fix commit tested in development:
+  `3122efc3304db0414c7f4784507c205d2e4053b9`.
+- Final evidence commit and GitHub Actions result: pending publication/handoff.
 - Production authentication acceptance: pending and release-blocking.

--- a/specs/jellyfin-local-config/evidence.md
+++ b/specs/jellyfin-local-config/evidence.md
@@ -68,7 +68,7 @@
 
 - Profile: existing `jellyfin` profile plus manual storage/init inspection
 - Branch slug: Pending
-- HEAD: Pending PR head
+- HEAD: `9a8ccf75133aad2013fcaa82383ed4de69d13d56` at draft PR creation
 - Report path: Pending
 - Cleanup: Pending
 - Result or exception: Not run because this connector session has no development
@@ -111,6 +111,8 @@
 
 - Final branch: `codex/jellyfin-local-config`
 - Implementation commit: `59726adf68f23d5cd7b70c2767acb8db575690fc`
-- Final HEAD: Use the draft PR head; it is intentionally not embedded because an
-  evidence update itself creates a new HEAD.
+- Draft PR: `#380` (`https://github.com/petebeegle/homelab/pull/380`)
+- PR creation HEAD: `9a8ccf75133aad2013fcaa82383ed4de69d13d56`
+- Final HEAD: Use the current draft PR head; it is intentionally not embedded
+  because an evidence update itself creates a new HEAD.
 - Commit: `feat(jellyfin): move config to local storage`

--- a/specs/jellyfin-local-config/evidence.md
+++ b/specs/jellyfin-local-config/evidence.md
@@ -1,0 +1,116 @@
+# Evidence: jellyfin-local-config
+
+**Branch**: `codex/jellyfin-local-config`
+**Risk Tier**: medium
+**Started**: 2026-08-08
+
+## Spec Kit Initialization
+
+- Command: Repo-local Spec Kit templates and workflow guidance reviewed through
+  the connected GitHub repository.
+- Outcome: PASS for artifact creation; no Spec Kit scaffolding changes.
+- Spec Kit version: Existing repository version; not changed by this
+  implementation.
+- Integration: `codex`
+- Fallback: The execution environment had no mounted repository checkout,
+  kubeconfig, authenticated `gh`, `kubectl`, or `kustomize`. Connector-backed
+  branch and commit operations were used. Repository-local and cluster checks
+  remain explicit draft-PR gates rather than being represented as passed.
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | PASS | User reported severe ingest degradation and approved moving config I/O off NFS. |
+| Spec approval | PASS | User reviewed the proposed artifacts and added critical authentication and memory constraints. |
+| Clarify | PASS | Authentication preservation, native fallback, migration ordering, rollback, and low-memory behavior were clarified in conversation. |
+| Plan approval | PASS | User instructed "Ok let's open the PR" after reviewing the bounded plan. |
+| Checklist | PASS | Requirements and authentication checklists completed; live cutover items remain intentionally unchecked. |
+| Tasks/analyze approval | PASS | All functional requirements map to implementation or explicit acceptance tasks; no unresolved critical conflict. |
+| Converge | PASS | ADR, runbook, spec, plan, tasks, tests, and manifests agree on node affinity, stale rollback source, authentication, and memory gates. |
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence` | PENDING | Requires a repository checkout; draft PR CI/local owner check must run it. |
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest tools/development/tests/test_jellyfin_config_migration.py` | PASS (isolated) | The exact proposed shell script and test were executed in a reconstructed repository path; 3 tests passed for copy/integrity, completed restart, and missing SSO fail-closed behavior. Repository-environment rerun is pending. |
+| PyYAML parse of proposed `pvc.yaml`, `values.yaml`, `kustomization.yaml`, and production Flux Kustomization | PASS | All proposed YAML documents parsed successfully. |
+| `pre-commit run yamllint ...` | PENDING | No mounted checkout/pre-commit environment. |
+| `pre-commit run k8svalidate ...` | PENDING | No mounted checkout/pre-commit environment. |
+| `kubectl kustomize kubernetes/apps/jellyfin` | PENDING | `kubectl`/`kustomize` unavailable in the connector execution environment. |
+| `python3 tools/policy/check_decision_metadata.py` | REVIEWED/PENDING | ADR metadata follows the required schema and uses the next unused ID `ADR-0015`; repository execution pending. |
+| `python3 tools/architecture/render.py --check` | PENDING | Generated architecture must not be edited manually; repository execution pending. |
+
+## Automated Smoke And Live Verification
+
+| Target | Method | Result | Notes |
+| ------ | ------ | ------ | ----- |
+| Jellyfin development branch environment | Existing `jellyfin` smoke profile | PENDING | Requires development kubeconfig. The fixture proves routed startup but not production-equivalent existing-user OIDC. |
+| `https://jellyfin.${cluster_domain}/sso/OID/start/authentik` | Controlled cutover request | PENDING | Must redirect to Authentik without provider errors. |
+| Existing SSO user/admin and native administrator | Interactive acceptance | PENDING | Release-blocking; pod readiness alone is insufficient. |
+
+## Deployment State
+
+- Source fetched SHA: Pending merge.
+- Target applied SHA: Pending merge.
+- Live resource spec checked: Pending.
+- Gateway/listener/DNS/certificate checked: Existing route is unchanged; live
+  callback behavior pending.
+- Exact user-facing URL result: Pending.
+
+## Development Validation
+
+- Profile: existing `jellyfin` profile plus manual storage/init inspection
+- Branch slug: Pending
+- HEAD: Pending PR head
+- Report path: Pending
+- Cleanup: Pending
+- Result or exception: Not run because this connector session has no development
+  kubeconfig. This is an unavailable-infrastructure exception for opening the
+  draft PR only, not approval to merge.
+
+## Documentation Impact
+
+- Updated:
+  `docs/runbooks/jellyfin-authentik-sso.md`
+- Added:
+  `docs/decisions/jellyfin-local-config-storage.md`
+- Generated docs:
+  `docs/architecture.md` check pending; no manual edit made.
+- No-docs rationale: N/A.
+
+## SDD Conformance
+
+- Local sources checked: `AGENTS.md`, SDD and implementation runbooks, storage
+  ADR, TDD/development evidence ADR, templates, existing Jellyfin SSO runbook.
+- Upstream Spec Kit sources checked: N/A; no Spec Kit behavior changed.
+- Human-gated Spec Kit alignment: Intent, spec, plan, and task/analyze approvals
+  are recorded from the conversation.
+- Artifact updates after implementation: Node affinity, stale rollback source,
+  memory preflight, and non-representative development OIDC fixture were
+  reconciled into all artifacts.
+
+## Exceptions And Follow-Ups
+
+- Repository-local validators and development smoke are pending because the
+  connector environment has no checkout or kubeconfig.
+- Production authentication acceptance is intentionally pending and
+  release-blocking.
+- The local PVC needs an explicit long-term backup/recovery follow-up after
+  successful cutover.
+- The retained NFS PVC is immediate rollback state, not a continuously updated
+  backup.
+
+## Final State
+
+- Final branch: `codex/jellyfin-local-config`
+- Implementation commit: `59726adf68f23d5cd7b70c2767acb8db575690fc`
+- Final HEAD: Use the draft PR head; it is intentionally not embedded because an
+  evidence update itself creates a new HEAD.
+- Commit: `feat(jellyfin): move config to local storage`

--- a/specs/jellyfin-local-config/plan.md
+++ b/specs/jellyfin-local-config/plan.md
@@ -27,15 +27,18 @@ Synology NFS CSI, Intel GPU device plugin, Python `unittest`, POSIX shell tools
 retained for media and migration source
 **Ingress**: Existing Cilium Gateway API route unchanged
 **Secrets**: Existing SOPS-encrypted `jellyfin-secrets` reference unchanged
-**Smoke Strategy**: Focused migration unit test and manifest render checks;
-existing routed Jellyfin smoke plus manual authentication acceptance before
-promotion
+**Smoke Strategy**: Focused migration unit tests and manifest render checks; an
+ephemeral development Job that runs the exact migration script from an NFS PVC
+to a `local-path` PVC; the existing routed Jellyfin branch smoke for application
+regression; manual authentication acceptance before promotion
 **Fanout Targets**: Read-only manifest/ADR validation and migration unit test can
 run independently; all results consolidate in `evidence.md`
-**Development Validation**: Existing Jellyfin development profile where
-available, supplemented by manual inspection of init ordering and local PVC
-binding. The current connector execution environment has no kubeconfig, so the
-draft PR records this as pending rather than waiving a real failure.
+**Development Validation**: Use two complementary layers. The existing Jellyfin
+profile proves the branch fixture reconciles, starts, routes, and serves its web
+shell, but its fresh NFS-backed config does not exercise the production
+migration. A one-off isolated development Job therefore runs the exact migration
+script against an NFS source PVC and a `local-path` target PVC, verifies copied
+database, hidden, and authentication state, and removes all test resources.
 **Post-Implementation SDD Conformance**: Local repository sources only; this
 change does not alter Spec Kit behavior or standards.
 
@@ -44,8 +47,9 @@ change does not alter Spec Kit behavior or standards.
 **Spec Gate**: Approved by Pete after reviewing the proposed spec and explicitly
 adding authentication and memory constraints.
 
-**Checklist Status**: PASS; requirements and authentication checklists in
-`specs/jellyfin-local-config/checklists/`.
+**Checklist Status**: Requirements checklist PASS. Authentication desired-state
+and migration-integrity sections PASS; seven time-sensitive cutover acceptance
+items remain intentionally open until production rollout.
 
 **Plan Gate**: Approved by Pete's "Ok let's open the PR" after the proposed
 architecture, authentication safeguards, and memory preflight were presented.
@@ -66,9 +70,9 @@ remain.
 - [x] NFS default considered; the app-specific local storage exception is
       recorded in binding ADR-0015.
 - [x] Talos boundary preserved; no SSH-based node operations introduced.
-- [x] Branch is `codex/jellyfin-local-config`; connector-backed editing is used
-      because this execution environment has no mounted checkout or authenticated
-      `gh` CLI.
+- [x] Branch is `codex/jellyfin-local-config`; tracked edits use the allowed
+      `/home/vscode/homelab-worktrees/jellyfin-local-config` fallback because the
+      preferred `/workspaces/homelab-worktrees/` path is not writable here.
 - [x] Documentation impact identified; SSO runbook and binding ADR are updated.
 - [x] PR review/status checks remain the review gate.
 
@@ -117,11 +121,14 @@ copy, retry, and fail-closed paths, and run before relying on rendered manifests
 - `python3 tools/architecture/render.py --check`
 - `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence`
 
-**Development smoke**: Run the existing Jellyfin branch verifier when cluster
-access is available, then manually confirm init order, PVC class, and workload
-mounts. A production-equivalent existing-user OIDC login cannot be represented
-by the current branch fixture because it uses a placeholder secret and
-branch-specific callback.
+**Development smoke**: Run the existing Jellyfin branch verifier, then run an
+isolated migration Job using the exact production script, source/target storage
+classes, image, mounts, and resource bounds. Confirm both PVCs bind, all
+containers exit zero, copied state byte-matches, the routed Jellyfin web shell is
+reachable, and cleanup removes the namespace and retained test PVs. A
+production-equivalent existing-user OIDC login cannot be represented by the
+current branch fixture because it uses a placeholder secret and branch-specific
+callback.
 
 **Automated smoke preference**: The routed development profile remains the first
 user-path check. Production cutover adds explicit SSO start, existing-user,
@@ -156,8 +163,9 @@ validation, and read-only diff review are independent. Results consolidate in
 4. Add `local-path-provisioner` to the production Flux dependencies.
 5. Add migration unit tests.
 6. Add ADR, runbook, SDD artifacts, and checklists.
-7. Run local checks available in the execution environment and record
-   unavailable development/live validation as pending.
+7. Run the full local check set, the isolated development migration Job, and the
+   routed Jellyfin branch smoke; keep production-only authentication acceptance
+   pending.
 8. Open a draft PR; do not mark it ready until cluster smoke and cutover
    preflight are completed.
 

--- a/specs/jellyfin-local-config/plan.md
+++ b/specs/jellyfin-local-config/plan.md
@@ -1,0 +1,182 @@
+# Implementation Plan: jellyfin-local-config
+
+**Branch**: `codex/jellyfin-local-config` | **Date**: 2026-08-08 | **Spec**:
+`specs/jellyfin-local-config/spec.md`
+
+**Input**: Feature specification from
+`specs/jellyfin-local-config/spec.md`
+
+## Summary
+
+Create a new 10 GiB `local-path` config PVC, retain the current NFS PVC, and use
+an ordered, resource-bounded migration init container to copy and validate the
+complete config before the existing SSO bootstrap runs. Set the Jellyfin
+Deployment to `Recreate`, add the local-path Flux dependency, document the
+storage exception and authentication cutover contract, and add an executable
+migration test.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, Flux, storage, Jellyfin, Authentik-adjacent
+authentication, tests, runbooks, decision records
+**Dependencies**: Flux, Jellyfin Helm chart `3.2.0`, local-path-provisioner,
+Synology NFS CSI, Intel GPU device plugin, Python `unittest`, POSIX shell tools
+**Storage**: App-specific `local-path` exception for `/config`; Synology NFS
+retained for media and migration source
+**Ingress**: Existing Cilium Gateway API route unchanged
+**Secrets**: Existing SOPS-encrypted `jellyfin-secrets` reference unchanged
+**Smoke Strategy**: Focused migration unit test and manifest render checks;
+existing routed Jellyfin smoke plus manual authentication acceptance before
+promotion
+**Fanout Targets**: Read-only manifest/ADR validation and migration unit test can
+run independently; all results consolidate in `evidence.md`
+**Development Validation**: Existing Jellyfin development profile where
+available, supplemented by manual inspection of init ordering and local PVC
+binding. The current connector execution environment has no kubeconfig, so the
+draft PR records this as pending rather than waiving a real failure.
+**Post-Implementation SDD Conformance**: Local repository sources only; this
+change does not alter Spec Kit behavior or standards.
+
+## Human Gates
+
+**Spec Gate**: Approved by Pete after reviewing the proposed spec and explicitly
+adding authentication and memory constraints.
+
+**Checklist Status**: PASS; requirements and authentication checklists in
+`specs/jellyfin-local-config/checklists/`.
+
+**Plan Gate**: Approved by Pete's "Ok let's open the PR" after the proposed
+architecture, authentication safeguards, and memory preflight were presented.
+
+**Expected Task/Analyze Gate**: PASS; requirements were mapped to implementation
+and validation tasks before tracked changes. No unresolved requirement conflicts
+remain.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation is identified as
+      pending in the draft PR rather than falsely reported.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered; the app-specific local storage exception is
+      recorded in binding ADR-0015.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/jellyfin-local-config`; connector-backed editing is used
+      because this execution environment has no mounted checkout or authenticated
+      `gh` CLI.
+- [x] Documentation impact identified; SSO runbook and binding ADR are updated.
+- [x] PR review/status checks remain the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/jellyfin-local-config/
+├── checklists/
+│   ├── authentication.md
+│   └── requirements.md
+├── spec.md
+├── plan.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+docs/decisions/jellyfin-local-config-storage.md
+docs/runbooks/jellyfin-authentik-sso.md
+kubernetes/apps/jellyfin/kustomization.yaml
+kubernetes/apps/jellyfin/migrate-config.sh
+kubernetes/apps/jellyfin/pvc.yaml
+kubernetes/apps/jellyfin/values.yaml
+kubernetes/clusters/production/apps/jellyfin.yaml
+tools/development/tests/test_jellyfin_config_migration.py
+specs/jellyfin-local-config/**
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add a focused `unittest` seam for the standalone migration
+script. The tests construct representative Jellyfin/SSO state, exercise the
+copy, retry, and fail-closed paths, and run before relying on rendered manifests.
+
+**Local checks**:
+
+- `python3 -m unittest tools/development/tests/test_jellyfin_config_migration.py`
+- `pre-commit run yamllint --files kubernetes/apps/jellyfin/pvc.yaml kubernetes/apps/jellyfin/values.yaml kubernetes/apps/jellyfin/kustomization.yaml kubernetes/clusters/production/apps/jellyfin.yaml`
+- `pre-commit run k8svalidate --files kubernetes/apps/jellyfin/pvc.yaml kubernetes/apps/jellyfin/kustomization.yaml kubernetes/clusters/production/apps/jellyfin.yaml`
+- `kubectl kustomize kubernetes/apps/jellyfin >/tmp/jellyfin-render.yaml`
+- `python3 tools/policy/check_decision_metadata.py`
+- `python3 tools/architecture/render.py --check`
+- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts --require-evidence`
+
+**Development smoke**: Run the existing Jellyfin branch verifier when cluster
+access is available, then manually confirm init order, PVC class, and workload
+mounts. A production-equivalent existing-user OIDC login cannot be represented
+by the current branch fixture because it uses a placeholder secret and
+branch-specific callback.
+
+**Automated smoke preference**: The routed development profile remains the first
+user-path check. Production cutover adds explicit SSO start, existing-user,
+administrator, and native-login acceptance.
+
+**Completion evidence**: After merge, record the source fetched SHA, HelmRelease
+applied SHA, live Deployment strategy, PVC binding/node, init-container
+completion, exact Jellyfin URL result, and authentication outcomes.
+
+**Fanout plan**: Migration test, YAML/render validation, decision metadata
+validation, and read-only diff review are independent. Results consolidate in
+`specs/jellyfin-local-config/evidence.md`.
+
+**Evidence destination**:
+`specs/jellyfin-local-config/evidence.md`.
+
+## Documentation Impact
+
+- Add binding ADR-0015 for the local config exception and availability tradeoff.
+- Extend the Jellyfin Authentik SSO runbook with migration preflight,
+  authentication acceptance, and rollback.
+- Generated `docs/architecture.md` must be checked by
+  `tools/architecture/render.py`; it must not be edited manually.
+
+## Implementation Steps
+
+1. Add the local PVC while retaining the NFS source PVC.
+2. Add the standalone fail-closed migration script and fixed-name ConfigMap
+   generator.
+3. Point Jellyfin `/config` at the local PVC, add ordered init containers,
+   resource bounds, source/config map volumes, and `Recreate`.
+4. Add `local-path-provisioner` to the production Flux dependencies.
+5. Add migration unit tests.
+6. Add ADR, runbook, SDD artifacts, and checklists.
+7. Run local checks available in the execution environment and record
+   unavailable development/live validation as pending.
+8. Open a draft PR; do not mark it ready until cluster smoke and cutover
+   preflight are completed.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Existing users or SSO state are lost | Copy the complete tree, byte-compare databases and pinned SSO artifacts, preserve the source PVC, and require live SSO/native acceptance. |
+| Jellyfin starts from a partial target | Marker is written only after validation; an unmarked target is cleared and recopied; init failure blocks startup. |
+| Concurrent SQLite access corrupts state | Use Deployment `Recreate` and a read-only source mount. |
+| Local PVC binds to a pressured node | Require `MemoryPressure=False` and safe Proxmox headroom before accepting cutover. |
+| Init copy worsens memory pressure | Keep main request unchanged and bound the copy init container to 64 MiB request/512 MiB limit. |
+| Node failure strands local config | Document node affinity, retain NFS rollback source, and keep PR draft until operator accepts the tradeoff. |
+| Old NFS rollback state becomes stale | Document that it is immediate rollback only and that later rollback can lose post-cutover changes. |
+| Development fixture cannot complete real OIDC login | Keep PR draft, run available routed smoke, and require controlled production existing-user/admin/native acceptance. |
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| App-specific exception to NFS default | SQLite/config latency is the suspected bottleneck | Keeping `/config` on the same NFS class does not address the targeted I/O path. |
+| Node-affine local storage | Provides lowest-latency config path using already-installed storage | A new shared block-storage architecture is broader than this bounded Jellyfin change. |

--- a/specs/jellyfin-local-config/plan.md
+++ b/specs/jellyfin-local-config/plan.md
@@ -39,6 +39,9 @@ shell, but its fresh NFS-backed config does not exercise the production
 migration. A one-off isolated development Job therefore runs the exact migration
 script against an NFS source PVC and a `local-path` target PVC, verifies copied
 database, hidden, and authentication state, and removes all test resources.
+If the development node lacks the fixture's required iGPU label/resource, record
+that routed-profile infrastructure exception without weakening the production or
+branch GPU pinning; do not apply Terraform merely to satisfy this PR's smoke.
 **Post-Implementation SDD Conformance**: Local repository sources only; this
 change does not alter Spec Kit behavior or standards.
 

--- a/specs/jellyfin-local-config/spec.md
+++ b/specs/jellyfin-local-config/spec.md
@@ -1,0 +1,221 @@
+# Feature Specification: jellyfin-local-config
+
+**Feature Branch**: `codex/jellyfin-local-config`
+**Created**: 2026-08-08
+**Status**: Approved
+**Risk Tier**: medium
+**Input**: User description: "Jellyfin seems to really struggle whenever I'm adding new media"; preserve authentication and account for low cluster memory.
+
+## Human Gate Status
+
+**Intent Brief**: Reduce Jellyfin degradation during media ingestion by moving
+latency-sensitive `/config` I/O off Synology NFS. Preserve all existing
+authentication, users, permissions, plugins, metadata, and a native administrator
+recovery path. Keep media on Synology. Fail closed on partial migration. Treat
+low-memory conditions as a cutover gate rather than increasing steady-state
+memory reservations.
+
+**Clarify Status**: Run through the conversation. The user explicitly elevated
+authentication preservation to a critical constraint and asked whether the
+cluster memory warning changes the design.
+
+**Spec Gate**: Approved by Pete after reviewing the proposed artifacts and
+authentication/memory safeguards; "Ok let's open the PR" authorizes the bounded
+implementation.
+
+## Summary
+
+Move Jellyfin's live configuration and database state from its NFS-backed PVC to
+a node-local PVC so library scans and media ingestion do not perform
+latency-sensitive config I/O over NFS. Preserve the entire existing config tree,
+run a validated one-time migration before Jellyfin starts, retain the old NFS
+PVC for immediate rollback, and leave Authentik configuration and secrets
+unchanged.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/synology-nfs-storage.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/runbooks/jellyfin-authentik-sso.md`
+
+## Scope
+
+### In Scope
+
+- Add a `local-path` PVC for Jellyfin `/config`.
+- Preserve the existing NFS config PVC as a read-only migration and immediate
+  rollback source.
+- Copy and validate the complete Jellyfin config tree before application
+  startup.
+- Preserve existing local accounts, user identifiers, permissions,
+  administrator assignments, plugins, SSO configuration, branding, and database
+  state.
+- Use `Recreate` so the source database is quiescent during copy.
+- Bound migration and SSO init-container resources.
+- Add an app-specific binding storage decision and operational runbook guidance.
+- Add a focused executable test for migration success, retry, and fail-closed
+  behavior.
+
+### Out Of Scope
+
+- Moving the media library off Synology.
+- Changing the Authentik application, provider, redirect URI, client ID, client
+  secret, scopes, group names, or role mappings.
+- Disabling native Jellyfin login.
+- Changing Jellyfin chapter-image, trickplay, or scan-parallelism settings.
+- Making `local-path` highly available.
+- Automating backup or replication of the new local volume.
+- Changing Jellyfin's main-container memory request or limit.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Responsive media ingestion (Priority: P1)
+
+As a Jellyfin user, I can continue browsing or playing media while new content is
+being discovered without Jellyfin's database and metadata writes competing on
+the NFS config volume.
+
+**Why this priority**: This is the reported operational problem and the smallest
+valuable outcome.
+
+**Independent Test**: Render the workload and confirm `/config` uses
+`jellyfin-config-local-v1` with StorageClass `local-path`, while
+`/custom-media` remains the Synology NFS mount.
+
+**Acceptance Scenarios**:
+
+1. **Given** the existing NFS-backed config and Synology media library, **When**
+   the migration rollout completes, **Then** Jellyfin reads and writes `/config`
+   on the local PVC and continues to read media from Synology.
+2. **Given** a subsequent library scan, **When** Jellyfin updates its databases
+   and metadata, **Then** those config operations no longer target
+   `jellyfin-config-v2`.
+
+### User Story 2 - Authentication survives cutover (Priority: P1)
+
+As an existing user or administrator, I can sign in through the same Authentik
+identity and retain the same Jellyfin account and privileges after migration,
+while a native administrator remains available for recovery.
+
+**Why this priority**: Authentication loss would make the performance fix
+unacceptable and could lock out administration.
+
+**Independent Test**: The migration test proves all database files and pinned SSO
+artifacts are copied and byte-matched before the completion marker. Cutover
+acceptance then verifies an existing user, existing SSO administrator, and native
+administrator.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing `Jellyfin Users` member, **When** they complete OIDC
+   login after cutover, **Then** they reach their existing Jellyfin account.
+2. **Given** an existing `Jellyfin Admins` member, **When** they sign in, **Then**
+   administrator access remains.
+3. **Given** Authentik is unavailable, **When** a known local administrator uses
+   native login, **Then** recovery access remains possible.
+4. **Given** a missing database, SSO config, branding file, or plugin artifact,
+   **When** migration runs, **Then** Jellyfin does not start.
+
+### User Story 3 - Safe retry and rollback (Priority: P2)
+
+As the cluster operator, I can retry an interrupted migration and immediately
+roll back without modifying the original NFS config.
+
+**Why this priority**: Local storage introduces node affinity and the cluster is
+already warning about low memory, so cutover must fail safely.
+
+**Independent Test**: The migration test starts with an untrusted partial target,
+verifies it is replaced, verifies the completion marker, and verifies a completed
+target can be validated on restart without recopying source data.
+
+**Acceptance Scenarios**:
+
+1. **Given** an interrupted target without the completion marker, **When** the
+   init container retries, **Then** it clears the target and recopies from the
+   read-only source.
+2. **Given** a completed migration, **When** the pod restarts, **Then** the target
+   is validated and the copy is skipped.
+3. **Given** the selected iGPU worker reports `MemoryPressure=True`, **When**
+   cutover is evaluated, **Then** deployment acceptance remains blocked.
+4. **Given** authentication acceptance fails, **When** rollback is chosen,
+   **Then** GitOps can point `/config` back to the retained NFS PVC.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Jellyfin `/config` MUST use a PVC named
+  `jellyfin-config-local-v1` with StorageClass `local-path`.
+- **FR-002**: `/custom-media` MUST remain mounted from
+  `/volume1/Media/Jellyfin` on Synology NFS.
+- **FR-003**: `jellyfin-config-v2` MUST remain declared and MUST be mounted
+  read-only by the migration container.
+- **FR-004**: The Deployment MUST use `Recreate`.
+- **FR-005**: Migration MUST run before the existing SSO bootstrap and before the
+  Jellyfin container.
+- **FR-006**: Migration MUST copy the complete config tree, including hidden
+  files.
+- **FR-007**: Migration MUST validate a non-empty Jellyfin database plus
+  `system.xml`, `branding.xml`, `SSO-Auth.xml`, and all expected pinned SSO plugin
+  files.
+- **FR-008**: Migration MUST byte-compare the copied database files and critical
+  authentication artifacts before writing its completion marker.
+- **FR-009**: A target without the completion marker MUST be treated as
+  incomplete and replaced from source.
+- **FR-010**: A completed target MUST be validated on every restart before copy
+  is skipped.
+- **FR-011**: Any migration or SSO bootstrap failure MUST prevent Jellyfin from
+  starting.
+- **FR-012**: The Authentik blueprint, encrypted OAuth client secret, client ID,
+  redirect URI, scope/claim configuration, group names, and native login behavior
+  MUST remain unchanged.
+- **FR-013**: Migration and SSO init containers MUST have explicit resource
+  requests and limits, and the effective pod scheduling request MUST remain
+  bounded by Jellyfin's existing 2 GiB request.
+- **FR-014**: Production Flux wiring MUST depend on
+  `local-path-provisioner`.
+- **FR-015**: A binding ADR MUST record the app-specific exception to the default
+  NFS storage decision and the node-affinity/rollback consequences.
+- **FR-016**: Evidence MUST distinguish local/unit validation from pending
+  development and production authentication acceptance.
+
+## Risk And Validation Expectations
+
+This is a medium-risk Kubernetes storage and app-behavior change. It requires a
+focused executable migration test, YAML/render checks, decision metadata checks,
+development-cluster validation or an explicit unavailable-infrastructure
+exception, and controlled production authentication acceptance. Pod readiness or
+the login page alone is insufficient evidence.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Rendered Jellyfin desired state mounts `/config` from
+  `jellyfin-config-local-v1` and media from the unchanged NFS export.
+- **SC-002**: Migration tests pass for complete copy, idempotent restart, partial
+  target replacement, and missing-SSO fail-closed behavior.
+- **SC-003**: Neither
+  `kubernetes/infra/authentik/blueprints/jellyfin-oauth.yaml` nor
+  `kubernetes/apps/jellyfin/secret.yaml` changes in the PR.
+- **SC-004**: An existing SSO user, SSO administrator, and native administrator
+  all authenticate successfully during controlled cutover acceptance.
+- **SC-005**: `jellyfin-config-v2` remains available after cutover.
+- **SC-006**: The selected iGPU worker has `MemoryPressure=False` at cutover.
+
+## Assumptions
+
+- The current NFS config PVC contains the complete working Jellyfin and SSO
+  state.
+- The chart remains pinned to Jellyfin Helm chart `3.2.0`, which supports
+  `deploymentStrategy` and ordered `extraInitContainers`.
+- `local-path` uses `WaitForFirstConsumer` and `Retain` in production.
+- The old pod is fully terminated before the new migration pod starts under
+  `Recreate`.
+- An operator can perform the live authentication checks before considering the
+  rollout accepted.
+
+## Open Questions
+
+- None. The availability tradeoff of node-local config is explicitly accepted
+  for this implementation and documented in the binding ADR.

--- a/specs/jellyfin-local-config/tasks.md
+++ b/specs/jellyfin-local-config/tasks.md
@@ -43,7 +43,8 @@ critical conflict.
 - [x] T007 [FR-014] Add the local-path dependency in
       `kubernetes/clusters/production/apps/jellyfin.yaml`.
 - [x] T008 [FR-006..FR-011] Add
-      `tools/development/tests/test_jellyfin_config_migration.py`.
+      `tools/development/tests/test_jellyfin_config_migration.py`, including
+      completed-target authentication-loss validation.
 - [x] T009 [FR-015] Add
       `docs/decisions/jellyfin-local-config-storage.md`.
 - [x] T010 [FR-012,FR-016] Update
@@ -59,7 +60,8 @@ critical conflict.
 - [x] T014 [FR-TEST] Parse the proposed Kubernetes YAML with PyYAML.
 - [ ] T015 [FR-TEST] Run repository pre-commit, k8svalidate, kustomize render,
       decision metadata, architecture, and SDD harness checks.
-- [ ] T016 [FR-SMOKE] Run the development Jellyfin smoke with cluster access.
+- [ ] T016 [FR-SMOKE] Run both development layers: the exact migration script
+      against NFS and `local-path` PVCs, and the routed Jellyfin branch profile.
 - [ ] T017 [FR-SMOKE] Confirm production preflight: old PVC bound, selected iGPU
       worker `MemoryPressure=False`, safe Proxmox headroom, and native admin
       credential available.
@@ -69,7 +71,7 @@ critical conflict.
 - [x] T019 [FR-CONVERGE] Reconcile implementation artifacts with discoveries:
       node affinity, stale rollback source, and non-representative branch OIDC
       fixture are recorded.
-- [x] T020 [FR-EVIDENCE] Record completed checks and pending cluster/live gates
+- [ ] T020 [FR-EVIDENCE] Record completed checks and pending production gates
       in `specs/jellyfin-local-config/evidence.md`.
 
 ## Phase 4: Commit And PR
@@ -78,3 +80,5 @@ critical conflict.
       commit message.
 - [x] T022 [FR-PR] Open draft PR #380 and leave it draft until T015-T018 are
       completed or explicitly reviewed as pending.
+- [ ] T023 [FR-PR] Commit and push the audit fixes and current evidence to PR
+      #380, then confirm GitHub Actions passes.

--- a/specs/jellyfin-local-config/tasks.md
+++ b/specs/jellyfin-local-config/tasks.md
@@ -76,5 +76,5 @@ critical conflict.
 
 - [x] T021 [FR-PR] Commit on `codex/jellyfin-local-config` with a conventional
       commit message.
-- [ ] T022 [FR-PR] Open a draft PR and leave it draft until T015-T018 are
+- [x] T022 [FR-PR] Open draft PR #380 and leave it draft until T015-T018 are
       completed or explicitly reviewed as pending.

--- a/specs/jellyfin-local-config/tasks.md
+++ b/specs/jellyfin-local-config/tasks.md
@@ -1,0 +1,80 @@
+---
+description: "Jellyfin local config migration task list"
+---
+
+# Tasks: jellyfin-local-config
+
+**Input**: `specs/jellyfin-local-config/spec.md` and
+`specs/jellyfin-local-config/plan.md`
+**Risk Tier**: medium
+**Prerequisites**: Branch `codex/jellyfin-local-config` and matching SDD
+artifacts.
+
+## Human Gate Status
+
+**Spec Gate**: Approved by Pete after artifact review and authentication/memory
+clarification.
+
+**Plan Gate**: Approved by Pete's instruction to open the PR.
+
+**Analyze Requirement**: Completed before implementation; all FRs map to a
+manifest, script, test, documentation, or acceptance task, with no unresolved
+critical conflict.
+
+## Phase 1: Setup
+
+- [x] T001 [FR-015] Confirm `AGENTS.md`, SDD workflow, storage ADR, SSO runbook,
+      chart `3.2.0`, and local-path provisioner behavior.
+- [x] T002 [FR-012] Confirm the Authentik blueprint and encrypted Jellyfin secret
+      are outside the implementation edit set.
+
+## Phase 2: Implementation
+
+- [x] T003 [FR-001,FR-003] Add `jellyfin-config-local-v1` while retaining
+      `jellyfin-config-v2` in `kubernetes/apps/jellyfin/pvc.yaml`.
+- [x] T004 [FR-005..FR-011] Add
+      `kubernetes/apps/jellyfin/migrate-config.sh`.
+- [x] T005 [FR-004,FR-005,FR-013] Update
+      `kubernetes/apps/jellyfin/values.yaml` with `Recreate`, ordered
+      resource-bounded init containers, and migration volumes.
+- [x] T006 [FR-005] Update
+      `kubernetes/apps/jellyfin/kustomization.yaml` to generate the migration
+      ConfigMap.
+- [x] T007 [FR-014] Add the local-path dependency in
+      `kubernetes/clusters/production/apps/jellyfin.yaml`.
+- [x] T008 [FR-006..FR-011] Add
+      `tools/development/tests/test_jellyfin_config_migration.py`.
+- [x] T009 [FR-015] Add
+      `docs/decisions/jellyfin-local-config-storage.md`.
+- [x] T010 [FR-012,FR-016] Update
+      `docs/runbooks/jellyfin-authentik-sso.md`.
+- [x] T011 [FR-SETUP] Re-check constitution gates after implementation edits.
+
+## Phase 3: Verification
+
+- [x] T012 [FR-ANALYZE] Complete requirements-to-task analysis before
+      implementation.
+- [x] T013 [FR-TEST] Run the exact migration script and unit test in an isolated
+      local reconstruction.
+- [x] T014 [FR-TEST] Parse the proposed Kubernetes YAML with PyYAML.
+- [ ] T015 [FR-TEST] Run repository pre-commit, k8svalidate, kustomize render,
+      decision metadata, architecture, and SDD harness checks.
+- [ ] T016 [FR-SMOKE] Run the development Jellyfin smoke with cluster access.
+- [ ] T017 [FR-SMOKE] Confirm production preflight: old PVC bound, selected iGPU
+      worker `MemoryPressure=False`, safe Proxmox headroom, and native admin
+      credential available.
+- [ ] T018 [FR-SMOKE] After controlled cutover, verify existing user SSO,
+      administrator mapping, native admin login, callback URI, and retained NFS
+      PVC.
+- [x] T019 [FR-CONVERGE] Reconcile implementation artifacts with discoveries:
+      node affinity, stale rollback source, and non-representative branch OIDC
+      fixture are recorded.
+- [x] T020 [FR-EVIDENCE] Record completed checks and pending cluster/live gates
+      in `specs/jellyfin-local-config/evidence.md`.
+
+## Phase 4: Commit And PR
+
+- [x] T021 [FR-PR] Commit on `codex/jellyfin-local-config` with a conventional
+      commit message.
+- [ ] T022 [FR-PR] Open a draft PR and leave it draft until T015-T018 are
+      completed or explicitly reviewed as pending.

--- a/specs/jellyfin-local-config/tasks.md
+++ b/specs/jellyfin-local-config/tasks.md
@@ -58,10 +58,12 @@ critical conflict.
 - [x] T013 [FR-TEST] Run the exact migration script and unit test in an isolated
       local reconstruction.
 - [x] T014 [FR-TEST] Parse the proposed Kubernetes YAML with PyYAML.
-- [ ] T015 [FR-TEST] Run repository pre-commit, k8svalidate, kustomize render,
+- [x] T015 [FR-TEST] Run repository pre-commit, k8svalidate, kustomize render,
       decision metadata, architecture, and SDD harness checks.
-- [ ] T016 [FR-SMOKE] Run both development layers: the exact migration script
-      against NFS and `local-path` PVCs, and the routed Jellyfin branch profile.
+- [x] T016 [FR-SMOKE] Run both development layers: the exact migration script
+      against NFS and `local-path` PVCs passed; the routed Jellyfin branch
+      profile was attempted and its GPU-pinning infrastructure exception was
+      recorded.
 - [ ] T017 [FR-SMOKE] Confirm production preflight: old PVC bound, selected iGPU
       worker `MemoryPressure=False`, safe Proxmox headroom, and native admin
       credential available.
@@ -71,7 +73,7 @@ critical conflict.
 - [x] T019 [FR-CONVERGE] Reconcile implementation artifacts with discoveries:
       node affinity, stale rollback source, and non-representative branch OIDC
       fixture are recorded.
-- [ ] T020 [FR-EVIDENCE] Record completed checks and pending production gates
+- [x] T020 [FR-EVIDENCE] Record completed checks and pending production gates
       in `specs/jellyfin-local-config/evidence.md`.
 
 ## Phase 4: Commit And PR
@@ -80,5 +82,5 @@ critical conflict.
       commit message.
 - [x] T022 [FR-PR] Open draft PR #380 and leave it draft until T015-T018 are
       completed or explicitly reviewed as pending.
-- [ ] T023 [FR-PR] Commit and push the audit fixes and current evidence to PR
-      #380, then confirm GitHub Actions passes.
+- [x] T023 [FR-PR] Commit and push the audit fixes and current evidence to PR
+      #380; report the final GitHub Actions result in the PR handoff.

--- a/tools/development/tests/test_jellyfin_config_migration.py
+++ b/tools/development/tests/test_jellyfin_config_migration.py
@@ -99,6 +99,23 @@ class JellyfinConfigMigrationTest(unittest.TestCase):
             self.assertEqual(second.returncode, 0, second.stderr)
             self.assertIn("already completed", second.stdout)
 
+    def test_completed_migration_fails_closed_when_authentication_state_is_lost(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            target = root / "target"
+            create_config(source)
+            target.mkdir()
+
+            first = self.run_migration(source, target)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            (target / "plugins" / "configurations" / "SSO-Auth.xml").unlink()
+
+            second = self.run_migration(source, target)
+
+            self.assertNotEqual(second.returncode, 0)
+            self.assertIn("SSO-Auth.xml", second.stderr)
+
     def test_fails_closed_when_sso_configuration_is_missing(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tools/development/tests/test_jellyfin_config_migration.py
+++ b/tools/development/tests/test_jellyfin_config_migration.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_SCRIPT = REPO_ROOT / "kubernetes" / "apps" / "jellyfin" / "migrate-config.sh"
+PLUGIN_FILES = (
+    "SSO-Auth.dll",
+    "Duende.IdentityModel.dll",
+    "Duende.IdentityModel.OidcClient.dll",
+    "meta.json",
+)
+
+
+def write_file(path: Path, content: bytes | str = b"state") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        path.write_text(content, encoding="utf-8")
+    else:
+        path.write_bytes(content)
+
+
+def create_config(root: Path) -> None:
+    write_file(root / "config" / "system.xml", "<ServerConfiguration />")
+    write_file(root / "config" / "branding.xml", "<BrandingOptions />")
+    write_file(
+        root / "plugins" / "configurations" / "SSO-Auth.xml",
+        "<PluginConfiguration><OidConfigs /></PluginConfiguration>",
+    )
+    plugin_dir = root / "plugins" / "SSO Authentication_4.0.0.4"
+    for plugin_file in PLUGIN_FILES:
+        write_file(plugin_dir / plugin_file, f"plugin:{plugin_file}")
+    write_file(root / "data" / "jellyfin.db", b"sqlite-state")
+    write_file(root / "data" / "authentication.db", b"authentication-state")
+    write_file(root / ".hidden-state", b"hidden")
+
+
+class JellyfinConfigMigrationTest(unittest.TestCase):
+    def run_migration(self, source: Path, target: Path) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update({"SOURCE_ROOT": str(source), "TARGET_ROOT": str(target)})
+        return subprocess.run(
+            ["/bin/sh", str(MIGRATION_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_copies_and_validates_complete_authentication_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            target = root / "target"
+            create_config(source)
+            target.mkdir()
+            write_file(target / "partial", b"untrusted")
+
+            result = self.run_migration(source, target)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((target / "partial").exists())
+            self.assertTrue((target / ".homelab-config-migration-v1").is_file())
+            self.assertEqual(
+                (target / "plugins" / "configurations" / "SSO-Auth.xml").read_bytes(),
+                (source / "plugins" / "configurations" / "SSO-Auth.xml").read_bytes(),
+            )
+            self.assertEqual(
+                (target / "data" / "authentication.db").read_bytes(),
+                (source / "data" / "authentication.db").read_bytes(),
+            )
+            self.assertEqual((target / ".hidden-state").read_bytes(), b"hidden")
+
+    def test_completed_migration_does_not_require_source_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            target = root / "target"
+            create_config(source)
+            target.mkdir()
+
+            first = self.run_migration(source, target)
+            self.assertEqual(first.returncode, 0, first.stderr)
+
+            for path in sorted(source.rglob("*"), reverse=True):
+                if path.is_file() or path.is_symlink():
+                    path.unlink()
+                elif path.is_dir():
+                    path.rmdir()
+            source.rmdir()
+
+            second = self.run_migration(source, target)
+
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("already completed", second.stdout)
+
+    def test_fails_closed_when_sso_configuration_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "source"
+            target = root / "target"
+            create_config(source)
+            (source / "plugins" / "configurations" / "SSO-Auth.xml").unlink()
+            target.mkdir()
+
+            result = self.run_migration(source, target)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("SSO-Auth.xml", result.stderr)
+            self.assertFalse((target / ".homelab-config-migration-v1").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/development/tests/test_verify_branch_deploy.py
+++ b/tools/development/tests/test_verify_branch_deploy.py
@@ -213,7 +213,7 @@ class VerifyBranchDeployTest(unittest.TestCase):
     def test_profile_loading_discovers_current_supported_apps(self) -> None:
         profiles = verify.load_smoke_profiles()
 
-        self.assertEqual(set(profiles), {"home-assistant", "homepage", "jellyfin", "whoami"})
+        self.assertEqual(set(profiles), {"home-assistant", "homepage", "immich", "jellyfin", "whoami"})
         self.assertEqual(profiles["homepage"].activation_template, "kubernetes/clusters/development/branches/homepage-template.yaml")
         self.assertEqual(profiles["homepage"].git_repository, "branch-homepage-${branch_slug}")
         self.assertEqual(profiles["whoami"].activation_template, "kubernetes/clusters/development/branches/whoami-template.yaml")


### PR DESCRIPTION
## Summary

- move Jellyfin `/config` from the Synology NFS-backed PVC to a 10 GiB `local-path` PVC
- keep the media library on the existing Synology NFS export
- retain `jellyfin-config-v2` as a read-only, point-in-time migration and immediate rollback source
- use a fail-closed migration init container before the existing SSO bootstrap
- switch the Deployment to `Recreate` so SQLite state is quiescent during cutover
- add explicit init-container memory bounds, a binding ADR, runbook updates, migration tests, and Spec Kit evidence

## Authentication safety

Authentication preservation is release-blocking in this PR.

- the Authentik provider blueprint and SOPS-encrypted Jellyfin OAuth secret are unchanged
- the complete Jellyfin config tree is copied, including databases and hidden state
- migration validates and byte-compares the databases, `system.xml`, `branding.xml`, `SSO-Auth.xml`, and pinned SSO Authentication `4.0.0.4` plugin files before writing its marker
- an incomplete target is cleared and recopied; a marked target with missing critical authentication state fails closed
- migration or SSO bootstrap failure prevents Jellyfin from starting
- native Jellyfin login remains available for recovery

## Memory and storage considerations

- Jellyfin's existing `2Gi` request and `6Gi` limit are unchanged
- migration init container: `64Mi` request / `512Mi` limit
- SSO init container: `64Mi` request / `256Mi` limit
- cutover must not proceed while the selected iGPU worker reports `MemoryPressure=True`
- `local-path` makes the config volume node-affine; a failed bound worker can make Jellyfin unavailable
- the retained NFS PVC becomes stale after cutover and is not a continuously updated backup
- a durable backup/recovery strategy for the local config volume is a follow-up

## Validation completed

- [x] all 13 pre-commit hooks, decision metadata, generated architecture, and SDD harness checks pass
- [x] production/development renders pass kubeconform: 119 resources, 0 invalid, 0 errors
- [x] Helm `3.2.0` render confirms `Recreate`, init ordering, local target, and read-only NFS source
- [x] four migration tests pass, including completed-target authentication-loss fail-closed behavior
- [x] exact migration script passed in development from a bound `nfs-csi-storage` source PVC to a bound `local-path` target PVC; marker, databases, hidden state, and auth files were verified
- [x] ephemeral development namespaces, Flux resources, PVCs, and retained test PVs were cleaned up
- [x] read-only production preflight confirms `jellyfin-config-v2` is Bound, the source layout matches migration assumptions, config uses about 776 MiB, and both iGPU workers currently report `MemoryPressure=False`
- [x] branch diff confirms no changes to the Authentik blueprint or encrypted Jellyfin secret

## Development routed-smoke exception

Flux fetched exact test commit `3122efc3304db0414c7f4784507c205d2e4053b9`, but the routed Jellyfin profile could not start its pod because the development node lacks both the required Jellyfin iGPU label and allocatable `gpu.intel.com/i915`. Resolving that would require applying the missing Proxmox/VM GPU state and is intentionally outside this PR. The production and branch GPU pinning are unchanged.

## Required before merge/cutover

- [x] GitHub Actions passes on the final head
- [ ] confirm the selected iGPU worker still has `MemoryPressure=False` and safe Proxmox host headroom
- [ ] confirm a known native local administrator credential is available
- [ ] confirm `/sso/OID/start/authentik` redirects successfully with the exact HTTPS callback
- [ ] confirm an existing `Jellyfin Users` member reaches the same account
- [ ] confirm an existing `Jellyfin Admins` member retains administrator access
- [ ] confirm a known native local administrator can still sign in
- [ ] confirm the retained NFS PVC remains available after cutover

This PR remains draft because the last authentication and host-headroom checks are production cutover acceptance and cannot be inferred from development fixtures.

## Rollback

Point `persistence.config.existingClaim` back to `jellyfin-config-v2`, remove or disable the migration init container, and reconcile through Flux. This is an immediate rollback path; changes made after cutover would not be present on the retained NFS source.