### PR TITLE
fix(jellyfin): clear rolling strategy during recreate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,12 @@ jobs:
       - name: Set up kubectl
         uses: azure/setup-kubectl@v5
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      - name: Add Jellyfin Helm repository
+        run: helm repo add jellyfin https://jellyfin.github.io/jellyfin-helm
+
       - name: Install Flux CLI
         env:
           FLUX_VERSION: "2.9.3"

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/jellyfin-migration-envsubst"}
+{"feature_directory":"specs/jellyfin-recreate-strategy"}

--- a/kubernetes/apps/jellyfin/values.yaml
+++ b/kubernetes/apps/jellyfin/values.yaml
@@ -7,6 +7,7 @@ persistence:
     enabled: false
 deploymentStrategy:
   type: Recreate
+  rollingUpdate: null
 nodeSelector:
   homelab.petebeegle.com/jellyfin-igpu: "true"
 resources:

--- a/specs/jellyfin-recreate-strategy/checklists/requirements.md
+++ b/specs/jellyfin-recreate-strategy/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Jellyfin Recreate Strategy
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-08-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No unnecessary implementation details
+- [x] Focused on operator and user outcomes
+- [x] Written clearly for repository stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No clarification markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria describe verifiable outcomes
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions are identified
+
+## Feature Readiness
+
+- [x] All functional requirements have acceptance criteria
+- [x] User scenarios cover the primary flows
+- [x] Feature meets the measurable outcomes
+- [x] Implementation detail is limited to the diagnosed operational contract
+
+## Notes
+
+- All 16 items pass. User authorization to continue covers the spec gate for
+  this exact production blocker.

--- a/specs/jellyfin-recreate-strategy/contracts/deployment-strategy.md
+++ b/specs/jellyfin-recreate-strategy/contracts/deployment-strategy.md
@@ -1,0 +1,13 @@
+# Contract: Jellyfin Deployment Strategy
+
+For Jellyfin chart version `3.2.0` rendered with
+`kubernetes/apps/jellyfin/values.yaml`:
+
+1. The Deployment strategy mapping contains `type: Recreate`.
+2. The same mapping contains `rollingUpdate: null` so server-side apply clears
+   the field inherited from the live RollingUpdate deployment.
+3. The rendered workload still uses `jellyfin-config-local-v1` for `/config`.
+4. The migration init container precedes the SSO bootstrap init container.
+5. The migration source remains `jellyfin-config-v2` and read-only.
+6. GPU selection, authentication references, routes, and resources are
+   unchanged.

--- a/specs/jellyfin-recreate-strategy/data-model.md
+++ b/specs/jellyfin-recreate-strategy/data-model.md
@@ -1,0 +1,24 @@
+# Data Model: Deployment Strategy Transition
+
+## Existing live strategy
+
+- Type: `RollingUpdate`
+- Rolling-update settings: present
+- Workload: healthy pre-migration Jellyfin deployment
+
+## Desired transition payload
+
+- Type: `Recreate`
+- Rolling-update settings: explicit null/clear
+- Invariant: no other Jellyfin values change
+
+## Accepted live strategy
+
+- Type: `Recreate`
+- Rolling-update settings: absent after API processing
+- Workload: migration init runs before SSO bootstrap and application startup
+
+## Rollback state
+
+- The old NFS config PVC remains declared and retained.
+- Helm rollback may restore the old Deployment if a later stage fails.

--- a/specs/jellyfin-recreate-strategy/evidence.md
+++ b/specs/jellyfin-recreate-strategy/evidence.md
@@ -45,6 +45,15 @@
 | `git diff --check` | PASS | No whitespace errors. |
 | `pre-commit run --all-files` | PASS | All repository hooks passed. |
 
+## GitHub Review Gate
+
+- Draft PR: `https://github.com/petebeegle/homelab/pull/385`
+- Initial head: `121e31e`
+- Checks: PASS, 7/7 (`Agnix`, `GitGuardian Security Checks`, `Kubernetes`,
+  `Pre-commit`, `Python`, `Secrets`, and `Terraform`).
+- The Kubernetes job passed with Helm setup, the pinned chart render, and all
+  eight focused Jellyfin tests in a clean runner.
+
 ## Development Validation
 
 Exact chart rendering and focused migration execution substitute for routed

--- a/specs/jellyfin-recreate-strategy/evidence.md
+++ b/specs/jellyfin-recreate-strategy/evidence.md
@@ -1,0 +1,66 @@
+# Evidence: Jellyfin Recreate Strategy
+
+**Branch**: `codex/jellyfin-recreate-strategy`
+**Risk Tier**: medium
+**Started**: 2026-08-09
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent brief | PASS | User directed continued iteration and cleanup only after success. |
+| Spec approval | PASS | The exact production blocker is within that authorization. |
+| Clarify | SKIP | Production events and chart output identify one unambiguous field transition. |
+| Plan approval | PASS | Narrow explicit-clear approach already reproduced in the pinned chart. |
+| Checklist | PASS | `checklists/requirements.md`: 16/16 complete. |
+| Tasks/analyze approval | PASS | Six requirements have task coverage; no ambiguity, conflict, or unmapped task remains. |
+| Converge | PASS | No remaining buildable gap across six requirements, five success criteria, and four acceptance scenarios. |
+
+## Baseline Production State
+
+- PR #382 merged as `b01509171dac73b785ddfcd24747d58ef8a1ce8a`.
+- Main CI run `31287600873` passed all six jobs at `2026-08-09T01:07:35Z`.
+- Production Flux fetched the SHA at `01:06:53Z` and passed the prior envsubst
+  blocker.
+- `app-jellyfin` applied the generated ConfigMap, local PVC, and HelmRelease at
+  `01:08:59Z`, then Helm failed four upgrade attempts and rolled back.
+- Exact error: `spec.strategy.rollingUpdate: Forbidden: may not be specified
+  when strategy type is 'Recreate'`.
+- At `01:09:49Z`, the Kustomization was `Ready=False`,
+  `HealthCheckFailed`; HelmRelease was `Stalled=True`, `RetriesExceeded`, with
+  rollback successful.
+- Live Jellyfin remained Ready on the old RollingUpdate deployment and
+  `jellyfin-config-v2` NFS claim. The local claim was Pending under
+  WaitForFirstConsumer. No migration pod, init logs, or marker existed.
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` at merged baseline | FAIL (expected) | Seven tests passed; the new strategy test failed because chart 3.2.0 rendered `type: Recreate` without `rollingUpdate: null`. |
+| `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` after repair | PASS | Eight tests passed: explicit strategy clear, Helm migration invariants, Flux script preservation/substitution, and four migration behaviors. |
+| `helm template jellyfin jellyfin/jellyfin --version 3.2.0 -f kubernetes/apps/jellyfin/values.yaml` | PASS | Deployment strategy renders `rollingUpdate: null` followed by `type: Recreate`. |
+| `python3 tools/architecture/render.py --check` | PASS | Generated architecture remains current. |
+| SDD context validator | PASS | Branch and required artifacts are coherent. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `pre-commit run --all-files` | PASS | All repository hooks passed. |
+
+## Development Validation
+
+Exact chart rendering and focused migration execution substitute for routed
+development smoke because the development environment lacks the pinned GPU
+resource. The user explicitly directed us not to change that infrastructure.
+
+## Documentation Impact
+
+No canonical documentation or generated architecture change is expected. The
+binding decision already requires Recreate; this implementation makes field
+removal explicit.
+
+## Exceptions And Follow-Ups
+
+- Cleanup remains unsafe until the local volume binds, migration succeeds, the
+  repaired application serves users, and binding authentication acceptance is
+  satisfied.
+- Anonymous smoke cannot prove existing user/admin mapping or native admin
+  login.

--- a/specs/jellyfin-recreate-strategy/plan.md
+++ b/specs/jellyfin-recreate-strategy/plan.md
@@ -1,0 +1,165 @@
+# Implementation Plan: Jellyfin Recreate Strategy
+
+**Branch**: `codex/jellyfin-recreate-strategy` | **Date**: 2026-08-09 | **Spec**:
+`specs/jellyfin-recreate-strategy/spec.md`
+
+**Input**: Feature specification from
+`specs/jellyfin-recreate-strategy/spec.md`
+
+## Summary
+
+Make the Helm-rendered Deployment explicitly clear `strategy.rollingUpdate`
+when selecting `Recreate`, so Helm controller server-side apply can transition
+the existing live Deployment without producing an invalid merged object. Extend
+the focused Jellyfin integration test to template chart 3.2.0 and assert both
+the clear operation and unchanged migration invariants.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, Helm, Flux, Python tests
+**Dependencies**: Spec Kit, Helm, Flux CLI, kubectl, Python standard library
+**Storage**: Existing local-path target and retained NFS rollback source; no
+storage change
+**Ingress**: Existing Gateway API routes; no route change
+**Secrets**: Existing SOPS-encrypted references; no secret change
+**Smoke Strategy**: Exact Helm template strategy assertion, focused migration
+tests, production Flux/Helm/workload/storage verification, and exact HTTPS web
+plus SSO-start probes
+**Fanout Targets**: GitHub/Flux revision state, rollout/storage/init state, and
+user-path/observability remain independent read-only lanes
+**Development Validation**: Exact chart/render/test path. Routed development
+smoke remains unavailable because the pinned GPU resource is absent, which the
+user explicitly excluded from this work.
+**Post-Implementation SDD Conformance**: Local artifacts only; no workflow or
+template change. The agent context update script is absent in this repository.
+
+## Human Gates
+
+**Spec Gate**: Approved by the user's instruction to keep iterating on rollout
+blockers.
+
+**Checklist Status**: PASS, 16/16 items in
+`specs/jellyfin-recreate-strategy/checklists/requirements.md`.
+
+**Plan Gate**: Approved by the same instruction; the approach is the exact
+rendered remediation proven by the read-only production lane.
+
+**Expected Task/Analyze Gate**: Tasks plus analyze required before
+implementation.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default considered; the binding local-config exception and retained
+      NFS rollback source remain unchanged.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch is `codex/jellyfin-recreate-strategy`; isolated worktree
+      `/home/vscode/homelab-worktrees/jellyfin-recreate-strategy` is
+      intentional and recorded when relevant.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/jellyfin-recreate-strategy/
+├── checklists/requirements.md
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/deployment-strategy.md
+├── quickstart.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/jellyfin/values.yaml
+tools/development/tests/test_jellyfin_config_migration.py
+.github/workflows/ci.yml
+.specify/feature.json
+specs/jellyfin-recreate-strategy/**
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add the chart strategy assertion before the values repair.
+The merged baseline must fail because the chart omits the explicit clear; the
+repair must pass with `rollingUpdate: null` and `type: Recreate` together.
+
+**Local checks**:
+
+- `python3 -m unittest tools.development.tests.test_jellyfin_config_migration`
+- `helm template jellyfin jellyfin/jellyfin --version 3.2.0 -f kubernetes/apps/jellyfin/values.yaml`
+- `python3 tools/architecture/render.py --check`
+- `pre-commit run --all-files`
+
+**Development smoke**: Exact Helm/chart rendering and migration tests substitute
+for the routed development profile. The profile cannot schedule because the
+development environment lacks the pinned GPU resource; the user directed us not
+to change that infrastructure.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization or HelmRelease applied SHA, live resource spec, Gateway/listener
+match when applicable, and exact user-facing URL result.
+
+**Fanout plan**: One read-only lane owns GitHub/Flux revision evidence, one owns
+Helm/workload/PVC/init evidence, and one owns routes/user paths/observability.
+The main lane owns tracked edits and consolidates all findings in `evidence.md`.
+
+**Evidence destination**: `specs/jellyfin-recreate-strategy/evidence.md`.
+
+## Documentation Impact
+
+No canonical docs, ADR, generated architecture, or agent guidance change is
+required. The binding migration design already requires Recreate; this repair
+only makes the transition explicit for server-side apply.
+
+## Implementation Steps
+
+1. Extend the focused test to template the pinned chart and fail unless the
+   Deployment strategy explicitly clears rolling-update while selecting
+   Recreate.
+2. Add `rollingUpdate: null` under the Jellyfin deployment strategy values.
+3. Add Helm setup to the existing CI job that runs the focused test.
+4. Run focused, architecture, SDD, and repository checks; publish a draft PR and
+   require all checks before merge.
+5. After merge, rerun the layered production acceptance. Keep all migration
+   assets if any technical or binding authentication gate remains unverified.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Null is dropped before apply | Assert the pinned chart output contains the explicit null. |
+| Repair changes unrelated workload fields | Limit the values diff to one key and assert migration/storage invariants. |
+| Helm rollback disrupts the old workload | Confirm rollback remains healthy and require green render/review gates before the next merge. |
+| Technical success is mistaken for authentication acceptance | Record exact authenticated limitations and defer cleanup until binding gates pass. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/jellyfin-recreate-strategy/quickstart.md
+++ b/specs/jellyfin-recreate-strategy/quickstart.md
@@ -1,0 +1,13 @@
+# Quickstart: Jellyfin Recreate Strategy Verification
+
+```bash
+python3 -m unittest tools.development.tests.test_jellyfin_config_migration
+helm template jellyfin jellyfin/jellyfin --version 3.2.0 \
+  -f kubernetes/apps/jellyfin/values.yaml
+python3 tools/architecture/render.py --check
+pre-commit run --all-files
+```
+
+After merge, record fetched/applied SHAs, Helm conditions, live Deployment
+strategy, PVCs, migration init and marker evidence, and exact user paths before
+considering a separate cleanup implementation.

--- a/specs/jellyfin-recreate-strategy/research.md
+++ b/specs/jellyfin-recreate-strategy/research.md
@@ -1,0 +1,26 @@
+# Research: Jellyfin Recreate Strategy
+
+## Decision: Emit an explicit null for rollingUpdate
+
+The existing Deployment is `RollingUpdate` and carries
+`spec.strategy.rollingUpdate`. Chart 3.2.0 directly renders the
+`deploymentStrategy` values map. Rendering only `type: Recreate` leaves the old
+field present during Helm controller server-side apply, producing an invalid
+merged object. Adding `rollingUpdate: null` renders an explicit clear operation
+alongside `type: Recreate`.
+
+## Alternatives considered
+
+- Force-recreate the Deployment: rejected because it is a live-cluster-first
+  mutation and bypasses reviewable GitOps desired state.
+- Temporarily retain RollingUpdate: rejected because the binding migration
+  design requires single-writer `Recreate` behavior.
+- Change field ownership or force Helm apply: broader and riskier than declaring
+  the intended field removal in the chart values.
+
+## Validation decision
+
+Template Jellyfin chart `3.2.0` with the repository values and assert the
+Deployment strategy contains `rollingUpdate: null` and `type: Recreate` in the
+same mapping. Continue running the full config migration test suite and verify
+production controller acceptance after merge.

--- a/specs/jellyfin-recreate-strategy/spec.md
+++ b/specs/jellyfin-recreate-strategy/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Jellyfin Recreate Strategy
+
+**Feature Branch**: `codex/jellyfin-recreate-strategy`
+**Created**: 2026-08-09
+**Status**: Approved
+**Risk Tier**: medium
+**Input**: Continue iterating on the merged Jellyfin migration until production
+success; clean up migration assets only after success.
+
+## Human Gate Status
+
+**Intent Brief**: Repair the production rollout transition without weakening
+the already-approved storage migration, authentication, rollback, GPU, or
+availability constraints.
+
+**Clarify Status**: Skipped. Production events and chart rendering identify one
+exact invalid transition: a stale rolling-update configuration remains when the
+workload changes to a recreate strategy.
+
+**Spec Gate**: Approved by the user's explicit instruction to keep going and
+iterate as needed.
+
+## Summary
+
+Allow the Jellyfin migration rollout to replace the existing rolling-update
+strategy with a recreate strategy. The desired state must explicitly remove the
+strategy setting that is invalid under recreate, while preserving every other
+migration, storage, authentication, GPU, and rollback safeguard.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/spec-driven-development.md`
+- `docs/decisions/jellyfin-local-config-storage.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/runbooks/jellyfin-authentik-sso.md`
+
+## Scope
+
+### In Scope
+
+- Make the rolling-to-recreate workload transition valid for the existing live
+  deployment.
+- Add regression coverage for the rendered strategy transition.
+- Preserve the full local-config migration and its rollback source.
+- Verify the repaired revision through review checks and layered production
+  acceptance.
+
+### Out Of Scope
+
+- Changing storage classes, PVC names, migration integrity rules, GPU pinning,
+  authentication configuration, routes, or resource limits.
+- Applying missing development GPU/VM infrastructure.
+- Removing migration assets before the repaired production migration and
+  authentication acceptance gates succeed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Valid migration rollout (Priority: P1)
+
+As the operator, I can roll Jellyfin from its existing update strategy to the
+required single-writer migration strategy without Kubernetes rejecting the
+workload.
+
+**Why this priority**: The current upgrade is rolled back before any migration
+pod can start.
+
+**Independent Test**: Render the exact Jellyfin release and verify that the
+recreate strategy also removes the incompatible rolling-update setting.
+
+**Acceptance Scenarios**:
+
+1. **Given** the live workload still carries rolling-update configuration,
+   **When** the repaired release is applied, **Then** the strategy transition is
+   accepted and the migration pod can start.
+2. **Given** the repaired desired state, **When** it is rendered, **Then** it
+   explicitly removes the incompatible setting rather than relying on implicit
+   field deletion.
+
+### User Story 2 - Migration safeguards remain intact (Priority: P1)
+
+As a Jellyfin user or administrator, I retain the approved config migration,
+SSO, storage, rollback, and scheduling safeguards while the transition is
+repaired.
+
+**Why this priority**: A rollout repair must not change the data or identity
+contract.
+
+**Independent Test**: Compare the rendered claims, init order, resources,
+selection, and authentication references with the approved migration design.
+
+**Acceptance Scenarios**:
+
+1. **Given** the repaired release, **When** it renders, **Then** the local target,
+   read-only NFS source, migration-before-SSO ordering, GPU selection, and
+   authentication references are unchanged.
+2. **Given** production rollout succeeds, **When** acceptance is evaluated,
+   **Then** migration cleanup remains gated on storage, application, and
+   authentication evidence rather than readiness alone.
+
+## Edge Cases
+
+- Helm rollback may leave the old deployment healthy while the new local claim
+  remains pending; this is safe pre-migration state, not success.
+- A null/clear operation must survive the chart render and reach the deployment
+  patch rather than disappearing from the desired state.
+- A completed technical migration does not by itself prove authenticated user,
+  administrator, or native-login acceptance.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Desired state MUST explicitly clear the rolling-update setting
+  while selecting the recreate strategy.
+- **FR-002**: The exact release render MUST contain a valid clear operation and
+  recreate strategy together.
+- **FR-003**: The repair MUST NOT change PVCs, storage classes, init ordering,
+  migration logic, GPU selection, authentication settings, routes, or resource
+  limits.
+- **FR-004**: Automated regression coverage MUST fail when the incompatible
+  rolling-update field is not explicitly cleared.
+- **FR-005**: Production verification MUST distinguish merged, fetched, applied,
+  live workload, migration, storage, and user-path layers.
+- **FR-006**: Migration cleanup MUST remain deferred until all binding cutover
+  acceptance gates that can safely authorize cleanup are satisfied.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: The repaired release renders exactly one recreate strategy with
+  the incompatible rolling-update setting explicitly cleared.
+- **SC-002**: All focused migration and strategy regression tests pass.
+- **SC-003**: Production accepts the repaired workload and completes the
+  migration init sequence without rollback.
+- **SC-004**: The live application uses the local config claim while the old NFS
+  claim remains retained for immediate rollback.
+- **SC-005**: Exact web and SSO-start paths remain healthy after rollout, with
+  any authenticated acceptance limitation stated explicitly.
+
+## Assumptions
+
+- The chart renders a null strategy value as an explicit field-clear operation.
+- The existing rollback preserved the pre-migration workload and NFS config.
+- The known development GPU limitation remains out of scope by user direction.
+
+## Open Questions
+
+- None.

--- a/specs/jellyfin-recreate-strategy/tasks.md
+++ b/specs/jellyfin-recreate-strategy/tasks.md
@@ -1,0 +1,69 @@
+# Tasks: Jellyfin Recreate Strategy
+
+## Phase 1: Setup and baseline
+
+- [X] T001 Record the production Helm failure and safe rollback baseline in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [X] T002 Add Helm setup for the focused Jellyfin test in
+  `.github/workflows/ci.yml`.
+
+## Phase 2: User Story 1 - Valid migration rollout
+
+**Goal**: Render and apply a valid RollingUpdate-to-Recreate transition.
+
+**Independent test**: Pinned chart output contains an explicit
+`rollingUpdate: null` and `type: Recreate` in the Deployment strategy.
+
+- [X] T003 [US1] Extend
+  `tools/development/tests/test_jellyfin_config_migration.py` with a failing
+  pinned-chart strategy regression.
+- [X] T004 [US1] Record the expected merged-baseline failure in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [X] T005 [US1] Add the explicit rolling-update clear to
+  `kubernetes/apps/jellyfin/values.yaml`.
+- [X] T006 [US1] Run the focused test and exact Helm render, recording passing
+  output in `specs/jellyfin-recreate-strategy/evidence.md`.
+
+## Phase 3: User Story 2 - Preserve safeguards
+
+**Goal**: Prove the transition repair does not alter migration, storage,
+authentication, scheduling, or rollback contracts.
+
+**Independent test**: Focused assertions and diff review show only the intended
+strategy transition while all existing migration cases pass.
+
+- [X] T007 [US2] Add or retain rendered invariant assertions for local target,
+  read-only NFS source, init ordering, and GPU selection in
+  `tools/development/tests/test_jellyfin_config_migration.py`.
+- [X] T008 [US2] Run architecture, SDD context, diff, and pre-commit validation;
+  record results in `specs/jellyfin-recreate-strategy/evidence.md`.
+
+## Phase 4: Review and production acceptance
+
+- [ ] T009 Push the implementation, open a draft PR, and require all GitHub
+  status checks before merge; record the PR in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [ ] T010 [P] Verify the merged/fetched/applied revision and Helm conditions in
+  production; record exact timestamps in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [ ] T011 [P] Verify live Deployment strategy, PVCs, migration init/marker,
+  application readiness, and storage/GPU state in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [ ] T012 [P] Verify exact web/SSO-start paths and relevant logs/observability,
+  recording authenticated limitations in
+  `specs/jellyfin-recreate-strategy/evidence.md`.
+- [ ] T013 Consolidate acceptance and decide whether cleanup is authorized; do
+  not remove assets in this implementation unless every binding gate is proven.
+
+## Dependencies
+
+- T001-T004 establish baseline and regression before T005.
+- T005 blocks T006-T009.
+- T009 and merge block T010-T013.
+- T010-T012 are independent read-only fanout lanes; T013 consolidates them.
+
+## Implementation strategy
+
+The MVP is User Story 1: one values field plus a pinned chart regression. User
+Story 2 and production acceptance are required before completion because the
+change affects a live storage migration.

--- a/specs/jellyfin-recreate-strategy/tasks.md
+++ b/specs/jellyfin-recreate-strategy/tasks.md
@@ -40,7 +40,7 @@ strategy transition while all existing migration cases pass.
 
 ## Phase 4: Review and production acceptance
 
-- [ ] T009 Push the implementation, open a draft PR, and require all GitHub
+- [X] T009 Push the implementation, open a draft PR, and require all GitHub
   status checks before merge; record the PR in
   `specs/jellyfin-recreate-strategy/evidence.md`.
 - [ ] T010 [P] Verify the merged/fetched/applied revision and Helm conditions in

--- a/tools/development/tests/test_jellyfin_config_migration.py
+++ b/tools/development/tests/test_jellyfin_config_migration.py
@@ -10,6 +10,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 MIGRATION_SCRIPT = REPO_ROOT / "kubernetes" / "apps" / "jellyfin" / "migrate-config.sh"
 JELLYFIN_MANIFESTS = REPO_ROOT / "kubernetes" / "apps" / "jellyfin"
+JELLYFIN_VALUES = JELLYFIN_MANIFESTS / "values.yaml"
 FLUX_KUSTOMIZATION = (
     REPO_ROOT / "kubernetes" / "clusters" / "production" / "apps" / "jellyfin.yaml"
 )
@@ -104,7 +105,27 @@ class JellyfinConfigMigrationTest(unittest.TestCase):
         if rendered.returncode != 0:
             raise AssertionError(rendered.stderr)
 
+        helm_rendered = subprocess.run(
+            [
+                "helm",
+                "template",
+                "jellyfin",
+                "jellyfin/jellyfin",
+                "--version",
+                "3.2.0",
+                "--values",
+                str(JELLYFIN_VALUES),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        if helm_rendered.returncode != 0:
+            raise AssertionError(helm_rendered.stderr)
+
         cls.rendered_manifests = rendered.stdout
+        cls.helm_manifests = helm_rendered.stdout
         cls.runtime_script = Path(cls.runtime_script_dir.name) / "migrate.sh"
         cls.runtime_script.write_text(
             extract_migration_script(rendered.stdout), encoding="utf-8"
@@ -121,6 +142,22 @@ class JellyfinConfigMigrationTest(unittest.TestCase):
         self.assertNotIn("${nfs_server}", self.rendered_manifests)
         self.assertIn("https://jellyfin.lab.petebeegle.com", self.rendered_manifests)
         self.assertIn("server: 192.0.2.10", self.rendered_manifests)
+
+    def test_recreate_strategy_explicitly_clears_rolling_update(self) -> None:
+        self.assertIn(
+            "  strategy:\n    rollingUpdate: null\n    type: Recreate\n",
+            self.helm_manifests,
+        )
+
+    def test_helm_render_preserves_migration_invariants(self) -> None:
+        self.assertLess(
+            self.helm_manifests.index("name: migrate-config"),
+            self.helm_manifests.index("name: install-sso-auth"),
+        )
+        self.assertIn("claimName: jellyfin-config-local-v1", self.helm_manifests)
+        self.assertIn("claimName: jellyfin-config-v2", self.helm_manifests)
+        self.assertIn("readOnly: true", self.helm_manifests)
+        self.assertIn("gpu.intel.com/i915: 1", self.helm_manifests)
 
     def run_migration(self, source: Path, target: Path) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()


### PR DESCRIPTION
## Summary

- explicitly clear `strategy.rollingUpdate` while selecting `Recreate`
- template the pinned Jellyfin chart in the focused migration suite
- assert the strategy transition plus migration ordering, PVC, read-only source, and GPU invariants
- install Helm in the Kubernetes CI job that runs the focused regression

## Root cause

PR #382 fixed Flux substitution and allowed Helm to begin the migration rollout. Helm controller then merged the desired `type: Recreate` with the live Deployment's retained `rollingUpdate` field, producing an invalid Kubernetes object. Four upgrade attempts failed and Helm rolled back successfully, leaving the old NFS-backed Jellyfin pod healthy.

Chart 3.2.0 renders `deploymentStrategy` directly. Adding `rollingUpdate: null` produces the required field-clear operation:

```yaml
strategy:
  rollingUpdate: null
  type: Recreate
```

## Validation

- TDD baseline: 7 passed, strategy regression failed as expected
- repaired focused suite: 8 passed
- pinned chart 3.2.0 render: explicit null + Recreate confirmed
- `python3 tools/architecture/render.py --check` — passed
- SDD context validator — passed
- `pre-commit run --all-files` — passed

## Deployment note

The old application remains available and migration has not started. The development routed profile still cannot schedule because its pinned GPU resource is absent; the user explicitly excluded that infrastructure change. After merge, production acceptance will again verify revisions, Helm conditions, live strategy, PVC/migration state, logs, and exact web/SSO paths. Migration cleanup remains deferred until those and the binding authentication gates pass.