### PR TITLE
fix: target live 1Password operator deployment

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/onepassword-prod-foundation"}
+{"feature_directory":"specs/onepassword-prod-foundation-alert-fix"}

--- a/docs/runbooks/onepassword-operator.md
+++ b/docs/runbooks/onepassword-operator.md
@@ -56,7 +56,7 @@ flux --kubeconfig /home/vscode/.kube/homelab-production.config \
 kubectl --kubeconfig /home/vscode/.kube/homelab-production.config \
   -n onepassword-system get helmrelease onepassword-operator
 kubectl --kubeconfig /home/vscode/.kube/homelab-production.config \
-  -n onepassword-system rollout status deployment/onepassword-operator \
+  -n onepassword-system rollout status deployment/onepassword-connect-operator \
   --timeout=10m
 ```
 
@@ -80,7 +80,7 @@ Grafana alerts after ten minutes when the operator Deployment is absent/unavaila
 ```bash
 kubectl get onepassworditems.onepassword.com -A
 kubectl -n onepassword-system get helmrelease,deployment,pods
-kubectl -n onepassword-system logs deployment/onepassword-operator --since=30m
+kubectl -n onepassword-system logs deployment/onepassword-connect-operator --since=30m
 ```
 
 A 1Password outage prevents refresh but does not remove an existing generated Secret. Confirm existing workloads remain running while investigating. Do not delete a durable `OnePasswordItem` as a diagnostic step: deletion also deletes its generated Kubernetes Secret.

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         description: "The 1Password Operator Deployment is missing or has unavailable replicas for at least 10 minutes. Existing generated Secrets remain, but refresh and rotation are blocked."
         summary: 1Password credential synchronization is unavailable
-        runbook: "Start with: flux get kustomization onepassword-operator; kubectl -n onepassword-system get helmrelease,deployment,pods; kubectl -n onepassword-system logs deployment/onepassword-operator"
+        runbook: "Start with: flux get kustomization onepassword-operator; kubectl -n onepassword-system get helmrelease,deployment,pods; kubectl -n onepassword-system logs deployment/onepassword-connect-operator"
       labels:
         severity: critical
         component: onepassword
@@ -31,7 +31,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: max(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-operator"} - kube_deployment_status_replicas_available{namespace="onepassword-system",deployment="onepassword-operator"}) OR absent(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-operator"})
+            expr: max(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-connect-operator"} - kube_deployment_status_replicas_available{namespace="onepassword-system",deployment="onepassword-connect-operator"}) OR absent(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-connect-operator"})
             refId: A
         - refId: B
           relativeTimeRange:
@@ -71,7 +71,7 @@ spec:
       annotations:
         description: "{{ $values.B.Value }} OnePasswordItem resource(s) have not reported Ready=True for at least 10 minutes."
         summary: 1Password item synchronization is failing
-        runbook: "Start with: kubectl get onepassworditems.onepassword.com -A; kubectl describe onepassworditem <name> -n <namespace>; kubectl -n onepassword-system logs deployment/onepassword-operator"
+        runbook: "Start with: kubectl get onepassworditems.onepassword.com -A; kubectl describe onepassworditem <name> -n <namespace>; kubectl -n onepassword-system logs deployment/onepassword-connect-operator"
       labels:
         severity: critical
         component: onepassword

--- a/specs/onepassword-prod-foundation-alert-fix/checklists/requirements.md
+++ b/specs/onepassword-prod-foundation-alert-fix/checklists/requirements.md
@@ -1,0 +1,7 @@
+# Requirements Checklist: 1Password Production Alert Selector Fix
+
+- [x] Scope is limited to the observed live-name mismatch.
+- [x] Expected Deployment name is exact and testable.
+- [x] Secret and consumer changes are excluded.
+- [x] Local and live acceptance layers are explicit.
+- [x] No clarification marker remains.

--- a/specs/onepassword-prod-foundation-alert-fix/evidence.md
+++ b/specs/onepassword-prod-foundation-alert-fix/evidence.md
@@ -1,0 +1,22 @@
+# Evidence: onepassword-prod-foundation-alert-fix
+
+**Base**: `origin/main` at `330d634c58a4909d10cbb6ed8bee23dd605f9785`
+
+## Discovery
+
+- Production operator Kustomization: Ready at the merged revision.
+- HelmRelease: Ready, chart `2.4.1`.
+- Live Deployment: `onepassword-connect-operator`, desired `1`, available `1`, image `1password/onepassword-operator:1.12.0`.
+- Incorrect alert target: `onepassword-operator`.
+- Grafana alert CR was absent because its Flux Kustomization had not yet advanced past a transient Gateway dependency wait; the incorrect rule did not become active.
+
+## Validation
+
+- TDD red: the new live-name regression test failed against merged main and showed all three incorrect PromQL selectors.
+- Focused policy tests: PASS, 3 tests.
+- Production foundation policy checker: PASS.
+- Alerting Kustomize render: PASS, 10 resources.
+- kubeconform 0.7.0: zero invalid/errors; all 10 Grafana custom resources skipped for unavailable schemas.
+- Architecture check: PASS; architecture output is unaffected.
+- Full pre-commit suite: PASS.
+- Convergence audit: no missing repository task; only post-merge live reconciliation remains.

--- a/specs/onepassword-prod-foundation-alert-fix/plan.md
+++ b/specs/onepassword-prod-foundation-alert-fix/plan.md
@@ -1,0 +1,31 @@
+# Implementation Plan: onepassword-prod-foundation-alert-fix
+
+**Branch**: `codex/onepassword-prod-foundation-alert-fix` | **Date**: 2026-08-09
+
+## Summary
+
+Add a focused failing regression test, correct the alert/policy/runbook selector, run local checks, publish the minimal PR, then reconcile Grafana and validate the corrected PromQL against production.
+
+## Workflow
+
+**SDD Tier**: full artifacts, narrowly scoped corrective implementation
+**Risk Tier**: high because the rule is production paging behavior
+**Smoke Strategy**: live Grafana CR readiness plus Prometheus evaluation against the healthy Deployment
+**Fanout**: none
+**Exceptions**: No development deployment is needed; the defect is a production Helm-generated object-name mismatch discovered during the approved production smoke. The shared chart render and policy test provide pre-merge validation.
+
+## Constitution Check
+
+- [x] GitOps remains the source of truth.
+- [x] No Secret or consumer state changes.
+- [x] Production mutation is limited to reconciling the corrected monitoring resource.
+- [x] Evidence remains metadata-only.
+- [x] Dedicated branch/worktree/PR used.
+
+## Validation
+
+- Focused Python regression tests and policy checker
+- Alerting Kustomize render and kubeconform
+- Full pre-commit hooks
+- Architecture check
+- Post-merge Flux/Grafana reconciliation and live PromQL evaluation

--- a/specs/onepassword-prod-foundation-alert-fix/spec.md
+++ b/specs/onepassword-prod-foundation-alert-fix/spec.md
@@ -1,0 +1,41 @@
+# Feature Specification: 1Password Production Alert Selector Fix
+
+**Feature Branch**: `codex/onepassword-prod-foundation-alert-fix`
+**Created**: 2026-08-09
+**Status**: Approved corrective follow-up
+**Risk Tier**: high
+
+## Summary
+
+Correct the production 1Password operator-unavailable alert and runbook to target the live Helm-generated Deployment name `onepassword-connect-operator`. Phase-2 post-merge validation found the operator healthy at `1/1` under that name before the Grafana alert group reconciled, so the incorrect rule never became active.
+
+## Scope
+
+### In Scope
+
+- Replace the incorrect Deployment selector in the PromQL alert.
+- Update operator diagnosis/rollout commands to use the live name.
+- Strengthen the production-foundation policy test so the selector cannot regress.
+- Reconcile Grafana only after the corrected rule merges.
+
+### Out Of Scope
+
+- Operator, token, vault, SOPS, consumer, or canary changes.
+- Any change to alert duration, severity, or item-readiness logic.
+
+## Requirements
+
+- **FR-001**: The operator-unavailable rule MUST query `onepassword-connect-operator` for desired, available, and absent Deployment cases.
+- **FR-002**: Repository policy MUST reject the former `deployment="onepassword-operator"` selector.
+- **FR-003**: Runbook rollout and log commands MUST reference the live Deployment.
+- **FR-004**: Local render/policy/pre-commit checks and live Grafana reconciliation MUST pass before the production phase is considered healthy.
+
+## Success Criteria
+
+- **SC-001**: The regression test fails on merged main and passes after the correction.
+- **SC-002**: The live Grafana `onepassword` alert group reconciles successfully from the corrected main revision.
+- **SC-003**: The healthy live operator does not satisfy the unavailable query.
+
+## Gate Status
+
+The user's instruction to continue the production phase authorizes this necessary bounded correction. No clarification is required because the live Deployment identity is authoritative.

--- a/specs/onepassword-prod-foundation-alert-fix/tasks.md
+++ b/specs/onepassword-prod-foundation-alert-fix/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: onepassword-prod-foundation-alert-fix
+
+- [x] T001 Record the live mismatch and bounded corrective specification/plan.
+- [x] T002 Add a regression test that fails with the merged Deployment selector.
+- [x] T003 Correct the alert, policy, and runbook Deployment name.
+- [x] T004 Run focused render, schema, policy, architecture, and pre-commit validation.
+- [ ] T005 Record evidence, converge, commit, push, and open the corrective PR.
+- [ ] T006 After merge, reconcile Grafana and prove the alert query is healthy.

--- a/tools/policy/check_onepassword_production_foundation.py
+++ b/tools/policy/check_onepassword_production_foundation.py
@@ -57,7 +57,8 @@ def check_repository(root: Path) -> list[str]:
     errors += check_item_metric_safety(root)
     errors += require(alert_kustomization, r"alert-rules-onepassword\.yaml", "1Password alert rules are not activated")
     errors += require(alerts, r"uid: onepassword-operator-unavailable", "operator-unavailable alert is missing")
-    errors += require(alerts, r"absent\(kube_deployment_spec_replicas", "operator alert must detect a missing Deployment")
+    errors += require(alerts, r'kube_deployment_spec_replicas\{namespace="onepassword-system",deployment="onepassword-connect-operator"\}', "operator alert must target the live Helm Deployment")
+    errors += require(alerts, r'absent\(kube_deployment_spec_replicas\{namespace="onepassword-system",deployment="onepassword-connect-operator"\}\)', "operator alert must detect a missing live Deployment")
     errors += require(alerts, r"uid: onepassword-item-unready", "item-unready alert is missing")
     errors += require(alerts, r'onepassword_item_info\{ready!="True"\}', "item alert must detect every non-True Ready state")
     if alerts.count("for: 10m") != 2:

--- a/tools/policy/tests/test_check_onepassword_production_foundation.py
+++ b/tools/policy/tests/test_check_onepassword_production_foundation.py
@@ -22,6 +22,14 @@ class OnePasswordProductionFoundationPolicyTest(unittest.TestCase):
     def test_repository_satisfies_production_foundation_policy(self) -> None:
         self.assertEqual([], self.module.check_repository(REPO_ROOT))
 
+    def test_operator_alert_targets_live_helm_deployment_name(self) -> None:
+        alerts = (
+            REPO_ROOT
+            / "kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn('deployment="onepassword-connect-operator"', alerts)
+        self.assertNotIn('deployment="onepassword-operator"', alerts)
+
     def test_checker_rejects_secret_data_in_item_metric(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

Post-merge production validation of #387 found that chart `connect` 2.4.1 names the healthy operator Deployment `onepassword-connect-operator`, while the new availability alert and runbook targeted `onepassword-operator`.

This PR:

- corrects all operator availability PromQL selectors, including the absent-Deployment case
- corrects rollout and log commands in the operator runbook
- adds a regression test and strengthens the repository policy checker with the authoritative live Helm name

## Production safety

The operator is currently healthy at `1/1`. The incorrect Grafana alert CR never reconciled because the Grafana Flux Kustomization had not advanced past a transient Gateway dependency wait, so no false page became active. This PR changes no Secret, token, vault, SOPS resource, consumer, or operator workload.

## Validation

- TDD regression failed against merged main, then passed after correction
- focused policy tests: 3 passed
- production foundation policy: passed
- alerting Kustomize render: passed
- kubeconform: zero invalid/errors
- architecture check: passed
- full pre-commit suite: passed

After merge, production Grafana will be reconciled and the alert query evaluated against the healthy live Deployment before canary validation continues.