### PR TITLE
fix(jellyfin): use client-side Helm transition

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/jellyfin-recreate-strategy"}
+{"feature_directory":"specs/jellyfin-helm-client-apply"}

--- a/kubernetes/apps/jellyfin/app.yaml
+++ b/kubernetes/apps/jellyfin/app.yaml
@@ -27,9 +27,12 @@ spec:
       retries: 3
   upgrade:
     crds: CreateReplace
+    serverSideApply: disabled
     remediation:
       retries: 3
       remediateLastFailure: true
+  rollback:
+    serverSideApply: disabled
   chart:
     spec:
       chart: jellyfin

--- a/specs/jellyfin-helm-client-apply/checklists/requirements.md
+++ b/specs/jellyfin-helm-client-apply/checklists/requirements.md
@@ -1,0 +1,19 @@
+# Specification Quality Checklist: Jellyfin Helm Client Apply
+
+**Created**: 2026-08-09
+**Feature**: [spec.md](../spec.md)
+
+- [x] Desired behavior and user/operator value are clear
+- [x] Scope and non-goals are bounded
+- [x] No clarification markers remain
+- [x] Requirements are testable
+- [x] Success criteria are measurable
+- [x] Primary and rollback flows are covered
+- [x] Edge cases are identified
+- [x] Binding migration and authentication constraints are preserved
+- [x] Cleanup gating is explicit
+- [x] Development exception is unchanged
+- [x] No secret or credential changes are requested
+- [x] No force replacement is authorized
+
+All 12 items pass.

--- a/specs/jellyfin-helm-client-apply/contracts/helm-action-mode.md
+++ b/specs/jellyfin-helm-client-apply/contracts/helm-action-mode.md
@@ -1,0 +1,14 @@
+# Contract: Jellyfin Helm Action Mode
+
+The rendered `HelmRelease/jellyfin` must contain:
+
+```yaml
+spec:
+  upgrade:
+    serverSideApply: disabled
+  rollback:
+    serverSideApply: disabled
+```
+
+Neither action may set `force: true`. Existing remediation, chart, values,
+post-renderer, and migration behavior remain present.

--- a/specs/jellyfin-helm-client-apply/data-model.md
+++ b/specs/jellyfin-helm-client-apply/data-model.md
@@ -1,0 +1,6 @@
+# Data Model: Helm Action Mode
+
+- **Upgrade**: `serverSideApply=disabled`, `force=false/absent`.
+- **Rollback**: `serverSideApply=disabled`, `force=false/absent`.
+- **Strategy intent**: `type=Recreate`, `rollingUpdate=null` remains explicit.
+- **Result**: live strategy contains only Recreate after API processing.

--- a/specs/jellyfin-helm-client-apply/evidence.md
+++ b/specs/jellyfin-helm-client-apply/evidence.md
@@ -39,6 +39,12 @@
 | `git diff --check` | PASS | No whitespace errors. |
 | `pre-commit run --all-files` | PASS | All hooks passed. |
 
+## GitHub Review Gate
+
+- Draft PR: `https://github.com/petebeegle/homelab/pull/386`
+- Initial head: `f73e5c7`
+- Checks: PASS, 7/7, including the Kubernetes job with all nine focused tests.
+
 ## Development Validation
 
 Focused full render and migration execution substitute for routed dev because

--- a/specs/jellyfin-helm-client-apply/evidence.md
+++ b/specs/jellyfin-helm-client-apply/evidence.md
@@ -1,0 +1,51 @@
+# Evidence: Jellyfin Helm Client Apply
+
+**Branch**: `codex/jellyfin-helm-client-apply`
+**Risk Tier**: medium
+**Started**: 2026-08-09
+
+## Human Gates
+
+| Gate | Result | Notes |
+| ---- | ------ | ----- |
+| Intent/spec/plan | PASS | User directed continued iteration; exact apply-mode repair proven by dry-run. |
+| Clarify | SKIP | Managed fields and full server dry-run remove ambiguity. |
+| Checklist | PASS | 12/12 complete. |
+| Tasks/analyze | PASS | Six requirements mapped; no conflict or uncovered task. |
+| Converge | PASS | No remaining buildable gap across six requirements and the two user stories. |
+
+## Baseline Production State
+
+- PR #385 merged as `5ead112b964db1f5a786391e1669e0203688e297`;
+  main CI passed at `01:19:54Z`.
+- Flux fetched the SHA, then Helm exhausted four upgrades and terminally stalled
+  at `01:23:47Z` with the unchanged rollingUpdate/Recreate SSA error.
+- Rollback succeeded. At `01:24:54Z`, old Jellyfin remained Ready on NFS; local
+  PVC remained Pending and migration had never started.
+- Live values contained `rollingUpdate: null`, proving null rendering was
+  insufficient.
+- Managed fields showed API-defaulted `rollingUpdate` was not owned by Helm's
+  SSA manager. A read-only full Helm 4 server dry-run with client-side apply
+  succeeded; the strategic patch produced only `strategy.type=Recreate`.
+
+## Local Checks
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `python3 -m unittest tools.development.tests.test_jellyfin_config_migration` at baseline | FAIL (expected) | Eight tests passed; apply-mode regression found zero of two required declarations. |
+| Focused suite after repair | PASS | Nine tests passed, including two client-side action declarations, no force, strategy, storage/init/GPU, Flux substitution, and migration behavior. |
+| Architecture check | PASS | Generated architecture remains current. |
+| SDD context validator | PASS | Branch and artifacts are coherent. |
+| `git diff --check` | PASS | No whitespace errors. |
+| `pre-commit run --all-files` | PASS | All hooks passed. |
+
+## Development Validation
+
+Focused full render and migration execution substitute for routed dev because
+the development cluster lacks the pinned GPU resource. User excluded that
+infrastructure work.
+
+## Cleanup Gate
+
+Not eligible. Migration has not run; authenticated user/admin/native-login
+acceptance is also unverified.

--- a/specs/jellyfin-helm-client-apply/plan.md
+++ b/specs/jellyfin-helm-client-apply/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Jellyfin Helm Client Apply
+
+**Branch**: `codex/jellyfin-helm-client-apply` | **Date**: 2026-08-09 | **Spec**:
+`specs/jellyfin-helm-client-apply/spec.md`
+
+**Input**: `specs/jellyfin-helm-client-apply/spec.md`
+
+## Summary
+
+Explicitly disable server-side apply for Jellyfin Helm upgrade and rollback.
+This makes Helm use the strategic client-side path that a read-only full server
+dry-run proved can remove the API-defaulted rolling strategy field. Do not force
+replacement; keep the existing strategy intent and migration safeguards.
+
+## Technical Context
+
+**Risk Tier**: medium
+**Workflow Tier**: medium
+**Primary Areas**: Kubernetes, HelmRelease, Flux, Python tests
+**Dependencies**: Spec Kit, Helm, Flux CLI, kubectl, Python
+**Storage**: Existing local target and retained NFS rollback source; unchanged
+**Ingress**: Existing Gateway API routes; unchanged
+**Secrets**: Existing SOPS references; unchanged
+**Smoke Strategy**: Full Flux render assertions, focused Helm/migration tests,
+production controller/workload/storage verification, exact web/SSO paths
+**Fanout Targets**: GitHub/Flux, rollout/storage/init, user paths/observability
+**Development Validation**: Exact render and tests. Routed dev remains blocked
+by the known missing pinned GPU resource, explicitly excluded by the user.
+**Post-Implementation SDD Conformance**: Local artifacts only; agent context
+update script is absent.
+
+## Human Gates
+
+**Spec Gate**: Approved by user direction to keep iterating.
+
+**Checklist Status**: PASS, 12/12.
+
+**Plan Gate**: Approved within the same direction; exact read-only full Helm
+server dry-run proves the scoped approach.
+
+**Expected Task/Analyze Gate**: Tasks plus analyze required.
+
+## Constitution Check
+
+*GATE: Must pass before tracked edits and be re-checked before commit.*
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; development validation plan or exception is
+      recorded for covered changes.
+- [x] Gateway API invariant preserved; no new Kubernetes `Ingress` resources.
+- [x] SOPS invariant preserved; no plaintext secret manifests staged.
+- [x] NFS default and binding local-config exception preserved.
+- [x] Talos boundary preserved; no SSH-based node operations introduced.
+- [x] Branch/worktree contract is intentional at
+      `/home/vscode/homelab-worktrees/jellyfin-helm-client-apply`.
+      intentional and recorded when relevant.
+- [x] Documentation impact identified; docs updated or no-docs rationale
+      recorded.
+- [x] PR review/status checks are the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/jellyfin-helm-client-apply/
+├── checklists/requirements.md
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── contracts/helm-action-mode.md
+├── quickstart.md
+├── tasks.md
+└── evidence.md
+```
+
+### Source Or Documentation Changes
+
+```text
+kubernetes/apps/jellyfin/app.yaml
+tools/development/tests/test_jellyfin_config_migration.py
+.specify/feature.json
+specs/jellyfin-helm-client-apply/**
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: Add render assertions for both action modes and absence of
+force before editing the HelmRelease. Baseline must fail those mode assertions.
+
+**Local checks**:
+
+- `python3 -m unittest tools.development.tests.test_jellyfin_config_migration`
+- `python3 tools/architecture/render.py --check`
+- `pre-commit run --all-files`
+
+**Development smoke**: Exact render/test substitute with documented GPU
+exception. Production user-path verification remains required after merge.
+
+**Automated smoke preference**: For user-facing, routed, deployed, or
+operational changes, prefer automated smoke in this order: development branch
+profile; production synthetic smoke or one-off in-cluster Job; scriptable
+Gateway/DNS/browser smoke against the exact user URL; manual browser checks only
+as supplemental evidence.
+
+**Completion evidence**: For deploy follow-up, record source fetched SHA, target
+kustomization or HelmRelease applied SHA, live resource spec, Gateway/listener
+match when applicable, and exact user-facing URL result.
+
+**Fanout plan**: Three read-only lanes verify revisions, rollout/storage/init,
+and user paths/observability. Main owns tracked edits and `evidence.md`.
+
+**Evidence destination**: `specs/jellyfin-helm-client-apply/evidence.md`.
+
+## Documentation Impact
+
+None. The migration decision is unchanged; this is a Helm action-mode repair.
+
+## Implementation Steps
+
+1. Add failing full-render assertions for disabled upgrade/rollback SSA and no
+   force.
+2. Declare client-side apply for both Helm actions.
+3. Run focused/repository checks, review-gated PR, and layered post-merge smoke.
+4. Defer cleanup if any binding authentication gate remains unverified.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Client-side apply differs from dry-run | Require production controller acceptance after merge. |
+| Rollback inherits prior SSA behavior | Explicitly disable SSA for rollback too. |
+| Force replacement increases blast radius | Assert force is absent. |
+| Cleanup is premature | Keep it gated on full cutover and authentication evidence. |
+
+## Complexity Tracking
+
+> Fill only when the constitution check has a violation that must be justified.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --------- | ---------- | ------------------------------------ |
+| N/A | N/A | N/A |

--- a/specs/jellyfin-helm-client-apply/quickstart.md
+++ b/specs/jellyfin-helm-client-apply/quickstart.md
@@ -1,0 +1,10 @@
+# Quickstart: Jellyfin Helm Client Apply
+
+```bash
+python3 -m unittest tools.development.tests.test_jellyfin_config_migration
+python3 tools/architecture/render.py --check
+pre-commit run --all-files
+```
+
+After merge, verify Helm no longer reports the strategy validation error, the
+migration completes, and exact user paths work before considering cleanup.

--- a/specs/jellyfin-helm-client-apply/research.md
+++ b/specs/jellyfin-helm-client-apply/research.md
@@ -1,0 +1,21 @@
+# Research: Jellyfin Helm Client Apply
+
+## Decision
+
+Set `upgrade.serverSideApply: disabled` and
+`rollback.serverSideApply: disabled` on the Jellyfin HelmRelease. Do not set
+force.
+
+## Rationale
+
+The live `rollingUpdate` field is API-defaulted and not owned by Helm's SSA field
+manager, so null cannot delete it. A read-only full Helm 4 server dry-run with
+client-side apply succeeds, and the equivalent strategic patch uses retainKeys
+to leave only `strategy.type=Recreate`. Flux documents force as ignored during
+SSA; replacement is unnecessary after SSA is disabled.
+
+## Alternatives
+
+- SSA plus null: failed twice in production.
+- Force replacement: broader and unnecessary; held as a last resort.
+- Live delete/patch: violates GitOps and production-first constraints.

--- a/specs/jellyfin-helm-client-apply/spec.md
+++ b/specs/jellyfin-helm-client-apply/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: Jellyfin Helm Client Apply
+
+**Feature Branch**: `codex/jellyfin-helm-client-apply`
+**Created**: 2026-08-09
+**Status**: Approved
+**Risk Tier**: medium
+**Input**: Continue iterating on the Jellyfin migration until production
+success, deferring cleanup until every binding acceptance gate passes.
+
+## Human Gate Status
+
+**Intent Brief**: Make the approved recreate transition remove API-defaulted
+rolling-update state without a live mutation or resource replacement.
+
+**Clarify Status**: Skipped. Managed fields and a server-side dry-run of the
+client-style strategic patch identify the exact apply-mode mismatch.
+
+**Spec Gate**: Approved by the user's instruction to keep going.
+
+## Summary
+
+Use an apply mode that can remove the live Deployment's API-defaulted
+rolling-update configuration during the transition to recreate. Apply the same
+mode to rollback so failure recovery remains consistent, while preserving all
+migration, storage, authentication, GPU, and route behavior.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/decisions/jellyfin-local-config-storage.md`
+- `docs/runbooks/jellyfin-authentik-sso.md`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Strategy transition applies (Priority: P1)
+
+As the operator, I can apply the recreate transition with an update method that
+removes API-defaulted rolling settings instead of retaining an invalid field.
+
+**Independent Test**: Render the full Jellyfin desired state and verify both
+upgrade and rollback explicitly select the compatible apply mode.
+
+**Acceptance Scenarios**:
+
+1. **Given** the live field is defaulted and unowned by the current server-side
+   manager, **When** the repaired upgrade runs, **Then** the strategic update
+   removes it and Kubernetes accepts recreate.
+2. **Given** a later migration failure, **When** Helm rolls back, **Then** rollback
+   uses the same declared apply mode and can restore the previous release.
+
+### User Story 2 - Cutover safety remains gated (Priority: P1)
+
+As a Jellyfin user or administrator, I retain the approved migration and
+identity safeguards and continue receiving service until a valid cutover starts.
+
+**Independent Test**: Existing focused migration and render assertions all pass,
+and the implementation diff changes only Helm action behavior plus tests/SDD.
+
+**Acceptance Scenarios**:
+
+1. **Given** the repaired release, **When** it renders, **Then** storage, init
+   ordering, GPU, authentication, routes, and rollback source are unchanged.
+2. **Given** production technical success, **When** cleanup is considered,
+   **Then** unverified authenticated acceptance still prevents cleanup.
+
+## Edge Cases
+
+- Replacement forcing is ineffective while server-side apply is active and is
+  unnecessary when the strategic patch already succeeds.
+- Rollback may occur after the old Deployment is removed; its apply mode must be
+  declared rather than inherited from release history.
+- Pod readiness and anonymous SSO redirects do not prove user/admin access.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: Jellyfin Helm upgrades MUST explicitly use client-side apply for
+  this transition.
+- **FR-002**: Jellyfin Helm rollbacks MUST explicitly use the same apply mode.
+- **FR-003**: The repair MUST NOT enable force replacement.
+- **FR-004**: The full rendered desired state MUST contain both apply-mode
+  declarations and the existing recreate/null strategy intent.
+- **FR-005**: Existing migration behavior and storage, GPU, authentication,
+  route, and resource invariants MUST remain unchanged.
+- **FR-006**: Production verification MUST cover revision, Helm, workload,
+  migration, storage, logs, and exact user paths before cleanup is considered.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: Focused regression fails at the merged baseline and passes with
+  both action modes declared.
+- **SC-002**: All existing Jellyfin migration and render tests pass.
+- **SC-003**: Production Helm upgrade completes without the strategy validation
+  error or a force replacement setting.
+- **SC-004**: Migration runs successfully and Jellyfin serves from the local
+  claim while the NFS rollback claim remains retained.
+- **SC-005**: Web and SSO-start paths remain healthy, with authenticated
+  acceptance limitations stated before cleanup.
+
+## Assumptions
+
+- Helm controller's disabled server-side mode uses the strategic client-side
+  patch behavior verified by the read-only API dry-run.
+- The old application remains safely restored after the failed prior rollout.
+
+## Open Questions
+
+- None.

--- a/specs/jellyfin-helm-client-apply/tasks.md
+++ b/specs/jellyfin-helm-client-apply/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Jellyfin Helm Client Apply
+
+## Phase 1: Baseline
+
+- [X] T001 Record PR #385 terminal SSA failure and safe rollback in
+  `specs/jellyfin-helm-client-apply/evidence.md`.
+- [X] T002 [US1] Add failing upgrade/rollback apply-mode and no-force assertions
+  to `tools/development/tests/test_jellyfin_config_migration.py`.
+- [X] T003 [US1] Record the expected baseline regression failure in
+  `specs/jellyfin-helm-client-apply/evidence.md`.
+
+## Phase 2: User Story 1 - Strategy transition applies
+
+- [X] T004 [US1] Set upgrade and rollback `serverSideApply: disabled` in
+  `kubernetes/apps/jellyfin/app.yaml` without enabling force.
+- [X] T005 [US1] Run the focused render/migration suite and record results in
+  `specs/jellyfin-helm-client-apply/evidence.md`.
+
+## Phase 3: User Story 2 - Preserve cutover safety
+
+- [X] T006 [US2] Verify diff and existing storage/init/GPU/auth assertions remain
+  green in `tools/development/tests/test_jellyfin_config_migration.py`.
+- [X] T007 [US2] Run architecture, SDD context, pre-commit, and diff validation;
+  record it in `specs/jellyfin-helm-client-apply/evidence.md`.
+
+## Phase 4: Review and production acceptance
+
+- [ ] T008 Push, open a draft PR, and require all GitHub checks; record PR data
+  in `specs/jellyfin-helm-client-apply/evidence.md`.
+- [ ] T009 [P] Verify merged/fetched/applied revision and Helm conditions in
+  `specs/jellyfin-helm-client-apply/evidence.md`.
+- [ ] T010 [P] Verify live Recreate strategy, local/NFS storage, migration init,
+  marker, pod/GPU/events in `specs/jellyfin-helm-client-apply/evidence.md`.
+- [ ] T011 [P] Verify exact web/SSO paths, logs, and observability with auth
+  limitations in `specs/jellyfin-helm-client-apply/evidence.md`.
+- [ ] T012 Consolidate cleanup eligibility; retain all migration assets if any
+  binding acceptance remains unverified.
+
+## Dependencies
+
+- T001-T003 precede T004.
+- T004 precedes T005-T008.
+- T008 and merge precede parallel T009-T011; T012 consolidates them.
+
+## Implementation strategy
+
+One HelmRelease behavior change plus focused regression is the MVP. Production
+acceptance remains required because this is the live storage cutover boundary.

--- a/specs/jellyfin-helm-client-apply/tasks.md
+++ b/specs/jellyfin-helm-client-apply/tasks.md
@@ -25,7 +25,7 @@
 
 ## Phase 4: Review and production acceptance
 
-- [ ] T008 Push, open a draft PR, and require all GitHub checks; record PR data
+- [X] T008 Push, open a draft PR, and require all GitHub checks; record PR data
   in `specs/jellyfin-helm-client-apply/evidence.md`.
 - [ ] T009 [P] Verify merged/fetched/applied revision and Helm conditions in
   `specs/jellyfin-helm-client-apply/evidence.md`.

--- a/tools/development/tests/test_jellyfin_config_migration.py
+++ b/tools/development/tests/test_jellyfin_config_migration.py
@@ -143,6 +143,13 @@ class JellyfinConfigMigrationTest(unittest.TestCase):
         self.assertIn("https://jellyfin.lab.petebeegle.com", self.rendered_manifests)
         self.assertIn("server: 192.0.2.10", self.rendered_manifests)
 
+    def test_helm_actions_use_client_side_apply_without_force(self) -> None:
+        self.assertEqual(
+            self.rendered_manifests.count("serverSideApply: disabled"),
+            2,
+        )
+        self.assertNotIn("force: true", self.rendered_manifests)
+
     def test_recreate_strategy_explicitly_clears_rolling_update(self) -> None:
         self.assertIn(
             "  strategy:\n    rollingUpdate: null\n    type: Recreate\n",


### PR DESCRIPTION
## Summary

- disable server-side apply for Jellyfin Helm upgrades and rollbacks
- keep force replacement disabled
- assert both action modes and no-force behavior in the full Flux render regression

## Root cause

The live Deployment's `strategy.rollingUpdate` is API-defaulted and not owned by Helm controller's SSA field manager. Even though PR #385 rendered `rollingUpdate: null`, SSA could not delete that unowned/defaulted field and Kubernetes rejected `type: Recreate` again.

A read-only full Helm 4 server dry-run using client-side apply succeeded. The equivalent strategic patch uses Kubernetes retainKeys behavior and results in only:

```yaml
strategy:
  type: Recreate
```

This PR declares client-side apply for both upgrade and rollback so remediation does not inherit the previous SSA mode. It deliberately does not enable force replacement.

## Validation

- TDD baseline: 8 passed, apply-mode regression failed as expected
- repaired focused suite: 9 passed
- full Helm 4 server dry-run with client-side apply: passed (read-only production API)
- architecture check, SDD context validator, diff check, and all pre-commit hooks: passed

## Deployment note

The previous Helm rollback preserved the old NFS-backed Jellyfin deployment; migration has not begun. After merge, production verification will cover Helm, live strategy, local/NFS storage, init logs/marker, exact web/SSO paths, and observability. Cleanup remains blocked until technical and binding authentication acceptance is complete.