### PR TITLE
fix(jellyfin): preserve migration script through Flux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,21 @@ jobs:
       - name: Set up kubectl
         uses: azure/setup-kubectl@v5
 
+      - name: Install Flux CLI
+        env:
+          FLUX_VERSION: "2.9.3"
+        run: |
+          set -euo pipefail
+          archive="flux_${FLUX_VERSION}_linux_amd64.tar.gz"
+          release="https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}"
+          curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+            -sSLO "${release}/${archive}"
+          curl --fail --location --retry 5 --retry-delay 5 --retry-all-errors \
+            -sSLO "${release}/flux_${FLUX_VERSION}_checksums.txt"
+          grep " ${archive}$" "flux_${FLUX_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "${archive}" flux
+          sudo install -m 0755 flux /usr/local/bin/flux
+
       - name: Install kubeconform
         env:
           KUBECONFORM_VERSION: "0.7.0"
@@ -156,6 +171,11 @@ jobs:
         run: >-
           kubectl kustomize kubernetes/clusters/development >
           /tmp/homelab-development.yaml
+
+      - name: Test Jellyfin config migration
+        run: >-
+          python3 -m unittest
+          tools.development.tests.test_jellyfin_config_migration
 
       - name: Validate rendered manifests
         run: >-

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/fix-cilium-gateway-crd"}
+{"feature_directory":"specs/jellyfin-migration-envsubst"}

--- a/kubernetes/apps/jellyfin/kustomization.yaml
+++ b/kubernetes/apps/jellyfin/kustomization.yaml
@@ -18,5 +18,7 @@ configMapGenerator:
       - migrate.sh=migrate-config.sh
     options:
       disableNameSuffixHash: true
+      annotations:
+        kustomize.toolkit.fluxcd.io/substitute: disabled
 configurations:
   - kustomizeconfig.yaml

--- a/specs/jellyfin-migration-envsubst/checklists/requirements.md
+++ b/specs/jellyfin-migration-envsubst/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Jellyfin Migration Envsubst
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2026-08-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] User/operator outcomes are stated before implementation details.
+- [x] The failure and desired recovery are narrowly scoped.
+- [x] Mandatory sections are complete.
+- [x] Binding safety constraints are explicit.
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+- [x] Requirements are testable and unambiguous.
+- [x] Success criteria are measurable.
+- [x] Acceptance scenarios cover reconciliation and safety preservation.
+- [x] Edge cases include silent substitution of valid shell variables.
+- [x] Scope and non-goals are explicit.
+- [x] Dependencies and assumptions are identified.
+
+## Feature Readiness
+
+- [x] Every functional requirement has a verifiable acceptance signal.
+- [x] User stories cover the rollout blocker and safety boundary.
+- [x] Cleanup is explicitly gated on successful production acceptance.
+- [x] The spec is ready for the bounded repair plan.
+
+## Notes
+
+- All 15 checks passed in one review iteration.
+- The user's "iterate as needed" instruction approves this direct repair after
+  three fanout lanes reproduced the same root cause.

--- a/specs/jellyfin-migration-envsubst/contracts/migration-configmap.md
+++ b/specs/jellyfin-migration-envsubst/contracts/migration-configmap.md
@@ -1,0 +1,14 @@
+# Contract: Migration ConfigMap Across Flux Post-Build
+
+Given the Jellyfin application Kustomization:
+
+1. Kustomize generates `ConfigMap/jellyfin-config-migration` in namespace
+   `jellyfin` with `migrate-config.sh` under `data.migrate.sh`.
+2. The resource carries annotation
+   `kustomize.toolkit.fluxcd.io/substitute: disabled`.
+3. Strict Flux substitution completes successfully for the full render.
+4. The post-substitution `data.migrate.sh` value is identical to the source
+   file, including nested and default-value shell expansions.
+5. `ConfigMap/jellyfin-values` remains eligible for normal Flux substitution.
+6. The init container executes the preserved script without a transport-time
+   decode or rewrite step.

--- a/specs/jellyfin-migration-envsubst/data-model.md
+++ b/specs/jellyfin-migration-envsubst/data-model.md
@@ -1,0 +1,32 @@
+# Data Model: Jellyfin Migration Rendering
+
+## Source script
+
+- **Path**: `kubernetes/apps/jellyfin/migrate-config.sh`
+- **Owner**: POSIX shell at init-container runtime
+- **Invariant**: Shell parameter expressions remain literal during GitOps
+  rendering.
+
+## Generated ConfigMap
+
+- **Name**: `jellyfin-config-migration`
+- **Namespace**: `jellyfin`
+- **Key**: `migrate.sh`
+- **Generator**: `kubernetes/apps/jellyfin/kustomization.yaml`
+- **Flux policy**: `kustomize.toolkit.fluxcd.io/substitute: disabled`
+- **Invariant**: `data["migrate.sh"]` equals the source script byte for byte.
+
+## Runtime consumer
+
+- **Consumer**: Jellyfin migration init container
+- **Mount**: Generated script ConfigMap
+- **Inputs**: Read-only NFS source PVC and local target PVC
+- **State transition**: Unmigrated target -> validated copied state -> marker;
+  marker-present retries validate the target and do not require the source.
+
+## Unchanged neighboring resource
+
+- **Name**: `jellyfin-values`
+- **Flux policy**: Substitution remains enabled.
+- **Invariant**: Cluster-domain and other intended GitOps variables continue to
+  resolve normally.

--- a/specs/jellyfin-migration-envsubst/evidence.md
+++ b/specs/jellyfin-migration-envsubst/evidence.md
@@ -1,0 +1,75 @@
+# Evidence: Jellyfin Migration Envsubst
+
+**Branch**: `codex/jellyfin-migration-envsubst`
+**Risk Tier**: medium
+**Started**: 2026-08-08
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | PASS | Verify merged migration, iterate on blockers, and clean up only after success. |
+| Spec approval | PASS | User explicitly authorized verification and needed iteration. |
+| Clarify | SKIP | Three independent read-only lanes reproduced the exact Flux failure. |
+| Plan approval | PASS | Repair is constrained to the diagnosed substitution boundary. |
+| Checklist | PASS | `checklists/requirements.md`: 15/15 complete. |
+| Tasks/analyze approval | PASS | Six requirements have task coverage; no inconsistency or ambiguity remained. |
+| Converge | PASS | No remaining buildable gap across six requirements, five success criteria, four acceptance scenarios, and the scoped plan decisions. |
+
+## Workflow Validation
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` | PASS | Branch and required SDD artifacts are coherent. |
+
+## Baseline Production State
+
+- PR #380 merged at `2026-08-08T23:11:49Z` as
+  `999c28e46b73ae59be1359dacbf762abfa2d859d`.
+- `GitRepository/flux-system` fetched that SHA at `2026-08-08T23:12:14Z`.
+- `Kustomization/app-jellyfin` reported `Ready=False`, `BuildFailed` at
+  `2026-08-08T23:14:51Z`; last applied remained
+  `ee26fe2c927523dbec6a6f2ccf9d874389a19af5`.
+- Error: `ConfigMap/jellyfin-config-migration: envsubst error: variable
+  substitution failed: bad substitution`.
+- Live Jellyfin remained on the old `RollingUpdate` deployment and
+  `jellyfin-config-v2` NFS PVC; the local PVC and migration ConfigMap were not
+  created, so the migration did not start.
+- The old pod remained Ready and continued serving the web and SSO-start paths.
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` at merge baseline | FAIL (expected) | Strict Flux substitution rejected the first unprotected runtime shell variable, `target_root`; production non-strict substitution reached the nested expression and reported `bad substitution`. |
+| `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` after repair | PASS | Six tests passed against the strict local Flux build output; script bytes, normal substitutions, copy, retry, and fail-closed behavior passed. |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture remains current; the resource annotation does not change topology. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `pre-commit run --all-files` | PASS | All repository hooks passed. |
+| Download Flux `2.9.3`, validate release checksum, and inspect archive | PASS | The exact CI download URLs, checksum entry, and `flux` archive member are valid. |
+
+## Automated Smoke And Live Verification
+
+Pending repaired merge. Baseline anonymous probes returned Jellyfin web/public
+info/branding successfully and produced the expected Authentik authorization
+redirect. They prove pre-migration availability, not migration success or
+authenticated role/session behavior.
+
+## Development Validation
+
+The exact local render/substitution integration replaces a routed development
+smoke because the development environment lacks the workload's pinned GPU
+resource. The user explicitly accepted that limitation and directed us not to
+change the pinning or VM infrastructure now.
+
+## Documentation Impact
+
+No canonical docs or generated architecture change is expected because storage,
+authentication, ingress, and migration semantics are unchanged.
+
+## Exceptions And Follow-Ups
+
+- Do not remove migration or rollback assets until the repaired production
+  rollout passes every acceptance layer.
+- Anonymous SSO smoke cannot prove user/admin authorization, role mapping,
+  native login, or session continuity.

--- a/specs/jellyfin-migration-envsubst/evidence.md
+++ b/specs/jellyfin-migration-envsubst/evidence.md
@@ -48,6 +48,15 @@
 | `pre-commit run --all-files` | PASS | All repository hooks passed. |
 | Download Flux `2.9.3`, validate release checksum, and inspect archive | PASS | The exact CI download URLs, checksum entry, and `flux` archive member are valid. |
 
+## GitHub Review Gate
+
+- Draft PR: `https://github.com/petebeegle/homelab/pull/382`
+- Initial head: `71f3f12`
+- Checks: PASS, 7/7 (`Agnix`, `GitGuardian Security Checks`, `Kubernetes`,
+  `Pre-commit`, `Python`, `Secrets`, and `Terraform`).
+- The Kubernetes job passed with the newly added strict Flux build and six-case
+  migration regression in a clean GitHub runner.
+
 ## Automated Smoke And Live Verification
 
 Pending repaired merge. Baseline anonymous probes returned Jellyfin web/public

--- a/specs/jellyfin-migration-envsubst/plan.md
+++ b/specs/jellyfin-migration-envsubst/plan.md
@@ -1,0 +1,171 @@
+# Implementation Plan: Jellyfin Migration Envsubst
+
+**Branch**: `codex/jellyfin-migration-envsubst` | **Date**: 2026-08-08 | **Spec**:
+`specs/jellyfin-migration-envsubst/spec.md`
+
+**Input**: Feature specification from
+`specs/jellyfin-migration-envsubst/spec.md`
+
+## Summary
+
+Repair the merged Jellyfin migration's Flux build failure by annotating only
+the generated migration ConfigMap to opt it out of post-build variable
+substitution. Keep substitution active for the application values ConfigMap,
+and add regression coverage that renders the manifests through strict Flux
+substitution, verifies the script is preserved, and executes that rendered
+script through the existing migration safety cases.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, Flux, shell migration, Python tests
+**Dependencies**: Spec Kit, Flux CLI, kubectl, Python standard library
+**Storage**: Existing `local-path` target and retained read-only
+`jellyfin-config-v2` NFS source; no storage change
+**Ingress**: Existing Gateway API `HTTPRoute`; no route change
+**Secrets**: Existing SOPS-encrypted secret references; no secret change
+**Smoke Strategy**: Exact local `flux build kustomization
+--strict-substitute` regression, focused migration tests, production
+Flux/workload/storage inspection, and exact HTTPS web plus SSO-start probes
+**Fanout Targets**: GitHub/Flux revision state, Kubernetes rollout/storage state,
+and user-path/observability checks are independent read-only lanes
+**Development Validation**: Exact local render/substitution and unit execution.
+The routed Jellyfin development profile cannot schedule because its pinned GPU
+resource is absent; the user explicitly accepted that known limitation for this
+work.
+**Post-Implementation SDD Conformance**: Local artifacts only; no template or
+upstream Spec Kit change
+
+## Human Gates
+
+**Spec Gate**: Approved by the user's instruction to verify the merged rollout
+and iterate as needed.
+
+**Checklist Status**: PASS, 15/15 items in
+`specs/jellyfin-migration-envsubst/checklists/requirements.md`.
+
+**Plan Gate**: Approved by the user's instruction to iterate on verification
+failures; the change is constrained to the exact diagnosed blocker.
+
+**Expected Task/Analyze Gate**: Tasks plus analyze required before
+implementation.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered for PVC-backed workloads; the approved local-config
+      decision remains binding and the NFS rollback source is retained.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/jellyfin-migration-envsubst`; isolated worktree
+      `/home/vscode/homelab-worktrees/jellyfin-migration-envsubst` is
+      intentional and recorded when relevant.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/jellyfin-migration-envsubst/
+├── checklists/requirements.md
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/migration-configmap.md
+├── quickstart.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/jellyfin/kustomization.yaml
+tools/development/tests/test_jellyfin_config_migration.py
+.github/workflows/ci.yml
+specs/jellyfin-migration-envsubst/**
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: First extend the focused test to render and execute the
+post-substitution script. At the merged baseline, that test must fail with
+Flux's `bad substitution`; after the ConfigMap annotation, it must pass without
+changing migration behavior.
+
+**Local checks**:
+
+- `python3 -m unittest tools.development.tests.test_jellyfin_config_migration`
+- `python3 tools/architecture/render.py --check`
+- `pre-commit run --all-files`
+
+**Development smoke**: The exact Flux post-build rendering path and migration
+script execution are automated locally. Routed development workload smoke is an
+explicit exception because the development node lacks the pinned GPU resource;
+the user directed us not to resolve that infrastructure mismatch now.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization or HelmRelease applied SHA, live resource spec, Gateway/listener
+match when applicable, and exact user-facing URL result.
+
+**Fanout plan**: One lane verifies GitHub merge and Flux source/application
+revisions, one verifies Kubernetes deployment/PVC/init state, and one verifies
+web/SSO paths plus logs. The main lane owns all tracked edits and consolidates
+timestamps, SHAs, commands, and outcomes into `evidence.md`.
+
+**Evidence destination**: `specs/jellyfin-migration-envsubst/evidence.md`.
+
+## Documentation Impact
+
+No canonical runbook, ADR, generated architecture, or agent guidance change is
+required. The binding Jellyfin local-storage decision remains unchanged; this
+implementation corrects only Flux processing of the migration payload. SDD
+artifacts record the failure, exception, repair, and verification evidence.
+
+## Implementation Steps
+
+1. Add a failing regression that performs a strict local Flux Kustomization
+   build, extracts the generated ConfigMap script, confirms
+   it matches the source, and runs the existing migration cases against it.
+2. Annotate only `jellyfin-config-migration` with
+   `kustomize.toolkit.fluxcd.io/substitute: disabled`.
+3. Run focused tests, strict production render, architecture check, and
+   repository validation; then push a PR and require GitHub status checks.
+4. After merge, verify fetched/applied revisions, the live deployment and PVCs,
+   migration init state/logs, and exact web and SSO-start paths.
+5. If all acceptance evidence passes, leave cleanup as a separately reviewed
+   follow-up; do not remove rollback assets in this repair.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Flux CLI behavior differs from kustomize-controller | Use the documented resource annotation and verify the merged revision in the controller. |
+| Annotation disables desired app substitutions | Scope it only to the migration ConfigMap and assert the values ConfigMap still substitutes. |
+| Tests execute repository source instead of controller output | Extract and execute the script from the post-substitution rendered ConfigMap. |
+| Migration changes authentication or storage semantics | Leave the script and workload manifests unchanged and rerun all fail-closed cases plus live invariants. |
+| Production outage during `Recreate` migration | Confirm the old deployment remains live until a buildable revision exists, then verify init completion and user paths immediately after rollout. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/jellyfin-migration-envsubst/quickstart.md
+++ b/specs/jellyfin-migration-envsubst/quickstart.md
@@ -1,0 +1,14 @@
+# Quickstart: Jellyfin Migration Envsubst Verification
+
+From the implementation worktree:
+
+```bash
+python3 -m unittest tools.development.tests.test_jellyfin_config_migration
+python3 tools/architecture/render.py --check
+pre-commit run --all-files
+```
+
+After merge, record the GitHub merge SHA, Flux source fetched SHA, Jellyfin
+Kustomization applied SHA, live deployment strategy/PVC/init state, and exact
+HTTPS web and SSO-start results in `evidence.md`. Do not remove migration or
+rollback assets until every acceptance layer passes.

--- a/specs/jellyfin-migration-envsubst/research.md
+++ b/specs/jellyfin-migration-envsubst/research.md
@@ -1,0 +1,43 @@
+# Research: Jellyfin Migration Envsubst
+
+## Decision: Disable substitution for the script-bearing resource
+
+Flux performs post-build substitution over the final YAML, including literal
+shell text stored in ConfigMap data. The merged migration script contains both
+ordinary shell expansions such as `${path}` and a nested removal expression,
+`${source_file#${source_root}/}`. The nested form causes `bad substitution`;
+ordinary forms may be replaced with empty values.
+
+Use the documented resource annotation
+`kustomize.toolkit.fluxcd.io/substitute: disabled` on only the generated
+`jellyfin-config-migration` ConfigMap. This makes the ownership boundary
+explicit: Flux owns Kubernetes manifest variables, while `/bin/sh` owns the
+migration script's variables.
+
+## Alternatives considered
+
+- Escape every shell expression with `$${...}`: supported by Flux, but couples
+  the standalone shell source to a templating transport and makes direct shell
+  tests invalid until an extra decoding step occurs. Missing one expression can
+  silently alter behavior.
+- Rewrite the nested expansion only: resolves the immediate parser error but
+  leaves ordinary shell expansions vulnerable to substitution.
+- Disable post-build substitution for the whole Jellyfin application: rejected
+  because `jellyfin-values` intentionally uses cluster variables.
+
+## Validation decision
+
+Run `flux build kustomization --dry-run --strict-substitute` with local inline
+production variables, then select the generated ConfigMap and compare its
+`migrate.sh` value with the repository source before executing the existing
+safety suite. Unlike the lower-level `flux envsubst` command, the local
+Kustomization build honors the per-resource substitution policy. Production
+controller reconciliation is still required because the CLI is only a local
+reproduction of the controller stage.
+
+## Tooling decision
+
+The focused Python test may use `kubectl` and `flux` subprocesses because both
+are required operator tools and exercise the actual failed integration. GitHub
+CI must install a pinned Flux CLI before running this focused test. No YAML
+library dependency is introduced.

--- a/specs/jellyfin-migration-envsubst/spec.md
+++ b/specs/jellyfin-migration-envsubst/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: jellyfin-migration-envsubst
+
+**Feature Branch**: `codex/jellyfin-migration-envsubst`
+**Created**: 2026-08-08
+**Status**: Approved
+**Risk Tier**: medium
+**Input**: User description: "Merged. Verify success, iterate as needed or clean
+up migration scripts upon success. Fan out."
+
+## Human Gate Status
+
+**Intent Brief**: Verify the merged Jellyfin config migration end to end, repair
+any rollout blocker without weakening storage, GPU, or authentication safety,
+and defer cleanup until the migration has actually succeeded.
+
+**Clarify Status**: Skipped. Three independent read-only fanout lanes reproduced
+the same exact Flux build failure and identified unescaped shell parameter
+expressions as the cause.
+
+**Spec Gate**: Approved by the user's explicit instruction to verify the merge
+and iterate as needed.
+
+## Summary
+
+Restore deployment of the already-merged Jellyfin local-config migration. Flux
+must be able to process the desired state without changing the migration
+script's runtime meaning, after which the migration can run with its existing
+authentication, rollback, storage, and GPU safeguards intact.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/jellyfin-local-config-storage.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/runbooks/jellyfin-authentik-sso.md`
+
+## Scope
+
+### In Scope
+
+- Make the generated migration script safe for Flux variable substitution.
+- Add regression coverage for the exact render-and-substitute path that failed.
+- Preserve the runtime shell expressions and migration behavior byte-for-byte
+  after Flux substitution.
+- Verify the repaired revision through GitHub Actions and layered production
+  reconciliation, workload, storage, and user-path evidence.
+
+### Out Of Scope
+
+- Changing Jellyfin storage classes, PVC names, GPU pinning, authentication
+  configuration, migration integrity rules, or rollback behavior.
+- Applying missing development GPU/VM infrastructure.
+- Removing migration assets before the repaired production migration and
+  acceptance checks succeed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Migration Reconciles (Priority: P1)
+
+As the operator, I can merge the repair and have Flux apply the Jellyfin local
+config migration rather than rejecting the generated configuration.
+
+**Why this priority**: The original change is fetched but cannot be built, so no
+migration behavior can run until substitution succeeds.
+
+**Independent Test**: Render the Jellyfin manifests, run strict Flux
+substitution, and confirm the resulting migration script retains every intended
+shell expression.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Jellyfin migration script is embedded in a generated
+   configuration object, **When** Flux performs strict substitution, **Then** it
+   reports no bad-substitution error and preserves the script for runtime.
+2. **Given** the repaired revision is merged, **When** production Flux
+   reconciles Jellyfin, **Then** the application Kustomization applies that
+   revision and starts the migration workload.
+
+### User Story 2 - Safety Is Preserved (Priority: P1)
+
+As a Jellyfin user or administrator, I retain the same storage, authentication,
+rollback, and availability safeguards while the rollout blocker is repaired.
+
+**Why this priority**: A syntax workaround is unacceptable if it changes the
+migration's fail-closed behavior or identity state.
+
+**Independent Test**: Run the existing migration suite against the substituted
+runtime script and compare the rendered workload's claims, init ordering, and
+authentication references with the merged design.
+
+**Acceptance Scenarios**:
+
+1. **Given** representative Jellyfin and SSO state, **When** the substituted
+   script migrates it, **Then** all existing success, retry, and fail-closed tests
+   pass.
+2. **Given** the repaired desired state, **When** it renders, **Then** the local
+   target, read-only NFS source, `Recreate` strategy, init ordering, and existing
+   authentication references remain unchanged.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: A strict local Flux Kustomization build MUST complete without an
+  error for the rendered Jellyfin application.
+- **FR-002**: Every runtime shell parameter expansion in the migration script
+  MUST remain present after Flux substitution.
+- **FR-003**: Existing migration tests MUST execute the post-substitution script
+  rather than only the repository source.
+- **FR-004**: The repair MUST NOT change PVC names, storage classes, deployment
+  strategy, init ordering, GPU selection, authentication settings, or rollback
+  source retention.
+- **FR-005**: Production verification MUST distinguish merged, fetched, applied,
+  live workload, storage, and exact user-path layers.
+- **FR-006**: Migration cleanup MUST remain deferred until the repaired rollout
+  is applied and verified.
+
+## Risk And Validation Expectations
+
+This is a medium-risk Kubernetes and Flux rendering repair. It requires focused
+unit tests, exact Kustomize plus strict Flux substitution, Helm/render review,
+repository validation, and post-merge production verification. The known
+development iGPU fixture limitation remains an explicit exception; substitute
+checks must exercise the exact failed rendering path and the production user
+path.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A strict local Flux Kustomization build of the rendered Jellyfin
+  application exits zero with no `bad substitution` message.
+- **SC-002**: All focused migration tests pass using the substituted script.
+- **SC-003**: Production Flux applies the repaired merge revision and the live
+  Jellyfin deployment uses `Recreate`, the local config PVC, and the expected
+  ordered init containers.
+- **SC-004**: The exact Jellyfin HTTPS web and SSO-start paths respond without a
+  server error after rollout.
+- **SC-005**: No migration, storage, or authentication error is present in the
+  repaired pod's init status or relevant logs.
+
+## Assumptions
+
+- `kustomize.toolkit.fluxcd.io/substitute: disabled` is the supported Flux
+  resource annotation for preserving literal shell expressions in the
+  generated migration ConfigMap while leaving substitution enabled elsewhere.
+- The old live Jellyfin deployment remains available until the repaired desired
+  state builds successfully.
+- Cleanup is a separate follow-up implementation after production acceptance.
+
+## Open Questions
+
+- None.

--- a/specs/jellyfin-migration-envsubst/tasks.md
+++ b/specs/jellyfin-migration-envsubst/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: Jellyfin Migration Envsubst
+
+**Input**: `spec.md`, `plan.md`, `research.md`, `data-model.md`,
+`contracts/migration-configmap.md`, and `quickstart.md`
+
+**Tests**: Required. The failure is in a rendered integration boundary and the
+existing behavioral test currently bypasses that boundary.
+
+## Phase 1: Baseline and failing regression
+
+- [X] T001 Record the merged production BuildFailed baseline and the still-live
+  pre-migration workload in `specs/jellyfin-migration-envsubst/evidence.md`.
+- [X] T002 [FR-001] [FR-002] [FR-003] Update
+  `tools/development/tests/test_jellyfin_config_migration.py` to run a strict
+  local Flux Kustomization build, extract the generated
+  migration script, compare it to the source, and execute all migration cases
+  against the rendered script.
+- [X] T003 Run the focused test at the merged baseline and record the expected
+  `bad substitution` failure in `specs/jellyfin-migration-envsubst/evidence.md`.
+- [X] T004 Add pinned Flux CLI setup and the focused migration regression to the
+  Kubernetes job in `.github/workflows/ci.yml`.
+
+## Phase 2: Focused repair
+
+- [X] T005 [FR-001] [FR-002] [FR-004] Add the documented
+  `kustomize.toolkit.fluxcd.io/substitute: disabled` annotation only to the
+  `jellyfin-config-migration` generator in
+  `kubernetes/apps/jellyfin/kustomization.yaml`.
+- [X] T006 [FR-003] Run the focused migration suite and confirm all existing
+  copy, retry, and fail-closed cases pass against the rendered script.
+- [X] T007 [FR-001] [FR-002] [FR-004] Run a strict full Jellyfin render and
+  confirm the migration script is preserved while intended application values
+  substitution remains enabled.
+
+## Phase 3: Repository validation and review gate
+
+- [X] T008 Run `python3 tools/architecture/render.py --check` and confirm no
+  generated architecture update is required.
+- [X] T009 Run `pre-commit run --all-files` and resolve only failures caused by
+  this implementation.
+- [X] T010 Re-check the constitution and inspect the final diff for unrelated,
+  secret, storage, GPU, authentication, and route changes.
+- [X] T011 Create `specs/jellyfin-migration-envsubst/evidence.md` with the
+  consolidated results from all fanout lanes and local validation.
+- [ ] T012 Push the branch, open the focused PR, and require all GitHub status
+  checks to pass before merge.
+
+## Phase 4: Post-merge production acceptance
+
+- [ ] T013 [P] [FR-005] Verify GitHub merge SHA, production Flux source fetched
+  SHA, and `app-jellyfin` applied SHA; record timestamps and conditions.
+- [ ] T014 [P] [FR-004] [FR-005] Verify the live Jellyfin deployment uses
+  `Recreate`, the local target PVC, the retained read-only NFS source, and the
+  expected migration-before-SSO init ordering.
+- [ ] T015 [P] [FR-005] Verify migration init completion/logs and inspect
+  relevant storage, database, authentication, and application errors.
+- [ ] T016 [P] [FR-005] Probe the exact HTTPS web, public-info, branding, and SSO
+  start/redirect paths without exposing OIDC state or secrets.
+- [ ] T017 [FR-005] Consolidate production acceptance, known anonymous-auth
+  limitations, and the development GPU exception into `evidence.md`.
+
+## Phase 5: Cleanup decision
+
+- [ ] T018 [FR-006] If every production acceptance layer passes, record that
+  migration/rollback cleanup is eligible for a separate implementation; if any
+  layer fails, iterate on the failure and leave all migration assets intact.
+
+## Dependencies
+
+- T001-T003 establish the failing test before T004-T005.
+- T005 blocks T006-T012.
+- T012 and PR merge block T013-T018.
+- T013-T016 are independent read-only verification lanes and may run in
+  parallel; T017 consolidates their evidence.
+- T018 is last and never removes assets in this implementation.
+
+## Parallel execution examples
+
+- After merge, T013 can inspect GitHub and Flux revisions while T014-T015
+  inspect Kubernetes state and T016 exercises exact user paths.
+- All tracked repository edits remain owned by the main implementation lane;
+  helpers return evidence only.

--- a/specs/jellyfin-migration-envsubst/tasks.md
+++ b/specs/jellyfin-migration-envsubst/tasks.md
@@ -42,7 +42,7 @@ existing behavioral test currently bypasses that boundary.
   secret, storage, GPU, authentication, and route changes.
 - [X] T011 Create `specs/jellyfin-migration-envsubst/evidence.md` with the
   consolidated results from all fanout lanes and local validation.
-- [ ] T012 Push the branch, open the focused PR, and require all GitHub status
+- [X] T012 Push the branch, open the focused PR, and require all GitHub status
   checks to pass before merge.
 
 ## Phase 4: Post-merge production acceptance

--- a/tools/development/tests/test_jellyfin_config_migration.py
+++ b/tools/development/tests/test_jellyfin_config_migration.py
@@ -9,6 +9,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MIGRATION_SCRIPT = REPO_ROOT / "kubernetes" / "apps" / "jellyfin" / "migrate-config.sh"
+JELLYFIN_MANIFESTS = REPO_ROOT / "kubernetes" / "apps" / "jellyfin"
+FLUX_KUSTOMIZATION = (
+    REPO_ROOT / "kubernetes" / "clusters" / "production" / "apps" / "jellyfin.yaml"
+)
 PLUGIN_FILES = (
     "SSO-Auth.dll",
     "Duende.IdentityModel.dll",
@@ -40,12 +44,89 @@ def create_config(root: Path) -> None:
     write_file(root / ".hidden-state", b"hidden")
 
 
+def extract_migration_script(manifests: str) -> str:
+    for document in manifests.split("\n---\n"):
+        if (
+            "\nkind: ConfigMap\n" not in document
+            or "name: jellyfin-config-migration\n" not in document
+            or "  migrate.sh: |\n" not in document
+        ):
+            continue
+
+        lines = document.splitlines(keepends=True)
+        start = lines.index("  migrate.sh: |\n") + 1
+        script_lines: list[str] = []
+        for line in lines[start:]:
+            if line.strip() and not line.startswith("    "):
+                break
+            script_lines.append(line[4:] if line.startswith("    ") else line)
+        return "".join(script_lines)
+
+    raise AssertionError("rendered jellyfin-config-migration ConfigMap was not found")
+
+
 class JellyfinConfigMigrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.runtime_script_dir = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.runtime_script_dir.cleanup)
+
+        local_kustomization = Path(cls.runtime_script_dir.name) / "jellyfin.yaml"
+        local_kustomization.write_text(
+            FLUX_KUSTOMIZATION.read_text(encoding="utf-8").replace(
+                "  postBuild:\n",
+                "  postBuild:\n"
+                "    substitute:\n"
+                '      cluster_domain: "lab.petebeegle.com"\n'
+                '      nfs_server: "192.0.2.10"\n',
+            ),
+            encoding="utf-8",
+        )
+
+        rendered = subprocess.run(
+            [
+                "flux",
+                "build",
+                "kustomization",
+                "app-jellyfin",
+                "--path",
+                str(JELLYFIN_MANIFESTS),
+                "--kustomization-file",
+                str(local_kustomization),
+                "--dry-run",
+                "--strict-substitute",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        if rendered.returncode != 0:
+            raise AssertionError(rendered.stderr)
+
+        cls.rendered_manifests = rendered.stdout
+        cls.runtime_script = Path(cls.runtime_script_dir.name) / "migrate.sh"
+        cls.runtime_script.write_text(
+            extract_migration_script(rendered.stdout), encoding="utf-8"
+        )
+
+    def test_flux_preserves_migration_script(self) -> None:
+        self.assertEqual(
+            self.runtime_script.read_bytes(),
+            MIGRATION_SCRIPT.read_bytes(),
+        )
+
+    def test_flux_still_substitutes_neighboring_application_values(self) -> None:
+        self.assertNotIn("${cluster_domain}", self.rendered_manifests)
+        self.assertNotIn("${nfs_server}", self.rendered_manifests)
+        self.assertIn("https://jellyfin.lab.petebeegle.com", self.rendered_manifests)
+        self.assertIn("server: 192.0.2.10", self.rendered_manifests)
+
     def run_migration(self, source: Path, target: Path) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update({"SOURCE_ROOT": str(source), "TARGET_ROOT": str(target)})
         return subprocess.run(
-            ["/bin/sh", str(MIGRATION_SCRIPT)],
+            ["/bin/sh", str(self.runtime_script)],
             check=False,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

- opt only the generated Jellyfin migration ConfigMap out of Flux post-build substitution
- preserve the migration shell script byte-for-byte while keeping normal Jellyfin value substitution enabled
- run the existing migration safety cases against a strict local Flux Kustomization build
- add the pinned, checksum-verified Flux CLI and focused regression to CI

## Root cause

PR #380 embedded POSIX shell `${...}` expressions in generated ConfigMap data. Flux processed those expressions as post-build variables: ordinary expressions could be emptied, and the nested `${source_file#${source_root}/}` expression caused `app-jellyfin` to fail its build with `bad substitution`. Production therefore stayed safely on the previous deployment and NFS config PVC; the migration never began.

Flux supports disabling substitution per resource. This PR scopes `kustomize.toolkit.fluxcd.io/substitute: disabled` to `ConfigMap/jellyfin-config-migration`, leaving `ConfigMap/jellyfin-values` eligible for the intended cluster substitutions.

## Validation

- `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` — 6 passed
- `python3 tools/architecture/render.py --check` — passed
- `python3 tools/codex-harness/validate_sdd_context.py --root "$(pwd)" --branch "$(git branch --show-current)" --require-plan-artifacts` — passed
- `pre-commit run --all-files` — passed
- Flux 2.9.3 CI archive checksum/download path — passed

## Deployment note

The routed development Jellyfin profile remains unavailable because its pinned GPU resource is absent; the user explicitly excluded that infrastructure change. The regression exercises the exact Flux build boundary instead. After merge, production acceptance will verify fetched/applied SHAs, init migration state, PVC/storage invariants, logs, and exact web/SSO paths before any cleanup is considered.