### PR TITLE
fix: use exported namespace in 1Password alert

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/onepassword-prod-foundation-alert-fix"}
+{"feature_directory":"specs/onepassword-prod-foundation-metric-label-fix"}

--- a/kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml
+++ b/kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml
@@ -31,7 +31,7 @@ spec:
             to: 0
           datasourceUid: prometheus
           model:
-            expr: max(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-connect-operator"} - kube_deployment_status_replicas_available{namespace="onepassword-system",deployment="onepassword-connect-operator"}) OR absent(kube_deployment_spec_replicas{namespace="onepassword-system",deployment="onepassword-connect-operator"})
+            expr: max(kube_deployment_spec_replicas{exported_namespace="onepassword-system",deployment="onepassword-connect-operator"} - kube_deployment_status_replicas_available{exported_namespace="onepassword-system",deployment="onepassword-connect-operator"}) OR absent(kube_deployment_spec_replicas{exported_namespace="onepassword-system",deployment="onepassword-connect-operator"})
             refId: A
         - refId: B
           relativeTimeRange:

--- a/specs/onepassword-prod-foundation-metric-label-fix/checklists/requirements.md
+++ b/specs/onepassword-prod-foundation-metric-label-fix/checklists/requirements.md
@@ -1,0 +1,6 @@
+# Requirements Checklist: 1Password Alert Metric Label Fix
+
+- [x] Live metric labels and expected value are explicit.
+- [x] Scope excludes credentials, consumers, and workloads.
+- [x] Regression and live acceptance are measurable.
+- [x] No clarification remains.

--- a/specs/onepassword-prod-foundation-metric-label-fix/evidence.md
+++ b/specs/onepassword-prod-foundation-metric-label-fix/evidence.md
@@ -1,0 +1,21 @@
+# Evidence: 1Password Alert Metric Label Fix
+
+**Base**: `origin/main` at `77e0405083f8e6d03b34833f9cd314dcb641afba`
+
+## Discovery
+
+- Kubernetes Deployment: desired `1`, available `1`.
+- Direct kube-state-metrics endpoint: desired `1`, available `1`, resource label `namespace="onepassword-system"`.
+- Mimir series: desired `1`, available `1`, labels `namespace="monitoring"` and `exported_namespace="onepassword-system"`.
+- Merged alert expression result: `1` through its absent branch.
+- Item-unready expression before canary: `0`.
+
+## Validation
+
+- TDD red: the exported-resource-namespace regression failed against merged main.
+- Focused policy tests: PASS, 4 tests.
+- Production foundation policy: PASS.
+- Alert render and kubeconform 0.7.0: zero invalid/errors; Grafana CR schemas unavailable and skipped.
+- Full pre-commit suite: PASS.
+- Exact corrected expression evaluated against live Mimir before merge: `0` for the healthy `1/1` operator.
+- Convergence audit found no missing repository task; post-merge reconciliation remains.

--- a/specs/onepassword-prod-foundation-metric-label-fix/plan.md
+++ b/specs/onepassword-prod-foundation-metric-label-fix/plan.md
@@ -1,0 +1,15 @@
+# Implementation Plan: 1Password Alert Metric Label Fix
+
+**SDD Tier**: full, narrowly scoped correction
+**Risk Tier**: high production paging behavior
+**Smoke Strategy**: exact PromQL evaluation through the in-cluster Mimir API after merge
+**Fanout**: none
+
+Add a failing live-label regression, update the PromQL and policy checker, run alert render/schema/pre-commit checks, publish the minimal PR, then reconcile Grafana and evaluate both expressions before the production canary.
+
+## Constitution Check
+
+- [x] GitOps owns the correction.
+- [x] No Secret or consumer state changes.
+- [x] Live evidence is metadata/metric-only.
+- [x] Dedicated branch/worktree/PR used.

--- a/specs/onepassword-prod-foundation-metric-label-fix/spec.md
+++ b/specs/onepassword-prod-foundation-metric-label-fix/spec.md
@@ -1,0 +1,25 @@
+# Feature Specification: 1Password Alert Metric Label Fix
+
+**Branch**: `codex/onepassword-prod-foundation-metric-label-fix`
+**Created**: 2026-08-09
+**Status**: Approved corrective follow-up
+**Risk Tier**: high
+
+## Summary
+
+Correct the operator availability alert to filter kube-state-metrics resource identity by `exported_namespace="onepassword-system"`. Live Mimir evaluation showed Alloy attaches `namespace="monitoring"` to the scrape target and preserves the Kubernetes resource namespace as `exported_namespace`; the merged rule therefore took its absent branch and returned `1` for a healthy operator.
+
+## Requirements
+
+- **FR-001**: All operator desired, available, and absent selectors MUST use `exported_namespace="onepassword-system"`.
+- **FR-002**: The rule MUST evaluate to `0` while the live Deployment is available `1/1`.
+- **FR-003**: The regression test and policy checker MUST reject `namespace="onepassword-system"` for these kube-state-metrics series.
+- **FR-004**: No credential, SOPS, consumer, operator, or item-readiness behavior may change.
+
+## Acceptance
+
+- Focused policy/pre-commit checks pass.
+- Corrected rule reconciles from merged main.
+- Exact live operator expression returns `0`; item expression returns `0` before the canary.
+
+The user's instruction to complete the production foundation authorizes this bounded correction. Live labels remove any design ambiguity.

--- a/specs/onepassword-prod-foundation-metric-label-fix/tasks.md
+++ b/specs/onepassword-prod-foundation-metric-label-fix/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: 1Password Alert Metric Label Fix
+
+- [x] T001 Record the live label mismatch and corrective scope.
+- [x] T002 Add a failing regression for `exported_namespace`.
+- [x] T003 Correct PromQL and policy enforcement.
+- [x] T004 Run local validation, converge, record evidence, and publish the PR.
+- [ ] T005 After merge, reconcile Grafana and prove both expressions healthy.

--- a/tools/policy/check_onepassword_production_foundation.py
+++ b/tools/policy/check_onepassword_production_foundation.py
@@ -57,8 +57,8 @@ def check_repository(root: Path) -> list[str]:
     errors += check_item_metric_safety(root)
     errors += require(alert_kustomization, r"alert-rules-onepassword\.yaml", "1Password alert rules are not activated")
     errors += require(alerts, r"uid: onepassword-operator-unavailable", "operator-unavailable alert is missing")
-    errors += require(alerts, r'kube_deployment_spec_replicas\{namespace="onepassword-system",deployment="onepassword-connect-operator"\}', "operator alert must target the live Helm Deployment")
-    errors += require(alerts, r'absent\(kube_deployment_spec_replicas\{namespace="onepassword-system",deployment="onepassword-connect-operator"\}\)', "operator alert must detect a missing live Deployment")
+    errors += require(alerts, r'kube_deployment_spec_replicas\{exported_namespace="onepassword-system",deployment="onepassword-connect-operator"\}', "operator alert must target the live Helm Deployment and exported resource namespace")
+    errors += require(alerts, r'absent\(kube_deployment_spec_replicas\{exported_namespace="onepassword-system",deployment="onepassword-connect-operator"\}\)', "operator alert must detect a missing live Deployment")
     errors += require(alerts, r"uid: onepassword-item-unready", "item-unready alert is missing")
     errors += require(alerts, r'onepassword_item_info\{ready!="True"\}', "item alert must detect every non-True Ready state")
     if alerts.count("for: 10m") != 2:

--- a/tools/policy/tests/test_check_onepassword_production_foundation.py
+++ b/tools/policy/tests/test_check_onepassword_production_foundation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -29,6 +30,19 @@ class OnePasswordProductionFoundationPolicyTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn('deployment="onepassword-connect-operator"', alerts)
         self.assertNotIn('deployment="onepassword-operator"', alerts)
+
+    def test_operator_alert_uses_exported_resource_namespace(self) -> None:
+        alerts = (
+            REPO_ROOT
+            / "kubernetes/infra/monitoring/grafana/alerting/alert-rules-onepassword.yaml"
+        ).read_text(encoding="utf-8")
+        operator_expression = next(
+            line for line in alerts.splitlines() if "kube_deployment_spec_replicas" in line
+        )
+        self.assertIn('exported_namespace="onepassword-system"', operator_expression)
+        self.assertIsNone(
+            re.search(r'(?<!exported_)namespace="onepassword-system"', operator_expression)
+        )
 
     def test_checker_rejects_secret_data_in_item_metric(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

Live Mimir evaluation after #388 showed Alloy labels the scrape target as `namespace="monitoring"` and preserves kube-state-metrics' Kubernetes resource namespace as `exported_namespace`. The operator rule therefore took its absent branch and returned `1` for a healthy `1/1` Deployment.

This PR changes the desired, available, and absent selectors to `exported_namespace="onepassword-system"`, and strengthens both regression tests and the repository policy checker.

## Safety

No credential, SOPS resource, consumer, operator workload, or item-readiness logic changes. This is limited to production paging correctness.

## Validation

- regression failed against merged main, then passed after correction
- focused policy tests: 4 passed
- production foundation policy: passed
- alert render/kubeconform: zero invalid/errors
- full pre-commit suite: passed
- exact corrected expression evaluated against live Mimir: `0` for the healthy `1/1` operator

After merge, Grafana will be reconciled and both live alert expressions re-evaluated before the production canary.