### PR TITLE
fix: enable Jellyfin SOPS decryption

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/onepassword-prod-foundation-metric-label-fix"}
+{"feature_directory":"specs/jellyfin-sops-decryption-fix"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `app-home-assistant` | `./kubernetes/apps/home-assistant` | `gateway`, `nfs-csi`, `authentik` | `cluster-vars` | `sops` |
 | `production` | `app-homepage` | `./kubernetes/apps/homepage` | `gateway`, `metrics-server` | `cluster-vars` | `no` |
 | `production` | `app-immich` | `./kubernetes/apps/immich` | `gateway`, `nfs-csi`, `local-path-provisioner`, `cloudnative-pg`, `authentik` | `cluster-vars` | `sops` |
-| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `local-path-provisioner`, `intel-gpu-device-plugin` | `cluster-vars` | `no` |
+| `production` | `app-jellyfin` | `./kubernetes/apps/jellyfin` | `gateway`, `nfs-csi`, `local-path-provisioner`, `intel-gpu-device-plugin` | `cluster-vars` | `sops` |
 | `production` | `app-pihole` | `./kubernetes/apps/pihole` | `gateway` | `cluster-vars` | `sops` |
 | `production` | `private-apps` | `./kubernetes/clusters/production/apps` | `private-source` | `cluster-vars` | `sops` |
 | `production` | `private-source` | `./kubernetes/clusters/production/apps/private/source` | (none) | `(none)` | `sops` |

--- a/kubernetes/clusters/production/apps/jellyfin.yaml
+++ b/kubernetes/clusters/production/apps/jellyfin.yaml
@@ -13,6 +13,10 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   dependsOn:
     - name: gateway
     - name: nfs-csi

--- a/specs/jellyfin-sops-decryption-fix/checklists/requirements.md
+++ b/specs/jellyfin-sops-decryption-fix/checklists/requirements.md
@@ -1,0 +1,22 @@
+# Specification Quality Checklist: Jellyfin SOPS Decryption Fix
+
+**Purpose**: Validate specification completeness before planning
+**Created**: 2026-08-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] CHK001 Is the operator outcome stated without unresolved implementation ambiguity? [Clarity]
+- [x] CHK002 Are scope and non-goals explicit for credentials, consumers, and rotation? [Completeness]
+
+## Safety And Acceptance
+
+- [x] CHK003 Are no-output credential handling requirements defined? [Security, Spec §FR-003]
+- [x] CHK004 Is post-merge exact-revision and live-byte acceptance measurable? [Acceptance, Spec §FR-004]
+- [x] CHK005 Are failure, mismatch, and rollback requirements defined? [Recovery, Spec §Edge Cases]
+- [x] CHK006 Is the production-only development-validation constraint identified? [Assumption]
+
+## Traceability
+
+- [x] CHK007 Are requirements traced to binding SOPS and validation decisions? [Traceability]
+- [x] CHK008 Does every success criterion have a corresponding requirement and scenario? [Consistency]

--- a/specs/jellyfin-sops-decryption-fix/data-model.md
+++ b/specs/jellyfin-sops-decryption-fix/data-model.md
@@ -1,0 +1,19 @@
+# Data Model: Jellyfin SOPS Decryption Fix
+
+## Flux Reconciliation
+
+- Identity: `flux-system/app-jellyfin`
+- Source path: `./kubernetes/apps/jellyfin`
+- Decryption provider: `sops`
+- Key source: `flux-system/sops-age`
+- Desired state: Ready at the exact merged revision
+
+## Shared OAuth Credential
+
+- Jellyfin Secret identity: `jellyfin/jellyfin-secrets`
+- Jellyfin key: `JELLYFIN_OAUTH_CLIENT_SECRET`
+- Authentik Secret identity: `authentik/authentik-secrets`
+- Authentik key: `JELLYFIN_OAUTH_CLIENT_SECRET`
+- Invariant: decoded byte strings are identical and the Jellyfin bytes are not an SOPS envelope
+
+No credential value, encoding, or hash is stored in this model or evidence.

--- a/specs/jellyfin-sops-decryption-fix/evidence.md
+++ b/specs/jellyfin-sops-decryption-fix/evidence.md
@@ -1,0 +1,45 @@
+# Evidence: Jellyfin SOPS Decryption Fix
+
+## Discovery
+
+- Live decoded `jellyfin/jellyfin-secrets.JELLYFIN_OAUTH_CLIENT_SECRET` begins with a SOPS `ENC[` envelope.
+- Production `flux-system/app-jellyfin` lacks `spec.decryption` in Git.
+- Status-only local SOPS comparison proved the committed Jellyfin and Authentik plaintext bytes match.
+
+## Human Gates
+
+- Intent/spec/plan/task scope approved by the user on 2026-08-10 after the separate prerequisite PR, exact configuration change, and no-output acceptance were stated.
+- Clarification produced no critical questions; scope and failure behavior are explicit.
+- Requirements checklist passes 8/8.
+
+## Validation
+
+- Pre-change structural assertion: expected failure confirmed because `app-jellyfin` had no `spec.decryption`.
+- Spec Kit analyze: 6/6 functional requirements and 4/4 success criteria mapped to tasks; zero ambiguity, duplication, inconsistency, or constitution findings.
+- Spec Kit agent-context update was not run because this repository does not include `.specify/scripts/bash/update-agent-context.sh`; no agent guidance change is required by the feature.
+- Production and development root renders: PASS.
+- Rendered `flux-system/app-jellyfin`: exactly one `spec.decryption`, `provider: sops`, `secretRef.name: sops-age`.
+- Committed OAuth plaintext equality/non-envelope comparison: PASS with status-only output.
+- Diff-scope assertion: no Secret, consumer, workload, Authentik blueprint, or development path changed.
+- Architecture generator: regenerated and check PASS; only Jellyfin's decryption column changes from `no` to `sops`.
+- Direct-auth 1Password chart and production-foundation policies: PASS.
+- Codex harness: 81 tests PASS.
+- Full pre-commit: PASS, including YAML, Kubernetes validation, generated architecture, and repository policies.
+- `git diff --check`: PASS.
+- Local kubeconform: unavailable in the devcontainer; CI installs pinned 0.7.0. Local `k8svalidate` passed.
+- Spec Kit converge: clean; all local buildable requirements are satisfied and no convergence tasks were appended. Post-merge acceptance remains intentionally pending.
+
+## Development Validation Exception
+
+The edited Flux Kustomization exists only under `kubernetes/clusters/production`. Development Jellyfin is exercised through a branch profile with a placeholder OAuth value, so a development smoke would neither reconcile this resource nor test SOPS decryption. Copying the production credential into development was rejected because it violates environment isolation. Substitute evidence is the pre/post structural assertion, both cluster renders, status-only committed-value equality, broad local policy/tests, and mandatory exact-revision production acceptance after merge.
+
+## Post-Merge Acceptance
+
+Pending merge.
+
+## PR State
+
+- Branch: `codex/jellyfin-sops-decryption-fix`
+- Commit subject: `fix: enable Jellyfin SOPS decryption`
+- Draft PR: #390
+- Local worktree clean after publication.

--- a/specs/jellyfin-sops-decryption-fix/plan.md
+++ b/specs/jellyfin-sops-decryption-fix/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: Jellyfin SOPS Decryption Fix
+
+**Branch**: `codex/jellyfin-sops-decryption-fix` | **Date**: 2026-08-10 | **Spec**: `specs/jellyfin-sops-decryption-fix/spec.md`
+
+**Input**: Approved prerequisite to correct production Jellyfin SOPS reconciliation before 1Password dual publication.
+
+## Summary
+
+Add the same Flux SOPS decryption configuration used by other production application Kustomizations to `app-jellyfin`. Do not edit credential material or consumers. Gate merge on rendering, policy, no-output committed-value equality, and post-merge exact-revision/live-byte verification.
+
+## Technical Context
+
+**Risk Tier**: high
+**Workflow Tier**: high
+**Primary Areas**: Flux, Kubernetes, SOPS, Jellyfin OAuth secret handling
+**Dependencies**: Flux Kustomization API, existing `flux-system/sops-age`, SOPS CLI, kubectl
+**Storage**: Unchanged
+**Ingress**: Unchanged
+**Secrets**: Existing SOPS/Age documents remain byte-for-byte unchanged
+**Smoke Strategy**: No development mutation; production-only reconciliation is verified after merge with exact applied revision plus status-only live byte comparison. Jellyfin SSO acceptance remains required at its later consumer-cutover gate.
+**Fanout Targets**: None; the repository change is one file and no agents were requested.
+**Development Validation**: Documented exception. Development does not reconcile this production Flux object and its Jellyfin branch profile uses a placeholder secret. Injecting the production credential into development would violate vault/environment isolation and would not test the changed resource.
+**Post-Implementation SDD Conformance**: Local full Spec Kit artifacts and convergence; no workflow-standard change.
+
+## Human Gates
+
+**Spec Gate**: Approved by the user on 2026-08-10 after the live ciphertext defect and separate-PR boundary were explained.
+
+**Checklist Status**: `checklists/requirements.md` passes 8/8 requirements-quality checks.
+
+**Plan Gate**: Approved by the same user response because the proposed change, separate PR, and no-output acceptance were stated before approval; this plan introduces no additional design choice.
+
+**Expected Task/Analyze Gate**: Tasks and non-destructive analysis required before implementation; covered by the same explicit approval of the narrowly bounded fix.
+
+## Constitution Check
+
+- [x] GitOps source of truth preserved; no durable live-cluster-only state.
+- [x] No production-first mutation; the production-only development exception and substitute checks are recorded.
+- [x] Gateway API invariant preserved; no ingress resources change.
+- [x] SOPS invariant preserved; no plaintext or encrypted Secret manifest changes.
+- [x] NFS default unaffected.
+- [x] Talos boundary preserved.
+- [x] Branch/worktree match `jellyfin-sops-decryption-fix`.
+- [x] Documentation impact is limited to durable SDD evidence; no canonical procedure changes.
+- [x] PR review/status checks remain the review gate.
+
+## Project Structure
+
+### SDD Artifacts
+
+```text
+specs/jellyfin-sops-decryption-fix/
+├── checklists/requirements.md
+├── data-model.md
+├── evidence.md
+├── plan.md
+├── quickstart.md
+├── research.md
+├── spec.md
+└── tasks.md
+```
+
+### Source Changes
+
+```text
+kubernetes/clusters/production/apps/jellyfin.yaml
+docs/architecture.md
+```
+
+## Tiered TDD And Validation Plan
+
+**TDD expectation**: There is no executable-code seam for a two-field declarative stanza. Before editing, the observed failing state is that rendered `app-jellyfin` has no `.spec.decryption`; after editing, structural assertions require exactly `provider: sops` and `secretRef.name: sops-age`.
+
+**Local checks**:
+
+- Render production and development cluster entrypoints.
+- Parse the production render and assert the exact `app-jellyfin` decryption configuration.
+- Decrypt the two committed fields into process memory and compare bytes with status-only output.
+- Assert encrypted Secret documents and all consumer paths are unchanged.
+- Run architecture check, SDD harness, focused policy, unit/harness suites, and full pre-commit.
+- Run kubeconform locally if available; otherwise rely on pinned CI 0.7.0 and record the exception.
+
+**Development smoke**: None for the production-only resource, for the isolation reasons above. Existing development Jellyfin branch smoke would validate a placeholder-backed workload, not this reconciliation change.
+
+**Completion evidence**: Record PR/merge SHA, Flux source fetched SHA, `app-jellyfin` applied SHA and Ready state, live decryption configuration, no-output equality, non-envelope check, and workload readiness. Exact SSO login remains outside this prerequisite because the credential is not rotated and consumer configuration is unchanged.
+
+**Fanout plan**: None.
+
+**Evidence destination**: `specs/jellyfin-sops-decryption-fix/evidence.md`.
+
+## Documentation Impact
+
+Regenerate `docs/architecture.md` so its `app-jellyfin` row reports SOPS decryption. No ADR, runbook, README, or procedural documentation changes are required. This restores conformance with the existing SOPS ADR and records discovery/acceptance in the implementation artifacts.
+
+## Implementation Steps
+
+1. Capture the missing-decryption failing assertion and committed-value equality.
+2. Add `provider: sops` and `secretRef.name: sops-age` to production `app-jellyfin`.
+3. Run broad local validation and diff-scope assertions.
+4. Open a gated PR, merge, reconcile exact main, and perform no-output live acceptance.
+5. Resume the blocked 1Password dual-publish PR.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| The Age key cannot decrypt the file | Normal Flux failure blocks readiness; do not proceed to dual publication. |
+| The two OAuth sources differ | Local and live status-only comparisons fail closed. |
+| Reconciliation changes credential bytes unexpectedly | Secret documents are untouched and both committed plaintexts are proven equal before merge. |
+| Sensitive values reach output | Comparisons occur in process memory and print status only; no values, Base64, or hashes are recorded. |
+
+## Complexity Tracking
+
+No constitution violation or additional complexity is introduced.

--- a/specs/jellyfin-sops-decryption-fix/quickstart.md
+++ b/specs/jellyfin-sops-decryption-fix/quickstart.md
@@ -1,0 +1,9 @@
+# Quickstart: Jellyfin SOPS Decryption Fix
+
+1. Render the production root and assert `flux-system/app-jellyfin` has exactly `provider: sops` and `secretRef.name: sops-age`.
+2. Render development and confirm it is unchanged relative to `origin/main`.
+3. Decrypt the committed Jellyfin and Authentik fields into memory and print only equality status.
+4. Assert the PR changes no Secret manifest, consumer, workload, blueprint, or development path.
+5. Merge only after CI and review pass.
+6. Reconcile the exact merge revision, require `app-jellyfin` Ready/applied at that revision, and compare live decoded bytes in memory.
+7. Stop if the live Jellyfin bytes still begin `ENC[` or differ from Authentik.

--- a/specs/jellyfin-sops-decryption-fix/research.md
+++ b/specs/jellyfin-sops-decryption-fix/research.md
@@ -1,0 +1,25 @@
+# Research: Jellyfin SOPS Decryption Fix
+
+## Root Cause
+
+**Decision**: Treat the missing `spec.decryption` on the production `app-jellyfin` Flux Kustomization as the defect.
+
+**Rationale**: The encrypted manifest is included by the reconciled app path, but the cluster-layer Kustomization lacks decryption. The live decoded Secret therefore contains the literal `ENC[AES256_GCM,...]` envelope. Other production SOPS-backed apps use `provider: sops` with `secretRef.name: sops-age`.
+
+**Alternatives considered**: Copying the live Jellyfin ciphertext into 1Password was rejected because it perpetuates the defect. Editing or re-encrypting the Secret was rejected because the committed plaintext is already correct.
+
+## Credential Authority
+
+**Decision**: Require the Jellyfin and Authentik committed plaintexts, then live Secret bytes, to match without output.
+
+**Rationale**: Jellyfin and the Authentik provider consume the same OAuth client secret. A local in-memory SOPS comparison already proved the committed values match.
+
+**Alternatives considered**: Hash logging was rejected because hashes of credentials are unnecessary evidence. Rotation was rejected as out of scope.
+
+## Validation Environment
+
+**Decision**: Use a documented development exception and exact-revision production verification after merge.
+
+**Rationale**: The changed resource exists only under `clusters/production`; development Jellyfin uses a non-secret placeholder branch profile. Reusing the production credential in development would weaken cluster isolation without exercising the changed Flux resource.
+
+**Alternatives considered**: Applying the production Kustomization to development was rejected because it would reconcile production app paths and credentials into the wrong cluster.

--- a/specs/jellyfin-sops-decryption-fix/spec.md
+++ b/specs/jellyfin-sops-decryption-fix/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: Jellyfin SOPS Decryption Fix
+
+**Feature Branch**: `codex/jellyfin-sops-decryption-fix`
+**Created**: 2026-08-10
+**Status**: Approved
+**Risk Tier**: high
+**Input**: Correct production Jellyfin's missing SOPS reconciliation before 1Password dual-publication parity.
+
+## Human Gate Status
+
+**Intent Brief**: During the approved 1Password migration, the user confirmed that the decoded live Jellyfin OAuth client-secret value is SOPS ciphertext. Inspection proved the production Jellyfin Flux resource lacks decryption while the committed Jellyfin and Authentik fields decrypt to identical plaintext. The user explicitly approved a separate prerequisite PR to correct this without exposing values.
+
+**Clarify Status**: Completed with no questions; the affected resource, authority, scope, rollback, and no-output acceptance are explicit.
+
+**Spec Gate**: Approved by the user in conversation on 2026-08-10.
+
+## Summary
+
+Restore the intended production secret behavior so Jellyfin receives the actual shared OAuth client secret rather than committed ciphertext. Preserve the encrypted manifest, consumer reference, Authentik configuration, and every other application path.
+
+## Binding Sources
+
+- `AGENTS.md`
+- `.specify/memory/constitution.md`
+- `docs/decisions/sops-age-secrets.md`
+- `docs/decisions/tdd-and-development-smoke-evidence.md`
+- `docs/runbooks/implementation-workflow.md`
+- `docs/runbooks/jellyfin-authentik-sso.md`
+
+## Scope
+
+### In Scope
+
+- Configure the production `app-jellyfin` reconciliation to decrypt SOPS resources using the existing `flux-system/sops-age` Secret.
+- Prove the committed Jellyfin and Authentik OAuth values decrypt to identical bytes without displaying either value.
+- After merge, prove Flux fetched/applied the exact revision and the live decoded Jellyfin and Authentik Secret bytes are identical without displaying either value.
+
+### Out Of Scope
+
+- Editing or re-encrypting either SOPS Secret manifest.
+- Changing the Jellyfin or Authentik Secret name, key, consumer, OAuth provider, or workload definition.
+- Switching any consumer to 1Password; that remains in later migration phases.
+- Rotating the OAuth client secret.
+
+## User Scenarios & Testing
+
+### User Story 1 - Restore Jellyfin OAuth Secret Reconciliation (Priority: P1)
+
+As the homelab operator, I need production Jellyfin to receive the same plaintext OAuth client secret configured in Authentik so SSO configuration is coherent and the 1Password migration can prove byte parity.
+
+**Why this priority**: This is the only defect and blocks the dual-publish parity gate.
+
+**Independent Test**: Render the production cluster, verify the Flux resource contains SOPS decryption with `sops-age`, and compare committed plus post-merge live bytes in memory with status-only output.
+
+**Acceptance Scenarios**:
+
+1. **Given** the encrypted Jellyfin Secret and existing Age key, **When** `app-jellyfin` reconciles, **Then** the live Secret contains plaintext equal to the Authentik Jellyfin OAuth field rather than an `ENC[` envelope.
+2. **Given** the fix is reviewed, **When** the diff is inspected, **Then** only the production Flux reconciliation resource, its generated architecture description, and SDD evidence change; secret documents and consumers do not.
+3. **Given** reconciliation cannot decrypt, **When** Flux reports failure, **Then** acceptance stops and rollback is removal of the added decryption stanza through Git.
+
+## Requirements
+
+- **FR-001**: Production `app-jellyfin` MUST use Flux SOPS decryption with Secret reference `sops-age`.
+- **FR-002**: Both committed encrypted Secret manifests and all consumer references MUST remain byte-for-byte unchanged.
+- **FR-003**: Local validation MUST prove the two committed fields decrypt to identical bytes without printing values.
+- **FR-004**: Post-merge validation MUST prove exact fetched/applied revision and live Secret byte equality without printing values, Base64, or hashes.
+- **FR-005**: The change MUST NOT create, rotate, or otherwise alter credential material.
+- **FR-006**: Failure or mismatch MUST block the dual-publish PR from reaching its parity gate.
+
+## Edge Cases
+
+- A missing or invalid Age key causes Flux reconciliation failure and blocks acceptance.
+- A live Jellyfin value that still begins `ENC[` after reconciliation is a failed deployment even if the Kustomization reports Ready.
+- Different plaintexts between Jellyfin and Authentik block acceptance and require credential-source investigation; neither is silently overwritten.
+
+## Risk And Validation Expectations
+
+This is high-risk secret-handling work. The changed Flux resource exists only in the production cluster path, while development Jellyfin uses a branch placeholder rather than this production SOPS Secret. A development-cluster mutation would therefore not exercise the changed resource and could introduce production credential material into development. Acceptance uses local encrypted-manifest equality, strict render/policy checks, normal PR review, and exact-revision post-merge production reconciliation with no-output live comparison.
+
+## Success Criteria
+
+- **SC-001**: Production rendering shows exactly one SOPS decryption configuration on `app-jellyfin` referencing `sops-age`.
+- **SC-002**: No Secret manifest, OAuth consumer, Authentik blueprint, or Jellyfin workload file changes in the PR; generated architecture records only that Jellyfin now uses SOPS.
+- **SC-003**: Status-only local comparison reports committed plaintext equality.
+- **SC-004**: Status-only post-merge comparison reports live equality and confirms the Jellyfin value is not an `ENC[` envelope.
+
+## Assumptions
+
+- The existing production `sops-age` Secret is healthy because other production Kustomizations decrypt with it.
+- The encrypted Jellyfin and Authentik values intentionally represent the same shared OAuth client secret, as confirmed by local no-output comparison.
+
+## Open Questions
+
+- None.

--- a/specs/jellyfin-sops-decryption-fix/tasks.md
+++ b/specs/jellyfin-sops-decryption-fix/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Jellyfin SOPS Decryption Fix
+
+**Input**: `specs/jellyfin-sops-decryption-fix/spec.md` and `plan.md`
+**Risk Tier**: high
+**Prerequisites**: Branch `codex/jellyfin-sops-decryption-fix`; user-approved narrow prerequisite scope.
+
+## Human Gate Status
+
+**Spec Gate**: Approved by the user on 2026-08-10.
+
+**Plan Gate**: Approved by the same explicit response to the stated one-stanza separate-PR approach and no-output acceptance.
+
+**Analyze Requirement**: Run before source implementation; remediate any critical or high findings before editing the production Flux resource.
+
+## Phase 1: Setup And Failing Evidence
+
+- [x] T001 [FR-001] Create the matching branch/worktree and complete SDD artifacts under `specs/jellyfin-sops-decryption-fix/`.
+- [x] T002 [FR-003] Record a status-only comparison proving committed Jellyfin and Authentik OAuth plaintext equality in `specs/jellyfin-sops-decryption-fix/evidence.md`.
+- [x] T003 [FR-001] Capture the pre-change structural assertion that `kubernetes/clusters/production/apps/jellyfin.yaml` lacks `spec.decryption`.
+- [x] T004 [FR-006] Run Spec Kit analyze across `spec.md`, `plan.md`, and `tasks.md` before the source edit.
+
+## Phase 2: User Story 1 - Restore Secret Reconciliation
+
+**Story Goal**: Production Jellyfin receives the same plaintext OAuth client secret used by Authentik.
+
+**Independent Test**: Render and structurally assert the exact Flux decryption configuration; committed and post-merge live comparisons report equality without values.
+
+- [x] T005 [US1] Add SOPS provider and `sops-age` Secret reference to `kubernetes/clusters/production/apps/jellyfin.yaml`.
+- [x] T006 [US1] Assert `app-jellyfin` renders exactly one correct decryption configuration from `kubernetes/clusters/production/`.
+- [x] T007 [US1] Assert encrypted Secret documents and all Jellyfin/Authentik consumers are unchanged relative to `origin/main`.
+
+## Phase 3: Verification And Evidence
+
+- [x] T008 [P] [FR-003] Repeat the no-output committed plaintext comparison and record status in `specs/jellyfin-sops-decryption-fix/evidence.md`.
+- [x] T009 [P] [SC-001] Run production/development renders, policy checks, architecture check, harness tests, and full pre-commit.
+- [x] T010 [FR-004] Record the production-only development-validation exception and substitute checks in `specs/jellyfin-sops-decryption-fix/evidence.md`.
+- [x] T011 [FR-006] Run Spec Kit converge and append any genuinely remaining implementation work to `tasks.md`.
+- [x] T012 [FR-004] Record validation results and pending exact-revision post-merge acceptance in `specs/jellyfin-sops-decryption-fix/evidence.md`.
+
+## Phase 4: Commit, PR, And Deployment Gate
+
+- [x] T013 [FR-002] Commit the scoped change with a conventional commit message.
+- [x] T014 [FR-004] Push `codex/jellyfin-sops-decryption-fix` and open the gated PR.
+- [ ] T015 [FR-004] After merge, reconcile exact main, require `app-jellyfin` Ready/applied, and prove live equality/non-envelope status without output.
+- [ ] T016 [FR-006] Resume the separate `onepassword-dual-publish` implementation only after T015 passes.
+
+## Dependencies
+
+- T003 and T004 block T005.
+- T005 blocks T006-T012.
+- T013-T014 require local validation complete.
+- T015 requires merge; T016 requires successful live acceptance.
+
+## Parallel Opportunities
+
+- T008 and T009 are read-only checks over distinct validation surfaces and may run independently, but no helper agents are used because the user did not request delegation.


### PR DESCRIPTION
## What changed

- enable Flux SOPS decryption on production `app-jellyfin` using the existing `flux-system/sops-age` Secret
- regenerate the architecture description so Jellyfin is recorded as SOPS-backed
- add full Spec Kit artifacts and no-output acceptance evidence

## Why

The 1Password dual-publication inventory exposed that the decoded live `jellyfin/jellyfin-secrets` OAuth value is the literal SOPS `ENC[...]` envelope. The encrypted Secret is included by the Jellyfin app path, but its production Flux Kustomization was the only relevant layer missing `spec.decryption`.

The committed Jellyfin and Authentik OAuth fields were compared in memory and decrypt to identical plaintext. This PR does not edit, rotate, or display credential material.

## Impact

After merge, Flux will reconcile the existing Jellyfin Secret as plaintext matching Authentik. No Secret manifest, consumer, workload, Authentik blueprint, development path, or 1Password reference changes.

## Validation

- production and development cluster roots render
- rendered `app-jellyfin` has exactly `provider: sops` and `secretRef.name: sops-age`
- committed Jellyfin/Authentik plaintext equality and non-envelope check passes with status-only output
- Secret/consumer/workload/blueprint/development diff-scope assertion passes
- architecture check passes
- direct-auth 1Password chart and production foundation policies pass
- Codex harness: 81 tests pass
- full pre-commit passes

Local kubeconform is unavailable in the devcontainer; CI installs pinned 0.7.0. Post-merge acceptance will reconcile the exact merge revision and compare live Jellyfin/Authentik bytes without printing values.
