### PR TITLE
feat: publish 1Password secret mirrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Run Codex harness tests
         run: python3 -m unittest discover -s tools/codex-harness/tests
 
+      - name: Run 1Password migration safety tests
+        run: python3 -m unittest discover -s tools/onepassword/tests
+
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,12 @@ repos:
         language: system
         files: ^(terraform/production/(main|variables)\.tf|kubernetes/clusters/production/infra/(kustomization|onepassword-operator)\.yaml|kubernetes/infra/monitoring/(kube-state-metrics/config/metrics|grafana/alerting/(kustomization|alert-rules-onepassword))\.yaml|tools/policy/check_onepassword_production_foundation\.py|\.pre-commit-config\.yaml)$
         pass_filenames: false
+      - id: onepassword-migration-safety
+        name: Test 1Password migration safety tooling
+        entry: python3 -m unittest discover -s tools/onepassword/tests
+        language: system
+        files: ^(tools/onepassword/|\.pre-commit-config\.yaml)$
+        pass_filenames: false
       - id: synology-oauth-redirect
         name: Check Synology OAuth redirect path
         entry: python3 tools/policy/check_synology_oauth_redirect.py

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/jellyfin-sops-decryption-fix"}
+{"feature_directory":"specs/onepassword-dual-publish"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This document is generated for agentic repo navigation. It records relationships
 ### Production
 
 - Root Kustomization: `kubernetes/clusters/production/kustomization.yaml`.
-- Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`.
+- Root resources: `flux-system`, `cluster-vars.yaml`, `infra`, `apps`, `onepassword-items.yaml`.
 - Infra activation list: `crds.yaml`, `onepassword-operator.yaml`, `cert-manager.yaml`, `local-path-provisioner.yaml`, `cloudnative-pg.yaml`, `grafana-operator.yaml`, `intel-device-plugins-operator.yaml`, `intel-gpu-device-plugin.yaml`, `nfs-csi.yaml`, `cilium.yaml`, `metrics-server.yaml`, `certs.yaml`, `gateway.yaml`, `vpn.yaml`, `monitoring.yaml`, `loki.yaml`, `mimir.yaml`, `alloy.yaml`, `grafana.yaml`, `otel-collector.yaml`, `authentik.yaml`.
 - App activation list: `external.yaml`, `homepage.yaml`, `pihole.yaml`, `whoami.yaml`, `renovate.yaml`, `cloudflare-tunnels.yaml`, `jellyfin.yaml`, `immich.yaml`, `home-assistant.yaml`, `foundryvtt.yaml`, `valheim.yaml`, `synthetics.yaml`, `access-broker.yaml`, `private`.
 

--- a/docs/runbooks/onepassword-operator.md
+++ b/docs/runbooks/onepassword-operator.md
@@ -85,6 +85,44 @@ kubectl -n onepassword-system logs deployment/onepassword-connect-operator --sin
 
 A 1Password outage prevents refresh but does not remove an existing generated Secret. Confirm existing workloads remain running while investigating. Do not delete a durable `OnePasswordItem` as a diagnostic step: deletion also deletes its generated Kubernetes Secret.
 
+## Prepare dual-publish items
+
+The repository contains 16 encrypted Secret files but 17 Secret objects because the Immich file contains both `immich-secrets` and `immich-postgres-user`. Create all 17 items in `cluster production`; use the inventory as the field-label contract:
+
+```bash
+jq -r '.items[] | [.item_title, (.keys | join(","))] | @tsv' \
+  tools/onepassword/production_items.json
+```
+
+For each entry:
+
+1. Create a Secure Note with the exact inventory title.
+2. Leave the note body empty and add exactly the listed custom fields.
+3. Populate every field with the current legacy Secret bytes. Preserve multiline content and trailing newlines exactly.
+4. Do not add a URL, file attachment, or any other populated field.
+
+Use the live `grafana/grafana-credentials` Secret as the source for that item because its committed SOPS document fails MAC validation. Handle recovered values only in a trusted local session or secure clipboard; do not paste values into chat, shell arguments, Git, logs, or evidence. The remaining live Secrets are also acceptable migration sources and align directly with byte-parity acceptance.
+
+After all items exist, resolve and validate their metadata from an authenticated user session:
+
+```bash
+unset OP_SERVICE_ACCOUNT_TOKEN
+python3 tools/onepassword/render_production_items.py \
+  --vault 'cluster production' \
+  --check-only
+```
+
+The command captures item JSON without displaying it. It fails on duplicate, missing, empty, or extra fields and on URLs/files. Once check-only passes, omit `--check-only` to write ID-only `OnePasswordItem` manifests. Review every generated `itemPath` to confirm it contains only vault/item IDs.
+
+After GitOps reconciliation, prove all pairs without displaying values:
+
+```bash
+python3 tools/onepassword/validate_secret_parity.py \
+  --kubeconfig /home/vscode/.kube/homelab-production.config
+```
+
+Do not delete a durable `OnePasswordItem` to retry generation. Its generated Secret is owned by the resource and is deleted with it.
+
 ## Rollback during foundation
 
 All application consumers still use SOPS during the foundation phases. If the production operator cannot meet acceptance, leave `sops-age` and consumers untouched, suspend the `onepassword-operator` Flux Kustomization if needed for diagnosis, and revert the new foundation Git change. Remove only a disposable canary namespace whose ownership is certain.

--- a/kubernetes/clusters/production/kustomization.yaml
+++ b/kubernetes/clusters/production/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - cluster-vars.yaml
   - infra
   - apps
+  - onepassword-items.yaml

--- a/kubernetes/clusters/production/onepassword-items.yaml
+++ b/kubernetes/clusters/production/onepassword-items.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: onepassword-items
+  namespace: flux-system
+spec:
+  interval: 2m
+  retryInterval: 2m
+  path: ./kubernetes/clusters/production/onepassword-items
+  prune: true
+  wait: true
+  timeout: 10m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: onepassword-operator
+    - name: app-access-broker
+    - name: app-cloudflare-tunnels
+    - name: app-foundryvtt
+    - name: app-home-assistant
+    - name: app-immich
+    - name: app-jellyfin
+    - name: app-pihole
+    - name: app-renovate
+    - name: app-valheim
+    - name: private-source
+    - name: authentik
+    - name: cert-manager
+    - name: grafana
+    - name: monitoring
+    - name: vpn

--- a/kubernetes/clusters/production/onepassword-items/access-broker--access-broker-secret-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/access-broker--access-broker-secret-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: access-broker-secret-onepassword
+  namespace: access-broker
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: access-broker-secret
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/pgsxqs5ue33cqz3p4amyanwnyu"

--- a/kubernetes/clusters/production/onepassword-items/authentik--authentik-secrets-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/authentik--authentik-secrets-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: authentik-secrets-onepassword
+  namespace: authentik
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: authentik-secrets
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/6asz7hfrr3vsyo4ewb6mksc5km"

--- a/kubernetes/clusters/production/onepassword-items/cert-manager--cloudflare-api-token-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/cert-manager--cloudflare-api-token-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token-onepassword
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: cloudflare-api-token
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/eakmwn7ymdi4uhbexo3c25qome"

--- a/kubernetes/clusters/production/onepassword-items/cloudflare--tunnel-credentials-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/cloudflare--tunnel-credentials-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: tunnel-credentials-onepassword
+  namespace: cloudflare
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: tunnel-credentials
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/dhojzrmh37b4rgttqziahgzvla"

--- a/kubernetes/clusters/production/onepassword-items/flux-system--homelab-private-deploy-key-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/flux-system--homelab-private-deploy-key-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: homelab-private-deploy-key-onepassword
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: homelab-private-deploy-key
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/5sjem2nv4rhsay2k3nr55wtwly"

--- a/kubernetes/clusters/production/onepassword-items/foundryvtt--foundryvtt-secret-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/foundryvtt--foundryvtt-secret-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: foundryvtt-secret-onepassword
+  namespace: foundryvtt
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: foundryvtt-secret
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/jjmijft7g63rtunpgwhuxqp5xa"

--- a/kubernetes/clusters/production/onepassword-items/grafana--grafana-credentials-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/grafana--grafana-credentials-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: grafana-credentials-onepassword
+  namespace: grafana
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: grafana-credentials
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/i5jugfy4ozpreex3jwwxouo44m"

--- a/kubernetes/clusters/production/onepassword-items/grafana--grafana-env-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/grafana--grafana-env-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: grafana-env-onepassword
+  namespace: grafana
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: grafana-env
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/pnqfucrgwhlmbt75eagrm3o2ka"

--- a/kubernetes/clusters/production/onepassword-items/home-assistant--home-assistant-secrets-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/home-assistant--home-assistant-secrets-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: home-assistant-secrets-onepassword
+  namespace: home-assistant
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: home-assistant-secrets
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/s24uuj6yxmelqkk66joxxmklui"

--- a/kubernetes/clusters/production/onepassword-items/immich--immich-postgres-user-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/immich--immich-postgres-user-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: immich-postgres-user-onepassword
+  namespace: immich
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: immich-postgres-user
+type: kubernetes.io/basic-auth
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/h3q5utoixi5xglph3l4idzg6xy"

--- a/kubernetes/clusters/production/onepassword-items/immich--immich-secrets-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/immich--immich-secrets-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: immich-secrets-onepassword
+  namespace: immich
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: immich-secrets
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/qlemiotzsx3iq6gkxjkoi5d7ha"

--- a/kubernetes/clusters/production/onepassword-items/jellyfin--jellyfin-secrets-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/jellyfin--jellyfin-secrets-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: jellyfin-secrets-onepassword
+  namespace: jellyfin
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: jellyfin-secrets
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/d5j2cavjfkcsdzwhcph7yr6ooy"

--- a/kubernetes/clusters/production/onepassword-items/kustomization.yaml
+++ b/kubernetes/clusters/production/onepassword-items/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - access-broker--access-broker-secret-onepassword.yaml
+  - authentik--authentik-secrets-onepassword.yaml
+  - cert-manager--cloudflare-api-token-onepassword.yaml
+  - cloudflare--tunnel-credentials-onepassword.yaml
+  - flux-system--homelab-private-deploy-key-onepassword.yaml
+  - foundryvtt--foundryvtt-secret-onepassword.yaml
+  - grafana--grafana-credentials-onepassword.yaml
+  - grafana--grafana-env-onepassword.yaml
+  - home-assistant--home-assistant-secrets-onepassword.yaml
+  - immich--immich-postgres-user-onepassword.yaml
+  - immich--immich-secrets-onepassword.yaml
+  - jellyfin--jellyfin-secrets-onepassword.yaml
+  - monitoring--grafana-env-onepassword.yaml
+  - pihole--pihole-admin-password-onepassword.yaml
+  - renovate--renovate-secret-onepassword.yaml
+  - valheim--valheim-secret-onepassword.yaml
+  - wireguard--wireguard-env-onepassword.yaml

--- a/kubernetes/clusters/production/onepassword-items/monitoring--grafana-env-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/monitoring--grafana-env-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: grafana-env-onepassword
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: grafana-env
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/36g65vt736wxnnolxti7nc2pda"

--- a/kubernetes/clusters/production/onepassword-items/pihole--pihole-admin-password-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/pihole--pihole-admin-password-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: pihole-admin-password-onepassword
+  namespace: pihole
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: pihole-admin-password
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/cqqdpqdgsj2kdkvibtluvypm4a"

--- a/kubernetes/clusters/production/onepassword-items/renovate--renovate-secret-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/renovate--renovate-secret-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: renovate-secret-onepassword
+  namespace: renovate
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: renovate-secret
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/wwb7bwungpareqqwngybtdi6t4"

--- a/kubernetes/clusters/production/onepassword-items/valheim--valheim-secret-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/valheim--valheim-secret-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: valheim-secret-onepassword
+  namespace: valheim
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: valheim-secret
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/rluc4ijztvc2ublf7ik5pgm7xa"

--- a/kubernetes/clusters/production/onepassword-items/wireguard--wireguard-env-onepassword.yaml
+++ b/kubernetes/clusters/production/onepassword-items/wireguard--wireguard-env-onepassword.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: wireguard-env-onepassword
+  namespace: wireguard
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: wireguard-env
+type: Opaque
+spec:
+  itemPath: "vaults/ydtsmbjna24k5of6ga23boczuu/items/24ej7c422dfx2j6fi6xl4nvkfy"

--- a/specs/onepassword-dual-publish/checklists/requirements.md
+++ b/specs/onepassword-dual-publish/checklists/requirements.md
@@ -1,0 +1,10 @@
+# Requirements Checklist: 1Password Dual Publish
+
+- [x] Inventory distinguishes 16 encrypted files from 17 Secret resources.
+- [x] Every namespace/name/type/key schema is explicit and live-verified.
+- [x] Grafana broken-MAC recovery source is explicit.
+- [x] IDs-only Git representation and production-only scope are explicit.
+- [x] No-output byte parity and failure classes are measurable.
+- [x] SOPS and consumer exclusions are explicit.
+- [x] Deletion semantics and external item prerequisites are explicit.
+- [x] No clarification marker remains.

--- a/specs/onepassword-dual-publish/contracts/item-resolver.md
+++ b/specs/onepassword-dual-publish/contracts/item-resolver.md
@@ -1,0 +1,7 @@
+# Item Resolver Contract
+
+- Input: authenticated user `op` session, vault title, static production inventory, output directory.
+- Captured data: vault/item JSON in process memory only; no values are logged.
+- Validation: one unique item per title, valid vault/item IDs, no URLs/files, and exact set of non-empty field labels.
+- Output: `OnePasswordItem` YAML and Kustomization containing namespace, generated name, Secret type, vault ID, and item ID only.
+- Failure: reports only item title and mismatch class/count; never a value or field value.

--- a/specs/onepassword-dual-publish/contracts/parity.md
+++ b/specs/onepassword-dual-publish/contracts/parity.md
@@ -1,0 +1,7 @@
+# Secret Parity Contract
+
+- Read legacy and generated Secret JSON with kubectl into captured memory.
+- Require generated `OnePasswordItem Ready=True` before comparison.
+- Compare Secret type, exact decoded key set, and each decoded byte string using constant-time comparison.
+- Success output: one pair-level PASS line and final `17/17` count.
+- Failure output: namespace/pair plus mismatch class/count only; never key names, base64, decoded bytes, or captured kubectl output.

--- a/specs/onepassword-dual-publish/data-model.md
+++ b/specs/onepassword-dual-publish/data-model.md
@@ -1,0 +1,26 @@
+# Data Model: onepassword-dual-publish
+
+## Inventory Entry
+
+- Namespace and legacy Secret name
+- Generated Secret/`OnePasswordItem` name with `-onepassword`
+- Unique item title `k8s--<namespace>--<legacy-name>`
+- Secret type
+- Sorted exact expected key labels
+
+No value, vault ID, or item ID is stored in the inventory.
+
+## Resolved Resource
+
+- Same namespace/generated name/type
+- Labels linking the legacy identity
+- `spec.itemPath` containing only production vault ID and item ID
+
+The generated Secret is owned by the `OnePasswordItem`; deletion cascades.
+
+## Parity State
+
+- `OnePasswordItem Ready=True`
+- Legacy and generated Secret types equal inventory type
+- Both key sets equal inventory key set
+- Decoded value bytes compare equal for every key

--- a/specs/onepassword-dual-publish/evidence.md
+++ b/specs/onepassword-dual-publish/evidence.md
@@ -1,0 +1,48 @@
+# Evidence: onepassword-dual-publish
+
+## Prior Gate
+
+- Production Flux/operator revision: `main@sha1:6844af5ccc5bbd0d06b2120140915dabf0ecb0db`, Ready.
+- Production rotation: Secret resourceVersion `116799548 -> 116801968`; pod UID `982d500a-39e6-4980-858c-ed4940b953b9 -> 407f0ea8-1043-4c1b-b603-1eb4890a676f`; namespace removed.
+- Operator alert: deployed healthy expression `0`; missing-Deployment expression `1`.
+- Item alert: isolated invalid item reached Ready=False and query `1`; disposable namespace removed before ten minutes.
+
+## Inventory Discovery
+
+- Encrypted files: 16.
+- Kubernetes Secret documents: 17; Immich contains two.
+- Live schemas/types: 17/17 read successfully without value output.
+- `kubernetes/infra/monitoring/grafana/secret.yaml`: committed SOPS MAC mismatch confirmed; live Secret is the recovery authority.
+
+## Implementation Validation
+
+- Authenticated item validation: `Production 1Password items validated: 17 ID-only resources`.
+- Authenticated manifest generation: `Production 1Password items rendered: 17 ID-only resources`.
+- ID-only safety scan: 17/17 resources contain only valid 26-character vault/item IDs; no `ENC[` payload appears.
+- Direct item Kustomization render: 17 `OnePasswordItem` resources.
+- Production and development cluster entrypoints: render PASS; the production root alone references `onepassword-items.yaml`.
+- Resolver/parity unit tests: 8 PASS.
+- Codex harness: 81 PASS.
+- Architecture generator: write/check PASS.
+- Direct-auth operator chart policy and production-foundation policy: PASS.
+- Full pre-commit: PASS, including YAML, Kubernetes validation, generated architecture, production policy, and migration safety tooling.
+- SOPS/consumer diff assertion: zero encrypted Secret/Grafana environment manifests and zero consumer paths changed.
+- Pinned kubeconform 0.7.0 over production, development, and direct item renders: 139 resources, 44 valid, 0 invalid, 0 errors, 95 missing-schema skips.
+- Rebased onto prerequisite merge `cdc8927b98deeb932dcf6edd05c35d116d6cadac`; the active Spec Kit pointer remains `onepassword-dual-publish`, and generated architecture contains both the Jellyfin SOPS correction and production item activation.
+
+## Discovered Prerequisite
+
+- Before correction, the live decoded `jellyfin/jellyfin-secrets` value began with SOPS ciphertext because `app-jellyfin` lacked a Flux `decryption` block.
+- A no-output comparison confirmed the committed Jellyfin and Authentik SOPS fields decrypt to identical plaintext.
+- The Jellyfin 1Password item therefore uses the decoded live `authentik/authentik-secrets` field as the correct shared OAuth credential, never the live Jellyfin ciphertext.
+- Prerequisite PR #390 merged as `cdc8927b98deeb932dcf6edd05c35d116d6cadac`.
+- Production Flux source and `app-jellyfin` applied that exact revision; the live resource uses `sops`/`sops-age`.
+- No-output live comparison passed: Jellyfin and Authentik OAuth bytes are equal and the Jellyfin value is not an SOPS envelope.
+- Jellyfin HelmRelease remained Ready and Deployment rollout status was complete.
+
+## PR State
+
+- Branch: `codex/onepassword-dual-publish`
+- Commit subject: `feat: publish 1password secret mirrors`
+- Draft PR: #393
+- Post-merge Ready/parity acceptance remains pending by design.

--- a/specs/onepassword-dual-publish/plan.md
+++ b/specs/onepassword-dual-publish/plan.md
@@ -1,0 +1,43 @@
+# Implementation Plan: onepassword-dual-publish
+
+**Branch**: `codex/onepassword-dual-publish` | **Date**: 2026-08-09
+
+## Technical Context
+
+**SDD Tier**: full/high-risk
+**Workflow Risk Tier**: high
+**Primary Areas**: 1Password item metadata, Kubernetes/Flux, secret-safe tooling, production validation
+**Smoke Strategy**: exact-main Flux reconciliation followed by Ready and 17-pair byte-parity validation; no consumer smoke because consumers do not change
+**Fanout**: none
+**Exceptions**: The source inventory uses live Kubernetes metadata because Grafana SOPS MAC validation is broken. Values are never printed or persisted by tooling.
+
+## Design
+
+1. Store the 17 non-secret schemas in `tools/onepassword/production_items.json`.
+2. Test and implement an authenticated resolver that verifies item metadata and writes ID-only manifests under `kubernetes/clusters/production/onepassword-items/`.
+3. Add one production Flux Kustomization depending on `onepassword-operator` and every namespace owner. Production-only placement prevents the development service account from attempting production item IDs.
+4. Test and implement a Kubernetes parity validator that reads both Secret objects into memory, compares type/key set/decoded bytes, and emits pair-level status only.
+5. Reconcile the exact merged revision and require every item Ready plus 17/17 parity.
+
+## Constitution Check
+
+- [x] GitOps owns all durable Kubernetes resources.
+- [x] Production foundation and rotation passed before dual publication.
+- [x] SOPS and all consumers remain unchanged.
+- [x] No Gateway, storage, or Talos behavior changes.
+- [x] Secret values are excluded from Git, logs, arguments, and evidence.
+- [x] Dedicated branch/worktree/PR used.
+
+## TDD and Validation
+
+- Unit tests first for inventory completeness, ID-only rendering, extra/missing fields, no-output failure handling, type/key/byte parity, and sentinel redaction.
+- Render development and production roots; assert no `OnePasswordItem` in development.
+- Run kubeconform, policy, architecture, harness, and full pre-commit.
+- Diff-check 16 encrypted files, 17 decryption blocks, and all consumer references.
+- Live: resolve items, reconcile exact main, wait 17 Ready items, run parity, record only counts/status/revisions.
+
+## Research Decisions
+
+- Official operator source maps non-empty item field labels directly to Secret keys, preserves Kubernetes-valid dots/underscores/uppercase, and supports `OnePasswordItem.type`.
+- Secure Note items with empty notes and exact custom fields avoid unintended built-in Login fields.
+- IDs in Git avoid ambiguous duplicate titles; item titles remain an operator-facing convention only.

--- a/specs/onepassword-dual-publish/quickstart.md
+++ b/specs/onepassword-dual-publish/quickstart.md
@@ -1,0 +1,10 @@
+# Quickstart: onepassword-dual-publish
+
+1. Review `tools/onepassword/production_items.json`; create all 17 empty-note Secure Notes in `cluster production` with exactly the listed populated fields.
+2. Use live Secret bytes, including live-only recovery for `grafana/grafana-credentials`; never paste values into chat or command arguments.
+3. Run `render_production_items.py --check-only` from an authenticated user session.
+4. Run the resolver without `--check-only` to write ID-only manifests.
+5. Complete local validation and merge the gated PR without consumer changes.
+6. Reconcile exact main, wait for 17 Ready items, and run `validate_secret_parity.py` for 17/17 PASS.
+
+Stop on any mismatch. Do not delete a durable item resource as a retry mechanism.

--- a/specs/onepassword-dual-publish/research.md
+++ b/specs/onepassword-dual-publish/research.md
@@ -1,0 +1,25 @@
+# Research: onepassword-dual-publish
+
+## Resource count
+
+**Decision**: Migrate 17 Secret resources represented by 16 encrypted files.
+
+**Evidence**: `kubernetes/apps/immich/base/secret.yaml` contains two `kind: Secret` documents. Live API metadata confirms both and their distinct schemas.
+
+## Field mapping
+
+**Decision**: Use empty Secure Notes with exact non-empty custom field labels.
+
+**Evidence**: Official operator source `BuildKubernetesSecretData` converts non-empty item fields to Secret data by field label, preserves labels already valid under Kubernetes `[-._a-zA-Z0-9]+`, skips empty values, and accepts a `OnePasswordItem.type`. Dotted and uppercase inventory keys are therefore supported. Extra populated built-ins would become extra Secret keys and are rejected by the resolver.
+
+## Production-only placement
+
+**Decision**: Keep all application items in a production cluster path and reconcile them through one production Flux Kustomization after namespace owners.
+
+**Rationale**: Shared app paths are also used by development branch validation. A production item ID there would be unreadable by the isolated development service account.
+
+## Value recovery
+
+**Decision**: Treat live Kubernetes Secrets as the byte authority for initial item population and parity; specifically require live recovery for Grafana credentials.
+
+**Rationale**: This avoids stale source assumptions and handles the confirmed Grafana SOPS MAC mismatch. Tooling never prints or persists values.

--- a/specs/onepassword-dual-publish/spec.md
+++ b/specs/onepassword-dual-publish/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: 1Password Dual Publish
+
+**Feature Branch**: `codex/onepassword-dual-publish`
+**Created**: 2026-08-09
+**Status**: Approved
+**Risk Tier**: high
+
+## Summary
+
+Create production-vault items matching every legacy SOPS-managed Kubernetes Secret object, then publish parallel `OnePasswordItem` resources whose generated Secrets use a `-onepassword` suffix. Require exact type, key-set, and byte parity before any consumer cutover. Existing SOPS resources and consumers remain unchanged.
+
+## Human Gate Status
+
+The user supplied and approved this as phase 3 of the migration. Clarification found one source-count correction: the repository contains 16 encrypted files but 17 `kind: Secret` documents because the Immich file contains two Secrets. All 17 objects are in scope; omitting one would violate the requested complete dual publication.
+
+## In Scope
+
+- Maintain a non-secret inventory of 17 legacy namespace/name/type/key schemas and corresponding 1Password item titles.
+- Create the 17 items out of band in `cluster production`, with exact non-empty field labels and values.
+- Recover `grafana/grafana-credentials` from the live Kubernetes Secret because its committed SOPS document fails MAC validation.
+- Resolve vault/item IDs from authenticated `op` metadata and generate Git-tracked `OnePasswordItem` resources containing IDs only.
+- Generate parallel Secrets named `<legacy-name>-onepassword`.
+- Reconcile all items only in production after their namespace owners and the operator are Ready.
+- Validate `Ready=True`, Secret type, exact key set, and byte-for-byte data parity without printing names of mismatched keys or any values.
+
+## Out of Scope
+
+- Changing a workload, issuer, Flux source, or other consumer to the generated Secret.
+- Removing or editing a SOPS Secret, decryption block, Age key, or SOPS tooling.
+- Creating development-vault application items; development cutover items belong to phase 4.
+- Terraform/provider credentials.
+
+## User Stories
+
+### P1 - Build Exact Item Inventory
+
+As an operator, I can see every required item title and field label without exposing values, including both Immich Secrets and the live-authoritative Grafana credentials.
+
+**Acceptance**: Inventory contains 17 unique namespace/name pairs, unique item titles, valid generated names, exact live key schemas, and Secret types.
+
+### P2 - Publish Parallel Secrets
+
+As an operator, I can resolve authenticated 1Password item IDs into Git-tracked `OnePasswordItem` resources without names or values in item paths.
+
+**Acceptance**: All resources use the production vault/item IDs, a `-onepassword` name, correct namespace/type, and reconcile `Ready=True`; no consumer changes.
+
+### P3 - Prove Parity Without Output
+
+As a reviewer, I can run one validator that proves all legacy/generated pairs have identical types, key sets, and decoded bytes while reporting only pair-level PASS or mismatch class/count.
+
+**Acceptance**: All 17 pairs pass. Captured output contains no fixture or live Secret value, base64 payload, or mismatched key name.
+
+## Requirements
+
+- **FR-001**: The migration inventory MUST cover 16 encrypted files and all 17 Secret documents.
+- **FR-002**: Item titles MUST be `k8s--<namespace>--<legacy-name>` and contain exactly the expected non-empty fields, with no populated note, URL, or extra field.
+- **FR-003**: Git-tracked item paths MUST use vault and item IDs, never titles.
+- **FR-004**: Generated Secret names MUST append `-onepassword` and MUST NOT collide with legacy names.
+- **FR-005**: `immich/immich-postgres-user-onepassword` MUST use type `kubernetes.io/basic-auth`; every other generated Secret MUST use `Opaque`.
+- **FR-006**: The resolver MUST capture `op` JSON without echoing it, validate IDs/field labels, and write only non-secret manifests.
+- **FR-007**: The parity validator MUST compare decoded bytes with constant-time comparison and suppress captured Kubernetes output on success and failure.
+- **FR-008**: A missing pair, non-Ready item, type mismatch, key-set mismatch, or any byte mismatch MUST fail acceptance.
+- **FR-009**: The production Flux Kustomization MUST depend on the operator and namespace-owning Kustomizations, prune/wait, and change no consumer reference.
+- **FR-010**: Deleting a durable `OnePasswordItem` MUST be documented as destructive because it deletes the generated Secret.
+- **FR-011**: All existing 17 SOPS decryption blocks and 16 encrypted files MUST remain unchanged.
+
+## Edge Cases
+
+- Duplicate item titles, missing/empty fields, populated default notes, URLs/files, invalid IDs, or extra fields block manifest generation.
+- Dotted keys such as `credentials.json`, `secrets.yaml`, and `immich-config.yaml` remain exact; the operator supports Kubernetes-valid `[-._a-zA-Z0-9]+` labels.
+- Multiline values and trailing newlines are byte-significant and caught by parity.
+- Grafana committed decryption failure does not permit using stale ciphertext; its live Secret is authoritative for value recovery and parity.
+- If any namespace dependency is unready, dual publication waits rather than applying a partial set.
+
+## Success Criteria
+
+- **SC-001**: Inventory validation reports 17 unique, complete entries.
+- **SC-002**: Both cluster entrypoints render/conform and development receives no production item.
+- **SC-003**: All 17 production items report Ready and all 17 generated Secrets exist.
+- **SC-004**: No-output parity reports 17/17 PASS.
+- **SC-005**: Git diff changes zero SOPS documents, decryption blocks, and consumer Secret references.
+
+## Assumptions
+
+- The authenticated human account can create Secure Note items in `cluster production`; item notes remain empty and all credential data is stored in custom fields whose labels exactly match the inventory.
+- The production service account can read every created item.
+- Operator 1.12.0 behavior is authoritative: non-empty item fields become Secret data keys, valid dotted/uppercase labels are preserved, empty fields are skipped, and `OnePasswordItem.type` controls Secret type.

--- a/specs/onepassword-dual-publish/tasks.md
+++ b/specs/onepassword-dual-publish/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: onepassword-dual-publish
+
+- [x] T001 Establish the branch/worktree and record the completed production-foundation gate.
+- [x] T002 Inventory live namespace/name/type/key schemas and resolve 16-file versus 17-resource scope.
+- [x] T003 Complete specification, plan, checklist, research, and contracts with no unresolved ambiguity.
+- [x] T004 Add failing inventory/resolver tests, including ID-only output and exact non-empty field validation.
+- [x] T005 Implement the non-secret inventory and authenticated item resolver/manifest generator.
+- [x] T006 Add failing no-output parity tests for types, key sets, decoded bytes, errors, and redaction.
+- [x] T007 Implement the 17-pair Kubernetes parity validator.
+- [x] T008 Add the production-only Flux Kustomization and generated ID-only item resources after item creation.
+- [x] T009 Add operator runbook instructions for manual item population, Grafana live recovery, resolver, parity, and destructive deletion.
+- [x] T010 Run local render/schema/policy/architecture/harness/pre-commit and unchanged-SOPS/consumer checks.
+- [x] T011 Create/validate the 17 production items without output, generate manifests, and open the gated PR.
+- [ ] T012 After merge, reconcile exact main, require 17 Ready items and 17/17 byte parity, then converge evidence.

--- a/tools/onepassword/production_items.json
+++ b/tools/onepassword/production_items.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "vault": "cluster production",
+  "items": [
+    {"namespace":"access-broker","legacy_name":"access-broker-secret","generated_name":"access-broker-secret-onepassword","item_title":"k8s--access-broker--access-broker-secret","type":"Opaque","keys":["AUTHENTIK_TOKEN","DISCORD_APP_ID","DISCORD_CLIENT_SECRET","DISCORD_PUBLIC_KEY","WGEASY_PASSWORD"]},
+    {"namespace":"cloudflare","legacy_name":"tunnel-credentials","generated_name":"tunnel-credentials-onepassword","item_title":"k8s--cloudflare--tunnel-credentials","type":"Opaque","keys":["credentials.json"]},
+    {"namespace":"foundryvtt","legacy_name":"foundryvtt-secret","generated_name":"foundryvtt-secret-onepassword","item_title":"k8s--foundryvtt--foundryvtt-secret","type":"Opaque","keys":["FOUNDRY_ADMIN_KEY","FOUNDRY_LICENSE_KEY","FOUNDRY_PASSWORD","FOUNDRY_USERNAME"]},
+    {"namespace":"home-assistant","legacy_name":"home-assistant-secrets","generated_name":"home-assistant-secrets-onepassword","item_title":"k8s--home-assistant--home-assistant-secrets","type":"Opaque","keys":["secrets.yaml"]},
+    {"namespace":"immich","legacy_name":"immich-secrets","generated_name":"immich-secrets-onepassword","item_title":"k8s--immich--immich-secrets","type":"Opaque","keys":["immich-config.yaml"]},
+    {"namespace":"immich","legacy_name":"immich-postgres-user","generated_name":"immich-postgres-user-onepassword","item_title":"k8s--immich--immich-postgres-user","type":"kubernetes.io/basic-auth","keys":["password","username"]},
+    {"namespace":"jellyfin","legacy_name":"jellyfin-secrets","generated_name":"jellyfin-secrets-onepassword","item_title":"k8s--jellyfin--jellyfin-secrets","type":"Opaque","keys":["JELLYFIN_OAUTH_CLIENT_SECRET"]},
+    {"namespace":"pihole","legacy_name":"pihole-admin-password","generated_name":"pihole-admin-password-onepassword","item_title":"k8s--pihole--pihole-admin-password","type":"Opaque","keys":["password"]},
+    {"namespace":"renovate","legacy_name":"renovate-secret","generated_name":"renovate-secret-onepassword","item_title":"k8s--renovate--renovate-secret","type":"Opaque","keys":["GITHUB_COM_TOKEN","RENOVATE_TOKEN"]},
+    {"namespace":"valheim","legacy_name":"valheim-secret","generated_name":"valheim-secret-onepassword","item_title":"k8s--valheim--valheim-secret","type":"Opaque","keys":["password"]},
+    {"namespace":"flux-system","legacy_name":"homelab-private-deploy-key","generated_name":"homelab-private-deploy-key-onepassword","item_title":"k8s--flux-system--homelab-private-deploy-key","type":"Opaque","keys":["identity","known_hosts"]},
+    {"namespace":"authentik","legacy_name":"authentik-secrets","generated_name":"authentik-secrets-onepassword","item_title":"k8s--authentik--authentik-secrets","type":"Opaque","keys":["AUTHENTIK_BOOTSTRAP_EMAIL","AUTHENTIK_BOOTSTRAP_PASSWORD","AUTHENTIK_BOOTSTRAP_TOKEN","AUTHENTIK_POSTGRESQL__PASSWORD","AUTHENTIK_SECRET_KEY","GRAFANA_OAUTH_CLIENT_SECRET","IMMICH_OAUTH_CLIENT_SECRET","JELLYFIN_OAUTH_CLIENT_SECRET","SYNOLOGY_OAUTH_CLIENT_SECRET","password"]},
+    {"namespace":"cert-manager","legacy_name":"cloudflare-api-token","generated_name":"cloudflare-api-token-onepassword","item_title":"k8s--cert-manager--cloudflare-api-token","type":"Opaque","keys":["token"]},
+    {"namespace":"grafana","legacy_name":"grafana-env","generated_name":"grafana-env-onepassword","item_title":"k8s--grafana--grafana-env","type":"Opaque","keys":["DISCORD_WEBHOOK_URL"]},
+    {"namespace":"grafana","legacy_name":"grafana-credentials","generated_name":"grafana-credentials-onepassword","item_title":"k8s--grafana--grafana-credentials","type":"Opaque","keys":["admin-password","admin-user","oauth-client-secret"]},
+    {"namespace":"monitoring","legacy_name":"grafana-env","generated_name":"grafana-env-onepassword","item_title":"k8s--monitoring--grafana-env","type":"Opaque","keys":["DISCORD_WEBHOOK_URL"]},
+    {"namespace":"wireguard","legacy_name":"wireguard-env","generated_name":"wireguard-env-onepassword","item_title":"k8s--wireguard--wireguard-env","type":"Opaque","keys":["WG_HOST","WG_PORT"]}
+  ]
+}

--- a/tools/onepassword/render_production_items.py
+++ b/tools/onepassword/render_production_items.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INVENTORY = Path(__file__).with_name("production_items.json")
+DEFAULT_OUTPUT = REPO_ROOT / "kubernetes/clusters/production/onepassword-items"
+ID_PATTERN = re.compile(r"^[a-z0-9]{26}$")
+NAME_PATTERN = re.compile(r"^[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?$")
+KEY_PATTERN = re.compile(r"^[-._a-zA-Z0-9]+$")
+
+
+def load_inventory(path: Path) -> dict[str, Any]:
+    inventory = json.loads(path.read_text(encoding="utf-8"))
+    items = inventory.get("items")
+    if inventory.get("schema_version") != 1 or not isinstance(items, list):
+        raise ValueError("inventory schema is invalid")
+    if len(items) != 17:
+        raise ValueError(f"inventory must contain 17 items, found {len(items)}")
+
+    pairs: set[tuple[str, str]] = set()
+    generated: set[tuple[str, str]] = set()
+    titles: set[str] = set()
+    for item in items:
+        pair = (item["namespace"], item["legacy_name"])
+        generated_pair = (item["namespace"], item["generated_name"])
+        title = item["item_title"]
+        expected_title = f"k8s--{item['namespace']}--{item['legacy_name']}"
+        if pair in pairs or generated_pair in generated or title in titles:
+            raise ValueError("inventory contains a duplicate identity")
+        pairs.add(pair)
+        generated.add(generated_pair)
+        titles.add(title)
+        if title != expected_title:
+            raise ValueError(f"item title convention mismatch for {item['namespace']}/{item['legacy_name']}")
+        if item["generated_name"] != f"{item['legacy_name']}-onepassword":
+            raise ValueError(f"generated name convention mismatch for {item['namespace']}/{item['legacy_name']}")
+        if not NAME_PATTERN.fullmatch(item["namespace"]) or not NAME_PATTERN.fullmatch(item["generated_name"]):
+            raise ValueError(f"invalid Kubernetes identity for {title}")
+        keys = item.get("keys")
+        if not isinstance(keys, list) or not keys or keys != sorted(set(keys)):
+            raise ValueError(f"keys must be a non-empty sorted unique list for {title}")
+        if any(not KEY_PATTERN.fullmatch(key) for key in keys):
+            raise ValueError(f"invalid Kubernetes Secret key in inventory for {title}")
+        if item["type"] not in {"Opaque", "kubernetes.io/basic-auth"}:
+            raise ValueError(f"unsupported Secret type for {title}")
+    return inventory
+
+
+def validate_id(kind: str, value: Any) -> str:
+    if not isinstance(value, str) or not ID_PATTERN.fullmatch(value):
+        raise ValueError(f"{kind} ID is invalid")
+    return value
+
+
+def validate_item_metadata(title: str, item_json: dict[str, Any], expected: set[str]) -> str:
+    item_id = validate_id("item", item_json.get("id"))
+    labels: list[str] = []
+    for field in item_json.get("fields") or []:
+        value = field.get("value")
+        if value is None or value == "":
+            continue
+        label = field.get("label") or field.get("id")
+        if not isinstance(label, str):
+            raise ValueError(f"field label is invalid for {title}")
+        labels.append(label)
+    populated_urls = [url for url in item_json.get("urls") or [] if url.get("href")]
+    files = item_json.get("files") or []
+    if populated_urls or files:
+        raise ValueError(f"URL/file fields are not allowed for {title}")
+    if len(labels) != len(set(labels)):
+        raise ValueError(f"duplicate non-empty field label for {title}")
+    if set(labels) != expected:
+        raise ValueError(
+            f"field set mismatch for {title}: expected {len(expected)}, observed {len(labels)}"
+        )
+    return item_id
+
+
+def render_item(item: dict[str, Any], vault_id: str, item_id: str) -> str:
+    validate_id("vault", vault_id)
+    validate_id("item", item_id)
+    return f'''---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {item["generated_name"]}
+  namespace: {item["namespace"]}
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: {item["legacy_name"]}
+type: {item["type"]}
+spec:
+  itemPath: "vaults/{vault_id}/items/{item_id}"
+'''
+
+
+def run_json(command: list[str], *, failure_context: str | None = None) -> dict[str, Any]:
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        context = failure_context or f"{command[0]} {command[1]} command failed"
+        raise RuntimeError(f"{context}; captured command output suppressed")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"command returned invalid JSON: {command[0]} {command[1]}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"command returned unexpected JSON: {command[0]} {command[1]}")
+    return value
+
+
+def resolve(inventory: dict[str, Any], vault: str) -> tuple[str, list[tuple[dict[str, Any], str]]]:
+    if shutil.which("op") is None:
+        raise RuntimeError("1Password CLI is required")
+    vault_json = run_json(["op", "vault", "get", vault, "--format=json"])
+    vault_id = validate_id("vault", vault_json.get("id"))
+    resolved: list[tuple[dict[str, Any], str]] = []
+    for item in inventory["items"]:
+        title = item["item_title"]
+        item_json = run_json(
+            ["op", "item", "get", title, "--vault", vault, "--format=json"],
+            failure_context=f"item lookup failed for {title}",
+        )
+        item_id = validate_item_metadata(title, item_json, set(item["keys"]))
+        resolved.append((item, item_id))
+    return vault_id, resolved
+
+
+def write_manifests(output_dir: Path, vault_id: str, resolved: list[tuple[dict[str, Any], str]]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    expected_files: set[str] = set()
+    for item, item_id in resolved:
+        filename = f"{item['namespace']}--{item['generated_name']}.yaml"
+        expected_files.add(filename)
+        (output_dir / filename).write_text(render_item(item, vault_id, item_id), encoding="utf-8")
+    expected_files.add("kustomization.yaml")
+    unexpected = {
+        path.name for path in output_dir.glob("*.yaml") if path.name not in expected_files
+    }
+    if unexpected:
+        raise RuntimeError(f"output directory contains {len(unexpected)} unexpected YAML file(s)")
+    resources = "\n".join(
+        f"  - {name}" for name in sorted(expected_files - {"kustomization.yaml"})
+    )
+    (output_dir / "kustomization.yaml").write_text(
+        "---\napiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n"
+        + resources
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Resolve production 1Password item IDs and render ID-only Kubernetes resources")
+    parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument("--vault", default="cluster production")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        inventory = load_inventory(args.inventory)
+        vault_id, resolved = resolve(inventory, args.vault)
+        if not args.check_only:
+            write_manifests(args.output_dir, vault_id, resolved)
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"1Password item resolution failed: {error}", file=sys.stderr)
+        return 1
+    action = "validated" if args.check_only else "rendered"
+    print(f"Production 1Password items {action}: {len(resolved)} ID-only resources")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/onepassword/tests/test_render_production_items.py
+++ b/tools/onepassword/tests/test_render_production_items.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools/onepassword/render_production_items.py"
+INVENTORY_PATH = REPO_ROOT / "tools/onepassword/production_items.json"
+
+
+class RenderProductionItemsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location("render_production_items", MODULE_PATH)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load resolver")
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    def test_production_inventory_has_all_seventeen_unique_pairs(self) -> None:
+        inventory = self.module.load_inventory(INVENTORY_PATH)
+        self.assertEqual(17, len(inventory["items"]))
+        pairs = {(item["namespace"], item["legacy_name"]) for item in inventory["items"]}
+        self.assertEqual(17, len(pairs))
+
+    def test_render_contains_ids_and_never_values_or_titles_in_item_path(self) -> None:
+        sentinel = "resolver-secret-sentinel"
+        item = {
+            "namespace": "example",
+            "legacy_name": "legacy",
+            "generated_name": "legacy-onepassword",
+            "item_title": "k8s--example--legacy",
+            "type": "Opaque",
+            "keys": ["password"],
+        }
+        rendered = self.module.render_item(
+            item,
+            vault_id="a" * 26,
+            item_id="b" * 26,
+        )
+        self.assertIn("vaults/" + "a" * 26 + "/items/" + "b" * 26, rendered)
+        self.assertNotIn(item["item_title"], rendered)
+        self.assertNotIn(sentinel, rendered)
+
+    def test_item_validation_rejects_extra_nonempty_field_without_printing_value(self) -> None:
+        sentinel = "extra-field-secret-sentinel"
+        item_json = {
+            "id": "b" * 26,
+            "fields": [
+                {"id": "password", "label": "password", "value": "expected"},
+                {"id": "extra", "label": "extra-key", "value": sentinel},
+            ],
+        }
+        with self.assertRaisesRegex(ValueError, "field set mismatch") as raised:
+            self.module.validate_item_metadata(
+                "k8s--example--legacy", item_json, {"password"}
+            )
+        self.assertNotIn(sentinel, str(raised.exception))
+        self.assertNotIn("extra-key", str(raised.exception))
+
+    def test_writer_emits_only_id_only_resources_and_kustomization(self) -> None:
+        item = {
+            "namespace": "example",
+            "legacy_name": "legacy",
+            "generated_name": "legacy-onepassword",
+            "item_title": "k8s--example--legacy",
+            "type": "Opaque",
+            "keys": ["password"],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir)
+            self.module.write_manifests(output, "a" * 26, [(item, "b" * 26)])
+            manifest = (output / "example--legacy-onepassword.yaml").read_text(
+                encoding="utf-8"
+            )
+            kustomization = (output / "kustomization.yaml").read_text(
+                encoding="utf-8"
+            )
+        self.assertIn('itemPath: "vaults/' + "a" * 26 + "/items/" + "b" * 26 + '"', manifest)
+        self.assertNotIn(item["item_title"], manifest)
+        self.assertIn("example--legacy-onepassword.yaml", kustomization)
+
+    def test_failed_item_lookup_reports_title_without_captured_output(self) -> None:
+        sentinel = "op-error-secret-sentinel"
+        completed = subprocess.CompletedProcess(
+            args=["op", "item", "get"],
+            returncode=1,
+            stdout="",
+            stderr=sentinel,
+        )
+        with patch.object(self.module.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "item lookup failed for k8s--example--legacy",
+            ) as raised:
+                self.module.run_json(
+                    ["op", "item", "get", "k8s--example--legacy"],
+                    failure_context="item lookup failed for k8s--example--legacy",
+                )
+        self.assertNotIn(sentinel, str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/onepassword/tests/test_validate_secret_parity.py
+++ b/tools/onepassword/tests/test_validate_secret_parity.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import base64
+import contextlib
+import importlib.util
+import io
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools/onepassword/validate_secret_parity.py"
+
+
+class ValidateSecretParityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location("validate_secret_parity", MODULE_PATH)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load parity validator")
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    @staticmethod
+    def secret(values: dict[str, bytes], secret_type: str = "Opaque") -> dict:
+        return {
+            "type": secret_type,
+            "data": {
+                key: base64.b64encode(value).decode("ascii")
+                for key, value in values.items()
+            },
+        }
+
+    def test_exact_type_keys_and_bytes_pass(self) -> None:
+        legacy = self.secret({"password": b"same\nbytes"})
+        generated = self.secret({"password": b"same\nbytes"})
+        self.module.compare_pair(legacy, generated, {"password"}, "Opaque")
+
+    def test_byte_mismatch_names_neither_key_nor_values(self) -> None:
+        legacy_value = "legacy-secret-sentinel"
+        generated_value = "generated-secret-sentinel"
+        with self.assertRaisesRegex(ValueError, "byte mismatch") as raised:
+            self.module.compare_pair(
+                self.secret({"sensitive-key-name": legacy_value.encode()}),
+                self.secret({"sensitive-key-name": generated_value.encode()}),
+                {"sensitive-key-name"},
+                "Opaque",
+            )
+        message = str(raised.exception)
+        self.assertNotIn("sensitive-key-name", message)
+        self.assertNotIn(legacy_value, message)
+        self.assertNotIn(generated_value, message)
+
+    def test_key_set_mismatch_reports_count_only(self) -> None:
+        with self.assertRaisesRegex(ValueError, "key set mismatch") as raised:
+            self.module.compare_pair(
+                self.secret({"legacy-key": b"value"}),
+                self.secret({"generated-key": b"value"}),
+                {"legacy-key"},
+                "Opaque",
+            )
+        self.assertNotIn("legacy-key", str(raised.exception))
+        self.assertNotIn("generated-key", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/onepassword/validate_secret_parity.py
+++ b/tools/onepassword/validate_secret_parity.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hmac
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from render_production_items import DEFAULT_INVENTORY, load_inventory
+
+
+def decode_data(secret: dict[str, Any]) -> dict[str, bytes]:
+    encoded = secret.get("data") or {}
+    if not isinstance(encoded, dict):
+        raise ValueError("Secret data is invalid")
+    decoded: dict[str, bytes] = {}
+    for key, value in encoded.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("Secret data is invalid")
+        try:
+            decoded[key] = base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise ValueError("Secret data contains invalid base64") from error
+    return decoded
+
+
+def compare_pair(
+    legacy: dict[str, Any],
+    generated: dict[str, Any],
+    expected_keys: set[str],
+    expected_type: str,
+) -> None:
+    if legacy.get("type") != expected_type or generated.get("type") != expected_type:
+        raise ValueError("Secret type mismatch")
+    legacy_data = decode_data(legacy)
+    generated_data = decode_data(generated)
+    if set(legacy_data) != expected_keys or set(generated_data) != expected_keys:
+        raise ValueError(
+            "Secret key set mismatch: "
+            f"expected {len(expected_keys)}, legacy {len(legacy_data)}, generated {len(generated_data)}"
+        )
+    mismatches = sum(
+        not hmac.compare_digest(legacy_data[key], generated_data[key])
+        for key in expected_keys
+    )
+    if mismatches:
+        raise ValueError(f"Secret byte mismatch: {mismatches} value(s) differ")
+
+
+def run_json(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(command, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"command failed without displaying captured output: {command[0]} get")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"command returned invalid JSON: {command[0]} get") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"command returned unexpected JSON: {command[0]} get")
+    return value
+
+
+def is_ready(item: dict[str, Any]) -> bool:
+    return any(
+        condition.get("type") == "Ready" and condition.get("status") == "True"
+        for condition in item.get("status", {}).get("conditions", [])
+    )
+
+
+def validate_live(kubeconfig: Path, inventory: dict[str, Any]) -> None:
+    passed = 0
+    for item in inventory["items"]:
+        base = ["kubectl", "--kubeconfig", str(kubeconfig), "-n", item["namespace"], "get"]
+        opi = run_json(base + ["onepassworditem", item["generated_name"], "-o", "json"])
+        if not is_ready(opi):
+            raise ValueError(f"OnePasswordItem is not Ready for {item['namespace']}/{item['generated_name']}")
+        legacy = run_json(base + ["secret", item["legacy_name"], "-o", "json"])
+        generated = run_json(base + ["secret", item["generated_name"], "-o", "json"])
+        compare_pair(legacy, generated, set(item["keys"]), item["type"])
+        passed += 1
+        print(f"PASS {item['namespace']}/{item['legacy_name']} -> {item['generated_name']}")
+    print(f"Secret parity passed: {passed}/{len(inventory['items'])}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare legacy and 1Password-generated Kubernetes Secrets without displaying data")
+    parser.add_argument("--kubeconfig", type=Path, required=True)
+    parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        inventory = load_inventory(args.inventory)
+        validate_live(args.kubeconfig, inventory)
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"Secret parity failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add a non-secret inventory for all 17 Kubernetes Secret resources represented by the 16 SOPS files
- add authenticated tooling that validates 1Password item schemas and renders vault/item-ID-only `OnePasswordItem` resources
- publish 17 production-only parallel Secrets with the `-onepassword` suffix through one dependency-gated Flux Kustomization
- add a no-output validator for `Ready=True`, Secret type, exact key sets, and decoded byte parity
- add unit tests, CI/pre-commit coverage, migration safety guidance, and Spec Kit evidence

## Why

This is phase 3 of the SOPS-to-1Password migration. It allows SOPS and 1Password copies to coexist without changing a single consumer, so synchronization and exact byte parity can be proven before any cutover.

The inventory includes both Secret documents from the Immich file. Grafana's live Secret remains the value authority because its committed SOPS manifest has a known MAC failure.

## Safety

- Git contains only Kubernetes metadata plus 26-character vault/item IDs; no values, Base64, token, or SOPS payload is generated
- item fields were authenticated and validated as exactly 17 schemas before manifest generation
- existing encrypted Secret manifests, decryption configuration, and consumer references are unchanged by this PR
- development receives no production item resources
- deleting a `OnePasswordItem` is destructive because the operator deletes its generated Secret; the runbook calls this out explicitly
- prerequisite PR #390 corrected Jellyfin's missing SOPS decryption and production equality/non-envelope acceptance passed at exact revision `cdc8927b`

## Validation

- authenticated item validation: 17 ID-only resources
- direct item render: 17 `OnePasswordItem` resources
- kubeconform 0.7.0: 139 resources, 44 valid, 0 invalid, 0 errors, 95 missing-schema skips
- resolver/parity unit tests: 8 passed
- Codex harness: 81 passed
- production/development renders passed
- direct-auth chart and production-foundation policies passed
- generated architecture check passed
- full pre-commit passed
- SOPS and consumer diff-scope assertion passed

## Post-merge gate

Reconcile the exact merge revision, require all 17 items `Ready=True`, then run the no-output validator for 17/17 byte parity. No consumer cutover occurs in this PR.
