### PR TITLE
feat: cut over development secrets to 1Password

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/onepassword-rate-limit-fix"}
+{"feature_directory":"specs/onepassword-dev-cutover"}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,8 +80,8 @@ This document is generated for agentic repo navigation. It records relationships
 | `production` | `onepassword-operator` | `./kubernetes/infra/controllers/onepassword-operator` | `crds` | `(none)` | `no` |
 | `production` | `otel-collector` | `./kubernetes/infra/monitoring/otel-collector` | `crds`, `gateway` | `cluster-vars` | `no` |
 | `production` | `vpn` | `./kubernetes/infra/network/vpn` | `cilium`, `nfs-csi`, `gateway`, `authentik` | `cluster-vars` | `sops` |
-| `development` | `cert-manager` | `./kubernetes/infra/controllers/cert-manager` | `crds` | `cluster-vars` | `sops` |
-| `development` | `certs` | `./kubernetes/infra/network/certs` | `cert-manager`, `cilium` | `cluster-vars` | `no` |
+| `development` | `cert-manager` | `./kubernetes/infra/controllers/cert-manager-development` | `crds` | `cluster-vars` | `sops` |
+| `development` | `certs` | `./kubernetes/infra/network/certs-development` | `cert-manager`, `cilium` | `cluster-vars` | `no` |
 | `development` | `cilium` | `./kubernetes/infra/network/cilium` | `crds` | `cluster-vars` | `no` |
 | `development` | `cloudnative-pg` | `./kubernetes/infra/controllers/cloudnative-pg` | `local-path-provisioner` | `(none)` | `no` |
 | `development` | `crds` | `./kubernetes/infra/crds` | (none) | `cluster-vars` | `no` |
@@ -122,6 +122,7 @@ This document is generated for agentic repo navigation. It records relationships
 | --- | --- |
 | `kubernetes/infra/authentik` | `namespace.yaml`, `app.yaml`, `secret.yaml`, `httproute.yaml`, `referencegrant.yaml`, `blueprints` |
 | `kubernetes/infra/controllers/cert-manager` | `app.yaml`, `secret.yaml` |
+| `kubernetes/infra/controllers/cert-manager-development` | `../cert-manager`, `onepassword-item.yaml` |
 | `kubernetes/infra/controllers/cloudnative-pg` | `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/controllers/grafana-operator` | `namespace.yaml`, `app.yaml` |
 | `kubernetes/infra/controllers/intel-device-plugins/gpu` | `app.yaml` |
@@ -147,6 +148,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/infra/monitoring/pretty-discord-alerts` | `grafana-env.yaml`, `deployment.yaml`, `service.yaml` |
 | `kubernetes/infra/monitoring/snmp-exporter` | `repositories.yaml`, `deployment.yaml`, `service.yaml`, `servicemonitor.yaml` |
 | `kubernetes/infra/network/certs` | `./issuer.yaml` |
+| `kubernetes/infra/network/certs-development` | `../certs` |
 | `kubernetes/infra/network/cilium` | `app.yaml`, `announcement.yaml`, `ip-pool.yaml` |
 | `kubernetes/infra/network/gateway` | `./namespace.yaml`, `./certificate.yaml`, `./gateway-internal.yaml`, `./gateway-passthrough.yaml`, `./gateway-external.yaml`, `./gateway-external-passthrough.yaml`, `./https-redirect.yaml`, `./referencegrant.yaml` |
 | `kubernetes/infra/network` | `./cilium`, `./certs`, `./vpn`, `./gateway` |
@@ -163,7 +165,7 @@ This document is generated for agentic repo navigation. It records relationships
 | `kubernetes/apps/homepage/development` | `../base` |
 | `kubernetes/apps/homepage` | `base` |
 | `kubernetes/apps/immich/base` | `namespace.yaml`, `pvc.yaml`, `postgres.yaml`, `app.yaml`, `metrics-service.yaml`, `httproute.yaml`, `secret.yaml` |
-| `kubernetes/apps/immich/branch` | `../base` |
+| `kubernetes/apps/immich/branch` | `../base`, `onepassword-items/configuration.yaml`, `onepassword-items/postgres-user.yaml` |
 | `kubernetes/apps/immich` | `base` |
 | `kubernetes/apps/jellyfin/branch` | `jellyfin.yaml` |
 | `kubernetes/apps/jellyfin` | `./app.yaml`, `./pvc.yaml`, `./httproute.yaml`, `./secret.yaml`, `./sso-bootstrap.yaml` |

--- a/kubernetes/apps/immich/branch/kustomization.yaml
+++ b/kubernetes/apps/immich/branch/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 namespace: immich-${branch_slug}
 resources:
   - ../base
+  - onepassword-items/configuration.yaml
+  - onepassword-items/postgres-user.yaml
 patches:
   - target:
       kind: Namespace
@@ -50,6 +52,9 @@ patches:
       - op: replace
         path: /spec/storage/size
         value: 10Gi
+      - op: replace
+        path: /spec/bootstrap/initdb/secret/name
+        value: immich-postgres-user-onepassword
   - target:
       kind: ConfigMap
       name: immich-values
@@ -74,7 +79,7 @@ patches:
                     DB_PASSWORD:
                       valueFrom:
                         secretKeyRef:
-                          name: immich-postgres-user
+                          name: immich-postgres-user-onepassword
                           key: password
           server:
             service:
@@ -100,7 +105,7 @@ patches:
             persistence:
               library:
                 existingClaim: immich-library
-            existingConfiguration: immich-secrets
+            existingConfiguration: immich-secrets-onepassword
             configurationKind: Secret
           valkey:
             enabled: true

--- a/kubernetes/apps/immich/branch/onepassword-items/configuration.yaml
+++ b/kubernetes/apps/immich/branch/onepassword-items/configuration.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: immich-secrets-onepassword
+  namespace: immich
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: immich-secrets
+type: Opaque
+spec:
+  itemPath: "vaults/dic43ai4wt5e7vezs454whfrpu/items/dltmzprhcpzd6dwsq5gn56mnt4"

--- a/kubernetes/apps/immich/branch/onepassword-items/postgres-user.yaml
+++ b/kubernetes/apps/immich/branch/onepassword-items/postgres-user.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: immich-postgres-user-onepassword
+  namespace: immich
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: immich-postgres-user
+type: kubernetes.io/basic-auth
+spec:
+  itemPath: "vaults/dic43ai4wt5e7vezs454whfrpu/items/gxsz67f6h2wkqzwcld6nvwug3i"

--- a/kubernetes/clusters/development/infra/cert-manager.yaml
+++ b/kubernetes/clusters/development/infra/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/infra/controllers/cert-manager
+  path: ./kubernetes/infra/controllers/cert-manager-development
   prune: true
   wait: true
   sourceRef:

--- a/kubernetes/clusters/development/infra/certs.yaml
+++ b/kubernetes/clusters/development/infra/certs.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 2m
   retryInterval: 2m
-  path: ./kubernetes/infra/network/certs
+  path: ./kubernetes/infra/network/certs-development
   prune: true
   wait: true
   sourceRef:

--- a/kubernetes/infra/controllers/cert-manager-development/kustomization.yaml
+++ b/kubernetes/infra/controllers/cert-manager-development/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../cert-manager
+  - onepassword-item.yaml

--- a/kubernetes/infra/controllers/cert-manager-development/onepassword-item.yaml
+++ b/kubernetes/infra/controllers/cert-manager-development/onepassword-item.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token-onepassword
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/managed-by: onepassword-operator
+    homelab.petebeegle.com/legacy-secret: cloudflare-api-token
+type: Opaque
+spec:
+  itemPath: "vaults/dic43ai4wt5e7vezs454whfrpu/items/ip2lbkjnqx6ukopzpzox2kuwum"

--- a/kubernetes/infra/network/certs-development/kustomization.yaml
+++ b/kubernetes/infra/network/certs-development/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../certs
+patches:
+  - target:
+      group: cert-manager.io
+      version: v1
+      kind: ClusterIssuer
+    patch: |-
+      - op: replace
+        path: /spec/acme/solvers/0/dns01/cloudflare/apiTokenSecretRef/name
+        value: cloudflare-api-token-onepassword

--- a/specs/onepassword-dev-cutover/checklists/requirements.md
+++ b/specs/onepassword-dev-cutover/checklists/requirements.md
@@ -1,0 +1,8 @@
+# Requirements Checklist: 1Password Development Cutover
+
+- [x] CHK001 Are cluster and vault isolation explicit? [Security]
+- [x] CHK002 Are all three schemas and consumer references bounded? [Completeness]
+- [x] CHK003 Are certificate and exact Immich API outcomes measurable? [Acceptance]
+- [x] CHK004 Is outage duration and continuity behavior measurable? [Recovery]
+- [x] CHK005 Are destructive item/token deletion paths excluded? [Safety]
+- [x] CHK006 Are cleanup and rollback requirements explicit? [Completeness]

--- a/specs/onepassword-dev-cutover/data-model.md
+++ b/specs/onepassword-dev-cutover/data-model.md
@@ -1,0 +1,6 @@
+# Data Model: onepassword-dev-cutover
+
+- Cert-manager item: Opaque, `token`, generated `cloudflare-api-token-onepassword`.
+- Immich configuration item: Opaque, `immich-config.yaml`, generated `immich-secrets-onepassword`.
+- Immich database item: `kubernetes.io/basic-auth`, `password` and `username`, generated `immich-postgres-user-onepassword`.
+- Outage evidence: Secret UID/resourceVersion/data digest held only in memory; workload UID/readiness; cleanup/recovery state.

--- a/specs/onepassword-dev-cutover/evidence.md
+++ b/specs/onepassword-dev-cutover/evidence.md
@@ -1,0 +1,21 @@
+# Evidence: onepassword-dev-cutover
+
+## Prior Gate
+
+- Phase 3 merge: `0986a461d21e02d4adc973729648bae98c1d56eb`.
+- Production `onepassword-items` Ready at exact revision.
+- 17 `OnePasswordItem` resources Ready=True.
+- Canonical no-output parity: 17/17 PASS.
+- The production gate is temporarily degraded by the account-wide rate-limit incident. PR #396 merged as `8d703908d785d7ab21c35321c1d531d5058261c1`; production now polls hourly and development uses explicit refresh. Live cutover remains blocked until the provider resets and production returns 17/17 Ready.
+
+## Discovery
+
+- Development base is Ready at phase-3 main revision and operator Deployment is 1/1.
+- Cert-manager currently reconciles the shared SOPS Secret; both ClusterIssuers reference `cloudflare-api-token`.
+- Immich branch currently includes both base SOPS Secrets and references their legacy names in Helm values and CloudNativePG bootstrap.
+- Required development items: cert-manager token, Immich configuration, and Immich basic-auth database user.
+- The original 300-second outage wait is obsolete after the user's manual-refresh decision. The validator will explicitly trigger one failed reconcile under deny-egress and one successful reconcile after cleanup.
+
+## Validation
+
+Pending.

--- a/specs/onepassword-dev-cutover/evidence.md
+++ b/specs/onepassword-dev-cutover/evidence.md
@@ -18,4 +18,62 @@
 
 ## Validation
 
-Pending.
+- T004 inventory/resolver: 3 exact development items, strict output-path allowlist, and ID-only renderer covered by unit tests.
+- T007 parity/certificate: dynamic namespace override, no-value parity comparison, and disposable staging Certificate cleanup covered by unit tests.
+- T008 outage retention: Cilium deny-egress isolation with only the `kube-apiserver` entity allowed, explicit operator restart/recovery, Secret byte-digest continuity, Pod identity/readiness, and guaranteed policy/consumer cleanup covered by unit tests.
+- `python3 -m unittest discover -s tools/onepassword/tests -p 'test_*.py'`: 13 passed.
+- `python3 -m unittest discover -s tools/development/tests -p 'test_verify_onepassword*.py'`: 12 passed.
+- `git diff --check`: passed.
+
+## Live Gate Check — 2026-08-14T21:02:31Z
+
+- Development and production Flux `onepassword-operator` Kustomizations are Ready at `main@sha1:8d703908d785d7ab21c35321c1d531d5058261c1`.
+- Both HelmReleases are Ready on chart `connect@2.4.1`; both operator Deployments are 1/1 on operator `1.12.0`.
+- Production remains 0/17 `OnePasswordItem` Ready. Current operator logs at 20:59–21:00 UTC explicitly report `1Password rate limit hit` and a 15-minute requeue for all 17 items.
+- A metadata-only development vault lookup at 21:05:06 UTC, using the development cluster's read-only service-account token via process environment, was also rejected with `Too many requests`; no item data was emitted.
+- No development item was created, rendered, applied, or used for cutover while this prerequisite was unhealthy.
+
+## Provider Recovery — 2026-08-15T02:21:21Z
+
+- Production recovered to 17/17 `OnePasswordItem` resources Ready=True.
+- A metadata-only lookup through the development read-only service account succeeded, confirming the provider quota recovered.
+- The lookup found 0/3 required development item titles, so ID rendering and live cutover remain gated on creating those three items in `cluster development`.
+
+## Development Items and Local Validation
+
+- Development read-only service-account validation: 3/3 exact item schemas passed.
+- Development renderer: 3 ID-only `OnePasswordItem` resources generated at the strict allowlisted paths.
+- Development cert-manager and certs paths are isolated overlays; production paths and consumers remain unchanged.
+- Immich branch Helm and CloudNativePG references use the generated Secret names; the SOPS base Secrets remain present for rollback.
+- OnePassword tooling tests: 13 passed.
+- Development 1Password verifier tests: 12 passed.
+- Codex harness: 81 passed.
+- Production, development, and Immich branch Kustomize renders: 134 resources total.
+- Kubeconform 0.7.0: 50 valid, 84 missing-schema skips, 0 invalid, 0 errors.
+- Direct-auth chart policy and production-foundation policy: passed.
+- Architecture generator write/check: passed.
+- Full pre-commit: passed.
+
+## Live Iteration
+
+- First branch-base reconciliation failed before applying the cert-manager overlay because Flux's Kustomize builder rejected a child overlay that referenced its parent as a cycle.
+- The verifier's guaranteed restoration returned `flux-system` to `main@sha1:9d2d762bc7d49605d00764494b800a6e31e52b67`; no development consumer changed during the failed attempt.
+- Both development overlays were moved to sibling directories (`cert-manager-development` and `certs-development`). Direct overlay renders, architecture regeneration, focused tests, and full pre-commit passed after the correction.
+- Immich branch reconciliation, Helm readiness, workload readiness, storage/service/route checks, and the exact `/api/server/ping` probe passed at the PR revision.
+- Development has no Authentik deployment. The migrated configuration preserves the rendered legacy development URLs for byte parity; OIDC is explicitly unavailable and was not claimed as an acceptance path for this phase.
+- No-output Secret comparison passed 3/3 after replacing Flux's `${cluster_domain}` placeholders with the rendered development domain in the 1Password item.
+- Disposable Let's Encrypt staging Certificate issuance passed and its temporary namespace was removed.
+- The first outage attempt showed that a blanket egress deny also prevents the operator from observing Kubernetes API events. Cleanup and recovery succeeded.
+- A follow-up IP allowlist proved insufficient because Cilium evaluates kube-apiserver traffic after Service translation. Operator logs recorded lost Kubernetes watch streams, so the final validator uses a temporary `CiliumNetworkPolicy` allowing only the native `kube-apiserver` entity and denying vault egress.
+- Because development polling is intentionally disabled and metadata-only annotations do not enqueue reconciliation, the validator restarts the stateless operator pod to force startup reconciliation under the outage. The pod became present but NotReady while the generated Secret stayed byte-identical and the consumer stayed ready with the same Pod UID.
+
+## Final Development Acceptance — 2026-08-15
+
+- Exact tested revision: `codex/onepassword-dev-cutover@sha1:12072c0c59fd13a388364291a6a31891263b4ae6`.
+- Cert-manager and certs reconciled from the branch revision; no-output parity passed 3/3.
+- Disposable Let's Encrypt staging Certificate became Ready and its namespace was removed.
+- During simulated vault outage, the operator was unavailable while the generated Secret and ready consumer were retained unchanged.
+- After egress restoration, the operator became Ready and the `OnePasswordItem` recovered; the temporary consumer and Cilium policy were removed.
+- The shared development Flux source and root Kustomization were restored to `main@sha1:9d2d762bc7d49605d00764494b800a6e31e52b67`.
+- The retained `branch-immich-onepassword-dev-cutover` Kustomization, GitRepository, and namespace were deleted normally. The older, unrelated `onepassword-dev-seed` branch environment was left untouched.
+- Development Immich OIDC remains untested and unavailable because development has no Authentik deployment; the exact API smoke, route, workloads, database, and storage checks passed.

--- a/specs/onepassword-dev-cutover/plan.md
+++ b/specs/onepassword-dev-cutover/plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: 1Password Development Cutover
+
+**Branch**: `codex/onepassword-dev-cutover` | **Date**: 2026-08-10
+
+## Technical Context
+
+**SDD Tier**: full/high-risk
+**Workflow Risk Tier**: high
+**Primary Areas**: development Flux, cert-manager, Immich branch overlay, 1Password, secret-safe smoke tooling
+**Smoke Strategy**: staging Certificate plus Immich profile with `--include-cluster-base`, followed by reversible deny-egress retention test
+**Fanout**: none
+**Exceptions**: Production is render/diff checked only; no production mutation.
+
+## Design
+
+1. Resolve three development item IDs from authenticated `op` metadata and render ID-only resources.
+2. Add a development cert-manager overlay containing its `OnePasswordItem`; add a development certs overlay that patches both ClusterIssuers to the generated Secret.
+3. Add two `OnePasswordItem` resources to the Immich branch overlay and patch every configuration/database reference to generated names.
+4. Extend no-output parity tooling to accept the three-item development inventory.
+5. Add automated disposable Certificate and outage-retention validators with guaranteed cleanup and explicit annotation-triggered refresh.
+6. Push the branch and run Immich smoke with sequential development-base reconciliation.
+
+## Constitution Check
+
+- [x] GitOps owns durable resources.
+- [x] Development precedes production.
+- [x] No plaintext Secret or token enters Git, state, arguments, or logs.
+- [x] Existing SOPS rollback remains.
+- [x] Production consumers and paths remain unchanged.
+- [x] Dedicated branch/worktree/PR is used.
+
+## Validation
+
+- Unit tests for inventory/rendering, reference completeness, redaction, outage cleanup, and continuity assertions.
+- Render/substitute both cluster roots and Immich branch overlay; kubeconform, policy, architecture, harness, pre-commit.
+- Live 3/3 Ready/parity, disposable certificate, Immich API smoke, and fail/recover explicit refreshes around the simulated outage.
+
+## Risks
+
+- A dynamic Immich namespace could retain a legacy reference; render-level reference enumeration and live smoke fail closed.
+- Deny-egress cleanup failure could leave refresh disabled; validator uses a finally cleanup and verifies operator recovery.
+- UI entry may alter multiline/trailing bytes; parity blocks cutover.

--- a/specs/onepassword-dev-cutover/quickstart.md
+++ b/specs/onepassword-dev-cutover/quickstart.md
@@ -1,0 +1,8 @@
+# Quickstart: onepassword-dev-cutover
+
+1. Create the three exact Secure Note items in `cluster development` from current development SOPS bytes.
+2. Resolve IDs and render ID-only resources.
+3. Push and reconcile the development base from the branch.
+4. Require 3/3 Ready/parity and issue a disposable staging certificate.
+5. Run the Immich branch profile with base reconciliation.
+6. Run the reversible outage-retention test with explicit fail/recover refresh triggers and verify cleanup.

--- a/specs/onepassword-dev-cutover/research.md
+++ b/specs/onepassword-dev-cutover/research.md
@@ -1,0 +1,7 @@
+# Research: onepassword-dev-cutover
+
+- Development overlays are required because cert-manager and certs shared paths are also used by production.
+- Immich item resources belong in the branch overlay so Kustomize applies the dynamic branch namespace.
+- A namespaced deny-egress NetworkPolicy is the reversible outage simulation; deleting an item or token is explicitly forbidden.
+- Operator 1.12.0 cannot disable `time.NewTicker` with zero. Development uses the merged one-year interval and resource annotation updates as explicit, item-scoped reconcile triggers.
+- Let's Encrypt staging is used for the disposable certificate to avoid production rate-limit impact.

--- a/specs/onepassword-dev-cutover/spec.md
+++ b/specs/onepassword-dev-cutover/spec.md
@@ -1,0 +1,59 @@
+# Feature Specification: 1Password Development Cutover
+
+**Feature Branch**: `codex/onepassword-dev-cutover`
+**Created**: 2026-08-10
+**Status**: Approved
+**Risk Tier**: high
+
+## Human Gate Status
+
+The user approved phase 4 in the original migration plan: switch development cert-manager and the Immich branch profile, prove disposable certificate issuance and Immich API smoke, and prove a simulated 1Password outage preserves generated Secrets and running workloads.
+
+Clarification found no unresolved choice. Production resources and consumers remain out of scope; development uses its isolated vault and service account.
+
+## User Story 1 - Development Certificate (P1)
+
+Development certificate issuance uses the 1Password-generated Cloudflare token Secret.
+
+**Acceptance**: A disposable staging Certificate reaches Ready and is cleaned up; the legacy SOPS Secret remains for rollback.
+
+## User Story 2 - Immich Branch (P1)
+
+The Immich branch profile consumes development-vault generated configuration and database Secrets.
+
+**Acceptance**: Branch smoke with development base reconciliation reaches the exact Immich `/api/server/ping` path and cleans up.
+
+## User Story 3 - Outage Retention (P1)
+
+An operator can prove a temporary 1Password connectivity outage does not delete existing generated Secrets or interrupt running consumers.
+
+**Acceptance**: A reversible deny-egress policy blocks an explicit item-scoped refresh; Secret identity/data and workload identity/readiness remain unchanged; cleanup plus a second explicit refresh restores operator reconciliation.
+
+## Requirements
+
+- **FR-001**: Git MUST contain only development vault/item IDs and exact non-secret schemas for three items.
+- **FR-002**: Development cert-manager/certs MUST reference `cloudflare-api-token-onepassword`; production MUST remain unchanged.
+- **FR-003**: The Immich branch overlay MUST reference `immich-secrets-onepassword` and `immich-postgres-user-onepassword` throughout.
+- **FR-004**: All three generated Secrets MUST be Ready and byte-identical to their legacy development source before consumer validation.
+- **FR-005**: SOPS resources/decryption MUST remain available for reference rollback.
+- **FR-006**: Certificate, Immich API, and outage-retention tests MUST suppress credential data and clean up temporary resources.
+- **FR-007**: Outage simulation MUST NOT delete the service-account token or any `OnePasswordItem`.
+
+## Success Criteria
+
+- **SC-001**: Three development items report Ready and 3/3 parity.
+- **SC-002**: Disposable staging certificate issuance passes.
+- **SC-003**: Immich branch API smoke passes with exact branch/base revision evidence.
+- **SC-004**: An explicit refresh fails during the simulated outage while the generated Secret and workload remain available, then succeeds after cleanup.
+- **SC-005**: Production render and Secret references are unchanged.
+
+## Assumptions
+
+- The user can create three exact Secure Note items in `cluster development`.
+- Current development SOPS bytes are the initial value authority.
+- The temporary outage policy is limited to the operator Deployment and removed in a guaranteed cleanup path.
+- Development periodic refresh is effectively disabled by the merged one-year interval; annotation updates explicitly request reconciliation.
+
+## Open Questions
+
+- None.

--- a/specs/onepassword-dev-cutover/tasks.md
+++ b/specs/onepassword-dev-cutover/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: onepassword-dev-cutover
+
+- [x] T001 Establish branch/worktree and record approved phase-4 scope.
+- [x] T002 Inventory exact development schemas, consumers, overlays, and live foundation state.
+- [x] T003 Complete spec, plan, requirements checklist, and risk analysis with no unresolved ambiguity.
+- [ ] T004 Add development inventory/resolver tests and implementation.
+- [ ] T005 Add development cert-manager/certs overlays and ID-only item resource.
+- [ ] T006 Add Immich branch ID-only resources and switch all branch references.
+- [ ] T007 Add no-output 3/3 parity and disposable certificate validation.
+- [ ] T008 Add reversible outage-retention validation with guaranteed cleanup.
+- [ ] T009 Create/validate the three development items and generate manifests.
+- [ ] T010 Run local validation and open the gated PR.
+- [ ] T011 Run development base/certificate/Immich/outage acceptance and converge evidence before production work.

--- a/specs/onepassword-dev-cutover/tasks.md
+++ b/specs/onepassword-dev-cutover/tasks.md
@@ -3,11 +3,11 @@
 - [x] T001 Establish branch/worktree and record approved phase-4 scope.
 - [x] T002 Inventory exact development schemas, consumers, overlays, and live foundation state.
 - [x] T003 Complete spec, plan, requirements checklist, and risk analysis with no unresolved ambiguity.
-- [ ] T004 Add development inventory/resolver tests and implementation.
-- [ ] T005 Add development cert-manager/certs overlays and ID-only item resource.
-- [ ] T006 Add Immich branch ID-only resources and switch all branch references.
-- [ ] T007 Add no-output 3/3 parity and disposable certificate validation.
-- [ ] T008 Add reversible outage-retention validation with guaranteed cleanup.
-- [ ] T009 Create/validate the three development items and generate manifests.
-- [ ] T010 Run local validation and open the gated PR.
-- [ ] T011 Run development base/certificate/Immich/outage acceptance and converge evidence before production work.
+- [x] T004 Add development inventory/resolver tests and implementation.
+- [x] T005 Add development cert-manager/certs overlays and ID-only item resource.
+- [x] T006 Add Immich branch ID-only resources and switch all branch references.
+- [x] T007 Add no-output 3/3 parity and disposable certificate validation.
+- [x] T008 Add reversible outage-retention validation with guaranteed cleanup.
+- [x] T009 Create/validate the three development items and generate manifests.
+- [x] T010 Run local validation and open the gated PR.
+- [x] T011 Run development base/certificate/Immich/outage acceptance and converge evidence before production work.

--- a/tools/development/smoke-profiles/immich.json
+++ b/tools/development/smoke-profiles/immich.json
@@ -14,8 +14,8 @@
       "immich"
     ],
     "secretRefs": [
-      "immich-secrets",
-      "immich-postgres-user"
+      "immich-secrets-onepassword",
+      "immich-postgres-user-onepassword"
     ],
     "pvcs": [
       {

--- a/tools/development/tests/test_verify_onepassword_certificate.py
+++ b/tools/development/tests/test_verify_onepassword_certificate.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools/development/verify_onepassword_certificate.py"
+
+
+@unittest.skipUnless(MODULE_PATH.exists(), "implementation module is not present yet")
+class OnePasswordCertificateVerifierTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location("verify_onepassword_certificate", MODULE_PATH)
+        assert spec and spec.loader
+        cls.module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cls.module
+        spec.loader.exec_module(cls.module)
+
+    def runner(self, *, fail_on: str | None = None):
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def run(args: list[str], **kwargs: object):
+            calls.append((list(args), dict(kwargs)))
+            if fail_on and fail_on in " ".join(args):
+                return SimpleNamespace(returncode=1, stdout="", stderr="secret-sentinel")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        return run, calls
+
+    def config(self):
+        return self.module.Config(
+            slug="example",
+            kubeconfig=Path("/tmp/dev.config"),
+            domain="dev.lab.petebeegle.com",
+            timeout_seconds=600,
+        )
+
+    def test_issues_staging_certificate_and_always_removes_namespace(self) -> None:
+        runner, calls = self.runner()
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.module.verify(self.config(), runner=runner)
+        commands = [" ".join(args) for args, _ in calls]
+        self.assertTrue(any("apply -f -" in command for command in commands))
+        self.assertTrue(any("wait certificate/onepassword-cutover" in command for command in commands))
+        self.assertTrue(any("delete namespace onepassword-certificate-example" in command for command in commands))
+        manifest = next(kwargs["input"] for args, kwargs in calls if "apply" in args)
+        self.assertIn("issuerRef:\n    kind: ClusterIssuer\n    name: cloudflare-staging", manifest)
+        self.assertIn("onepassword-example.dev.lab.petebeegle.com", manifest)
+        self.assertNotIn("secret-sentinel", output.getvalue())
+
+    def test_wait_failure_still_removes_namespace_without_displaying_output(self) -> None:
+        runner, calls = self.runner(fail_on="wait certificate")
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(self.module.VerificationError):
+            self.module.verify(self.config(), runner=runner)
+        self.assertTrue(any("delete namespace" in " ".join(args) for args, _ in calls))
+        self.assertNotIn("secret-sentinel", output.getvalue())
+
+    def test_rejects_unsafe_slug_before_mutation(self) -> None:
+        runner, calls = self.runner()
+        with self.assertRaises(self.module.VerificationError):
+            self.module.verify(
+                self.module.Config("BAD", Path("/tmp/dev.config"), "example.com", 60),
+                runner=runner,
+            )
+        self.assertEqual([], calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/development/tests/test_verify_onepassword_outage_retention.py
+++ b/tools/development/tests/test_verify_onepassword_outage_retention.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import base64
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools/development/verify_onepassword_outage_retention.py"
+SENTINEL = "outage-secret-sentinel"
+
+
+@unittest.skipUnless(MODULE_PATH.exists(), "implementation module is not present yet")
+class OnePasswordOutageRetentionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location("verify_onepassword_outage_retention", MODULE_PATH)
+        assert spec and spec.loader
+        cls.module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = cls.module
+        spec.loader.exec_module(cls.module)
+
+    def config(self):
+        return self.module.Config(
+            slug="example",
+            kubeconfig=Path("/tmp/dev.config"),
+            namespace="cert-manager",
+            item="cloudflare-api-token-onepassword",
+            secret="cloudflare-api-token-onepassword",
+            timeout_seconds=60,
+        )
+
+    def runner(self, *, mutate_secret: bool = False):
+        calls: list[tuple[list[str], dict[str, object]]] = []
+        item_states = iter([True, False, True])
+        operator_states = iter([False, True])
+        secret_calls = 0
+
+        def run(args: list[str], **kwargs: object):
+            nonlocal secret_calls
+            calls.append((list(args), dict(kwargs)))
+            command = " ".join(args)
+            if "get onepassworditem" in command:
+                ready = next(item_states)
+                body = {"status": {"conditions": [{"type": "Ready", "status": str(ready).lower().title()}]}}
+                return SimpleNamespace(returncode=0, stdout=json.dumps(body), stderr="")
+            if "get secret" in command:
+                secret_calls += 1
+                value = SENTINEL if not mutate_secret or secret_calls == 1 else "changed"
+                body = {
+                    "metadata": {"uid": "secret-uid", "resourceVersion": str(secret_calls)},
+                    "data": {"token": base64.b64encode(value.encode()).decode()},
+                }
+                return SimpleNamespace(returncode=0, stdout=json.dumps(body), stderr="")
+            if "-n onepassword-system get pod" in command:
+                ready = next(operator_states)
+                body = {
+                    "items": [{
+                        "metadata": {"uid": "operator-pod"},
+                        "status": {"conditions": [{"type": "Ready", "status": str(ready).lower().title()}]},
+                    }]
+                }
+                return SimpleNamespace(returncode=0, stdout=json.dumps(body), stderr="")
+            if "get pod" in command:
+                body = {
+                    "items": [{
+                        "metadata": {"uid": "pod-uid"},
+                        "status": {"conditions": [{"type": "Ready", "status": "True"}]},
+                    }]
+                }
+                return SimpleNamespace(returncode=0, stdout=json.dumps(body), stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        return run, calls
+
+    def test_proves_retention_and_recovers_without_printing_secret(self) -> None:
+        runner, calls = self.runner()
+        sleeps: list[float] = []
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.module.verify(
+                self.config(), runner=runner, sleep=sleeps.append, refresh_token=iter(["fail", "recover"]).__next__
+            )
+        commands = [" ".join(args) for args, _ in calls]
+        manifests = [kwargs.get("input", "") for args, kwargs in calls if "apply" in args]
+        self.assertTrue(any("kind: CiliumNetworkPolicy" in manifest for manifest in manifests))
+        self.assertTrue(any("name: onepassword-connect" in manifest for manifest in manifests))
+        self.assertTrue(any("- kube-apiserver" in manifest for manifest in manifests))
+        self.assertIn(self.module.NETWORK_POLICY_SETTLE_SECONDS, sleeps)
+        self.assertTrue(any("refresh-request=fail" in command for command in commands))
+        self.assertTrue(any("refresh-request=recover" in command for command in commands))
+        self.assertEqual(1, sum("delete pod" in command for command in commands))
+        self.assertTrue(any("delete ciliumnetworkpolicy onepassword-outage-example" in command for command in commands))
+        self.assertTrue(any("delete deployment onepassword-outage-example" in command for command in commands))
+        self.assertNotIn(SENTINEL, output.getvalue())
+        self.assertIn("operator unavailable while vault egress was blocked", output.getvalue())
+        self.assertIn("retained generated Secret and ready consumer", output.getvalue())
+        self.assertIn("OnePasswordItem recovered", output.getvalue())
+
+    def test_changed_secret_fails_but_still_removes_policy_and_consumer(self) -> None:
+        runner, calls = self.runner(mutate_secret=True)
+        with contextlib.redirect_stdout(io.StringIO()), self.assertRaisesRegex(
+            self.module.VerificationError, "changed during outage"
+        ):
+            self.module.verify(
+                self.config(), runner=runner, sleep=lambda _: None, refresh_token=iter(["fail", "recover"]).__next__
+            )
+        commands = [" ".join(args) for args, _ in calls]
+        self.assertTrue(any("delete ciliumnetworkpolicy" in command for command in commands))
+        self.assertTrue(any("delete deployment" in command for command in commands))
+
+    def test_rejects_unsafe_names_before_mutation(self) -> None:
+        runner, calls = self.runner()
+        with self.assertRaises(self.module.VerificationError):
+            self.module.verify(
+                self.module.Config("BAD", Path("/tmp/dev"), "cert-manager", "item", "secret", 60),
+                runner=runner,
+            )
+        self.assertEqual([], calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/development/verify_onepassword_certificate.py
+++ b/tools/development/verify_onepassword_certificate.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Issue and remove a disposable staging certificate without reading its Secret."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+DNS_LABEL = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$")
+DNS_NAME = re.compile(r"^[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?$")
+
+
+class VerificationError(RuntimeError):
+    """Raised when certificate acceptance cannot be proved."""
+
+
+class Runner(Protocol):
+    def __call__(self, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]: ...
+
+
+@dataclass(frozen=True)
+class Config:
+    slug: str
+    kubeconfig: Path
+    domain: str
+    timeout_seconds: int
+
+    @property
+    def namespace(self) -> str:
+        return f"onepassword-certificate-{self.slug}"
+
+    @property
+    def dns_name(self) -> str:
+        return f"onepassword-{self.slug}.{self.domain}"
+
+
+def _run(
+    runner: Runner,
+    args: list[str],
+    *,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = runner(
+            args,
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise VerificationError(f"unable to run required command: {args[0]}") from error
+    if result.returncode != 0:
+        raise VerificationError(
+            f"command failed without displaying captured output: {args[0]} {args[1]}"
+        )
+    return result
+
+
+def _kubectl(config: Config, *args: str) -> list[str]:
+    return ["kubectl", "--kubeconfig", str(config.kubeconfig), *args]
+
+
+def _manifest(config: Config) -> str:
+    return f"""---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {config.namespace}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: onepassword-cutover
+  namespace: {config.namespace}
+spec:
+  secretName: onepassword-cutover-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: cloudflare-staging
+  dnsNames:
+    - {config.dns_name}
+"""
+
+
+def verify(config: Config, *, runner: Runner = subprocess.run) -> None:
+    if not DNS_LABEL.fullmatch(config.slug):
+        raise VerificationError("slug must be a lowercase DNS label of at most 40 characters")
+    if not DNS_NAME.fullmatch(config.domain) or "." not in config.domain:
+        raise VerificationError("domain must be a lowercase DNS name")
+    if config.timeout_seconds <= 0:
+        raise VerificationError("timeout must be positive")
+
+    mutation_started = False
+    try:
+        mutation_started = True
+        _run(runner, _kubectl(config, "apply", "-f", "-"), input_text=_manifest(config))
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                config.namespace,
+                "wait",
+                "certificate/onepassword-cutover",
+                "--for=condition=Ready=True",
+                f"--timeout={config.timeout_seconds}s",
+            ),
+        )
+        print(f"Disposable staging Certificate Ready: {config.namespace}/onepassword-cutover")
+    finally:
+        if mutation_started:
+            _run(
+                runner,
+                _kubectl(
+                    config,
+                    "delete",
+                    "namespace",
+                    config.namespace,
+                    "--ignore-not-found=true",
+                    "--wait=true",
+                    f"--timeout={config.timeout_seconds}s",
+                ),
+            )
+            print(f"Disposable certificate namespace removed: {config.namespace}")
+
+
+def _duration(value: str) -> int:
+    match = re.fullmatch(r"([1-9][0-9]*)([smh]?)", value)
+    if not match:
+        raise argparse.ArgumentTypeError(
+            "timeout must be a positive integer with optional s, m, or h"
+        )
+    return int(match.group(1)) * {"": 1, "s": 1, "m": 60, "h": 3600}[match.group(2)]
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--kubeconfig", type=Path, required=True)
+    parser.add_argument("--domain", default="dev.lab.petebeegle.com")
+    parser.add_argument("--timeout", type=_duration, default=600, dest="timeout_seconds")
+    return Config(**vars(parser.parse_args()))
+
+
+def main() -> int:
+    try:
+        verify(_parse_args())
+    except VerificationError as error:
+        print(f"Disposable certificate verification failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/development/verify_onepassword_outage_retention.py
+++ b/tools/development/verify_onepassword_outage_retention.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Prove a 1Password outage retains an existing Secret and ready consumer."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Protocol
+
+
+DNS_LABEL = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
+NETWORK_POLICY_SETTLE_SECONDS = 5.0
+
+
+class VerificationError(RuntimeError):
+    """Raised when outage-retention acceptance cannot be proved."""
+
+
+class Runner(Protocol):
+    def __call__(self, args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]: ...
+
+
+@dataclass(frozen=True)
+class Config:
+    slug: str
+    kubeconfig: Path
+    namespace: str
+    item: str
+    secret: str
+    timeout_seconds: int
+
+    @property
+    def resource_name(self) -> str:
+        return f"onepassword-outage-{self.slug}"
+
+
+@dataclass(frozen=True)
+class SecretSnapshot:
+    uid: str
+    resource_version: str
+    data_digest: str
+
+
+def _run(
+    runner: Runner,
+    args: list[str],
+    *,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = runner(
+            args,
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        raise VerificationError(f"unable to run required command: {args[0]}") from error
+    if result.returncode != 0:
+        raise VerificationError(
+            f"command failed without displaying captured output: {args[0]} {args[1]}"
+        )
+    return result
+
+
+def _json(result: subprocess.CompletedProcess[str], description: str) -> dict[str, object]:
+    try:
+        value = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise VerificationError(f"{description} returned invalid JSON") from error
+    if not isinstance(value, dict):
+        raise VerificationError(f"{description} returned an unexpected JSON shape")
+    return value
+
+
+def _kubectl(config: Config, *args: str) -> list[str]:
+    return ["kubectl", "--kubeconfig", str(config.kubeconfig), *args]
+
+
+def _item_ready(item: dict[str, object]) -> bool:
+    status = item.get("status")
+    if not isinstance(status, dict):
+        return False
+    conditions = status.get("conditions")
+    return isinstance(conditions, list) and any(
+        isinstance(condition, dict)
+        and condition.get("type") == "Ready"
+        and condition.get("status") == "True"
+        for condition in conditions
+    )
+
+
+def _get_item(config: Config, runner: Runner) -> dict[str, object]:
+    return _json(
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                config.namespace,
+                "get",
+                "onepassworditem",
+                config.item,
+                "-o",
+                "json",
+            ),
+        ),
+        "OnePasswordItem",
+    )
+
+
+def _wait_item(
+    config: Config,
+    runner: Runner,
+    expected_ready: bool,
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+) -> None:
+    deadline = monotonic() + config.timeout_seconds
+    while monotonic() < deadline:
+        if _item_ready(_get_item(config, runner)) is expected_ready:
+            return
+        sleep(3)
+    state = "Ready=True" if expected_ready else "Ready=False"
+    raise VerificationError(f"timed out waiting for OnePasswordItem {state}")
+
+
+def _secret_snapshot(config: Config, runner: Runner) -> SecretSnapshot:
+    secret = _json(
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                config.namespace,
+                "get",
+                "secret",
+                config.secret,
+                "-o",
+                "json",
+            ),
+        ),
+        "Secret",
+    )
+    metadata = secret.get("metadata")
+    data = secret.get("data")
+    if not isinstance(metadata, dict) or not isinstance(data, dict) or not data:
+        raise VerificationError("Secret metadata or data is invalid")
+    uid = metadata.get("uid")
+    resource_version = metadata.get("resourceVersion")
+    if not isinstance(uid, str) or not uid or not isinstance(resource_version, str):
+        raise VerificationError("Secret identity metadata is invalid")
+    digest = hashlib.sha256()
+    for key in sorted(data):
+        value = data[key]
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise VerificationError("Secret data is invalid")
+        try:
+            decoded = base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise VerificationError("Secret data is invalid") from error
+        digest.update(len(key).to_bytes(4, "big"))
+        digest.update(key.encode())
+        digest.update(len(decoded).to_bytes(8, "big"))
+        digest.update(decoded)
+    return SecretSnapshot(uid, resource_version, digest.hexdigest())
+
+
+def _pod_uid(config: Config, runner: Runner) -> str:
+    pods = _json(
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                config.namespace,
+                "get",
+                "pod",
+                "-l",
+                f"app.kubernetes.io/name={config.resource_name}",
+                "-o",
+                "json",
+            ),
+        ),
+        "consumer Pod",
+    )
+    items = pods.get("items")
+    if not isinstance(items, list) or len(items) != 1 or not isinstance(items[0], dict):
+        raise VerificationError("expected exactly one outage consumer Pod")
+    pod = items[0]
+    metadata = pod.get("metadata")
+    status = pod.get("status")
+    conditions = status.get("conditions") if isinstance(status, dict) else None
+    uid = metadata.get("uid") if isinstance(metadata, dict) else None
+    ready = isinstance(conditions, list) and any(
+        isinstance(condition, dict)
+        and condition.get("type") == "Ready"
+        and condition.get("status") == "True"
+        for condition in conditions
+    )
+    if not isinstance(uid, str) or not uid or not ready:
+        raise VerificationError("outage consumer Pod is not Ready")
+    return uid
+
+
+def _consumer_manifest(config: Config) -> str:
+    return f"""---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {config.resource_name}
+  namespace: {config.namespace}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {config.resource_name}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {config.resource_name}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: hold
+          image: alpine:3.24
+          command: ["/bin/sh", "-c", "sleep 3600"]
+          volumeMounts:
+            - name: generated-secret
+              mountPath: /run/onepassword
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      volumes:
+        - name: generated-secret
+          secret:
+            secretName: {config.secret}
+"""
+
+
+def _policy_manifest(config: Config) -> str:
+    return f"""---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {config.resource_name}
+  namespace: onepassword-system
+spec:
+  endpointSelector:
+    matchLabels:
+      name: onepassword-connect
+  egress:
+    - toEntities:
+        - kube-apiserver
+"""
+
+
+def _annotate(config: Config, runner: Runner, token: str) -> None:
+    _run(
+        runner,
+        _kubectl(
+            config,
+            "-n",
+            config.namespace,
+            "annotate",
+            f"onepassworditem/{config.item}",
+            f"homelab.petebeegle.com/refresh-request={token}",
+            "--overwrite",
+        ),
+    )
+
+
+def _restart_operator(config: Config, runner: Runner) -> None:
+    _run(
+        runner,
+        _kubectl(
+            config,
+            "-n",
+            "onepassword-system",
+            "delete",
+            "pod",
+            "-l",
+            "name=onepassword-connect",
+            "--wait=true",
+            f"--timeout={config.timeout_seconds}s",
+        ),
+    )
+
+
+def _operator_ready(config: Config, runner: Runner) -> tuple[bool, bool]:
+    pods = _json(
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                "onepassword-system",
+                "get",
+                "pod",
+                "-l",
+                "name=onepassword-connect",
+                "-o",
+                "json",
+            ),
+        ),
+        "1Password operator Pods",
+    )
+    items = pods.get("items")
+    if not isinstance(items, list) or not items:
+        return False, False
+    ready = any(
+        isinstance(pod, dict)
+        and any(
+            isinstance(condition, dict)
+            and condition.get("type") == "Ready"
+            and condition.get("status") == "True"
+            for condition in (
+                pod.get("status", {}).get("conditions", [])
+                if isinstance(pod.get("status"), dict)
+                else []
+            )
+        )
+        for pod in items
+    )
+    return True, ready
+
+
+def _wait_operator(
+    config: Config,
+    runner: Runner,
+    expected_ready: bool,
+    sleep: Callable[[float], None],
+    monotonic: Callable[[], float],
+) -> None:
+    deadline = monotonic() + config.timeout_seconds
+    while monotonic() < deadline:
+        present, ready = _operator_ready(config, runner)
+        if present and ready is expected_ready:
+            return
+        sleep(3)
+    state = "Ready" if expected_ready else "present and NotReady"
+    raise VerificationError(f"timed out waiting for 1Password operator to be {state}")
+
+
+def verify(
+    config: Config,
+    *,
+    runner: Runner = subprocess.run,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+    refresh_token: Callable[[], str] = lambda: str(time.time_ns()),
+) -> None:
+    names = [config.slug, config.namespace, config.item, config.secret, config.resource_name]
+    if any(len(name) > 63 or not DNS_LABEL.fullmatch(name) for name in names):
+        raise VerificationError("slug and Kubernetes resource names must be safe DNS labels")
+    if config.timeout_seconds <= 0:
+        raise VerificationError("timeout must be positive")
+
+    consumer_started = False
+    policy_started = False
+    failure_triggered = False
+    try:
+        _wait_item(config, runner, True, sleep, monotonic)
+        consumer_started = True
+        _run(runner, _kubectl(config, "apply", "-f", "-"), input_text=_consumer_manifest(config))
+        _run(
+            runner,
+            _kubectl(
+                config,
+                "-n",
+                config.namespace,
+                "rollout",
+                "status",
+                f"deployment/{config.resource_name}",
+                f"--timeout={config.timeout_seconds}s",
+            ),
+        )
+        initial_secret = _secret_snapshot(config, runner)
+        initial_pod_uid = _pod_uid(config, runner)
+
+        policy_started = True
+        _run(
+            runner,
+            _kubectl(config, "apply", "-f", "-"),
+            input_text=_policy_manifest(config),
+        )
+        # Give Cilium time to program the selected operator endpoint before
+        # forcing a vault read.
+        sleep(NETWORK_POLICY_SETTLE_SECONDS)
+        failure_triggered = True
+        _annotate(config, runner, refresh_token())
+        _restart_operator(config, runner)
+        _wait_operator(config, runner, False, sleep, monotonic)
+        print("1Password operator unavailable while vault egress was blocked")
+
+        retained_secret = _secret_snapshot(config, runner)
+        retained_pod_uid = _pod_uid(config, runner)
+        if (
+            retained_secret.uid != initial_secret.uid
+            or retained_secret.data_digest != initial_secret.data_digest
+        ):
+            raise VerificationError("generated Secret changed during outage")
+        if retained_pod_uid != initial_pod_uid:
+            raise VerificationError("consumer Pod restarted during outage")
+        print("1Password outage retained generated Secret and ready consumer")
+    finally:
+        if policy_started:
+            _run(
+                runner,
+                _kubectl(
+                    config,
+                    "-n",
+                    "onepassword-system",
+                    "delete",
+                    "ciliumnetworkpolicy",
+                    config.resource_name,
+                    "--ignore-not-found=true",
+                ),
+            )
+        if failure_triggered:
+            _annotate(config, runner, refresh_token())
+            _wait_operator(config, runner, True, sleep, monotonic)
+            _wait_item(config, runner, True, sleep, monotonic)
+            print("OnePasswordItem recovered after operator egress restoration")
+        if consumer_started:
+            _run(
+                runner,
+                _kubectl(
+                    config,
+                    "-n",
+                    config.namespace,
+                    "delete",
+                    "deployment",
+                    config.resource_name,
+                    "--ignore-not-found=true",
+                    "--wait=true",
+                    f"--timeout={config.timeout_seconds}s",
+                ),
+            )
+            print(f"Outage consumer removed: {config.namespace}/{config.resource_name}")
+
+
+def _duration(value: str) -> int:
+    match = re.fullmatch(r"([1-9][0-9]*)([smh]?)", value)
+    if not match:
+        raise argparse.ArgumentTypeError(
+            "timeout must be a positive integer with optional s, m, or h"
+        )
+    return int(match.group(1)) * {"": 1, "s": 1, "m": 60, "h": 3600}[match.group(2)]
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--kubeconfig", type=Path, required=True)
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--item", required=True)
+    parser.add_argument("--secret", required=True)
+    parser.add_argument("--timeout", type=_duration, default=600, dest="timeout_seconds")
+    return Config(**vars(parser.parse_args()))
+
+
+def main() -> int:
+    try:
+        verify(_parse_args())
+    except VerificationError as error:
+        print(f"1Password outage-retention verification failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/onepassword/development_items.json
+++ b/tools/onepassword/development_items.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "expected_count": 3,
+  "vault": "cluster development",
+  "items": [
+    {
+      "namespace": "cert-manager",
+      "legacy_name": "cloudflare-api-token",
+      "generated_name": "cloudflare-api-token-onepassword",
+      "item_title": "k8s--cert-manager--cloudflare-api-token",
+      "type": "Opaque",
+      "keys": ["token"],
+      "output_path": "kubernetes/infra/controllers/cert-manager-development/onepassword-item.yaml"
+    },
+    {
+      "namespace": "immich",
+      "legacy_name": "immich-postgres-user",
+      "generated_name": "immich-postgres-user-onepassword",
+      "item_title": "k8s--immich--immich-postgres-user",
+      "type": "kubernetes.io/basic-auth",
+      "keys": ["password", "username"],
+      "output_path": "kubernetes/apps/immich/branch/onepassword-items/postgres-user.yaml"
+    },
+    {
+      "namespace": "immich",
+      "legacy_name": "immich-secrets",
+      "generated_name": "immich-secrets-onepassword",
+      "item_title": "k8s--immich--immich-secrets",
+      "type": "Opaque",
+      "keys": ["immich-config.yaml"],
+      "output_path": "kubernetes/apps/immich/branch/onepassword-items/configuration.yaml"
+    }
+  ]
+}

--- a/tools/onepassword/render_development_items.py
+++ b/tools/onepassword/render_development_items.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from render_production_items import load_inventory, render_item, resolve
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INVENTORY = SCRIPT_DIR / "development_items.json"
+EXPECTED_OUTPUTS = {
+    ("cert-manager", "cloudflare-api-token"): Path(
+        "kubernetes/infra/controllers/cert-manager-development/onepassword-item.yaml"
+    ),
+    ("immich", "immich-postgres-user"): Path(
+        "kubernetes/apps/immich/branch/onepassword-items/postgres-user.yaml"
+    ),
+    ("immich", "immich-secrets"): Path(
+        "kubernetes/apps/immich/branch/onepassword-items/configuration.yaml"
+    ),
+}
+
+
+def load_development_inventory(path: Path) -> dict[str, Any]:
+    inventory = load_inventory(path)
+    if inventory.get("expected_count") != 3:
+        raise ValueError("development inventory must declare expected_count 3")
+    observed: dict[tuple[str, str], Path] = {}
+    for item in inventory["items"]:
+        output = item.get("output_path")
+        if not isinstance(output, str):
+            raise ValueError("development item output path is invalid")
+        output_path = Path(output)
+        if output_path.is_absolute() or ".." in output_path.parts:
+            raise ValueError("development item output path is invalid")
+        observed[(item["namespace"], item["legacy_name"])] = output_path
+    if observed != EXPECTED_OUTPUTS:
+        raise ValueError("development item output paths do not match the allowlist")
+    return inventory
+
+
+def write_development_manifests(
+    root: Path,
+    vault_id: str,
+    resolved: list[tuple[dict[str, Any], str]],
+) -> None:
+    for item, item_id in resolved:
+        identity = (item["namespace"], item["legacy_name"])
+        output_path = Path(item.get("output_path", ""))
+        if EXPECTED_OUTPUTS.get(identity) != output_path:
+            raise ValueError("development item output path is not allowed")
+        destination = root / output_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(render_item(item, vault_id, item_id), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve development 1Password item IDs and render ID-only resources"
+    )
+    parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument("--vault", default="cluster development")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--check-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        inventory = load_development_inventory(args.inventory)
+        vault_id, resolved = resolve(inventory, args.vault)
+        if not args.check_only:
+            write_development_manifests(args.root, vault_id, resolved)
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"Development 1Password item resolution failed: {error}", file=sys.stderr)
+        return 1
+    action = "validated" if args.check_only else "rendered"
+    print(f"Development 1Password items {action}: {len(resolved)} ID-only resources")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/onepassword/render_production_items.py
+++ b/tools/onepassword/render_production_items.py
@@ -24,8 +24,13 @@ def load_inventory(path: Path) -> dict[str, Any]:
     items = inventory.get("items")
     if inventory.get("schema_version") != 1 or not isinstance(items, list):
         raise ValueError("inventory schema is invalid")
-    if len(items) != 17:
-        raise ValueError(f"inventory must contain 17 items, found {len(items)}")
+    expected_count = inventory.get("expected_count", 17)
+    if not isinstance(expected_count, int) or expected_count <= 0:
+        raise ValueError("inventory expected_count is invalid")
+    if len(items) != expected_count:
+        raise ValueError(
+            f"inventory must contain {expected_count} items, found {len(items)}"
+        )
 
     pairs: set[tuple[str, str]] = set()
     generated: set[tuple[str, str]] = set()

--- a/tools/onepassword/tests/test_render_development_items.py
+++ b/tools/onepassword/tests/test_render_development_items.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = REPO_ROOT / "tools/onepassword/render_development_items.py"
+INVENTORY_PATH = REPO_ROOT / "tools/onepassword/development_items.json"
+
+
+class RenderDevelopmentItemsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        spec = importlib.util.spec_from_file_location("render_development_items", MODULE_PATH)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load development resolver")
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    def test_inventory_has_three_exact_development_items(self) -> None:
+        inventory = self.module.load_development_inventory(INVENTORY_PATH)
+        identities = {
+            (item["namespace"], item["legacy_name"])
+            for item in inventory["items"]
+        }
+        self.assertEqual(
+            {
+                ("cert-manager", "cloudflare-api-token"),
+                ("immich", "immich-postgres-user"),
+                ("immich", "immich-secrets"),
+            },
+            identities,
+        )
+
+    def test_writer_places_only_id_resources_at_allowlisted_paths(self) -> None:
+        inventory = self.module.load_development_inventory(INVENTORY_PATH)
+        resolved = [(item, chr(ord("b") + index) * 26) for index, item in enumerate(inventory["items"])]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.module.write_development_manifests(root, "a" * 26, resolved)
+            rendered = [
+                (root / item["output_path"]).read_text(encoding="utf-8")
+                for item in inventory["items"]
+            ]
+        self.assertEqual(3, len(rendered))
+        self.assertTrue(all("vaults/" + "a" * 26 + "/items/" in text for text in rendered))
+        self.assertTrue(all("item_title" not in text for text in rendered))
+
+    def test_writer_rejects_path_outside_allowlisted_overlays(self) -> None:
+        item = {
+            "namespace": "immich",
+            "legacy_name": "immich-secrets",
+            "generated_name": "immich-secrets-onepassword",
+            "item_title": "k8s--immich--immich-secrets",
+            "type": "Opaque",
+            "keys": ["immich-config.yaml"],
+            "output_path": "kubernetes/clusters/production/unsafe.yaml",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir, self.assertRaisesRegex(
+            ValueError, "output path"
+        ):
+            self.module.write_development_manifests(
+                Path(temp_dir), "a" * 26, [(item, "b" * 26)]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/onepassword/tests/test_validate_secret_parity.py
+++ b/tools/onepassword/tests/test_validate_secret_parity.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -61,6 +62,44 @@ class ValidateSecretParityTest(unittest.TestCase):
             )
         self.assertNotIn("legacy-key", str(raised.exception))
         self.assertNotIn("generated-key", str(raised.exception))
+
+    def test_namespace_overrides_are_strict_and_repeatable(self) -> None:
+        self.assertEqual(
+            {"immich": "immich-feature", "cert-manager": "cert-manager"},
+            self.module.parse_namespace_overrides(
+                ["immich=immich-feature", "cert-manager=cert-manager"]
+            ),
+        )
+        for invalid in ["immich", "=target", "source=", "UPPER=target"]:
+            with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                self.module.parse_namespace_overrides([invalid])
+
+    def test_live_validation_uses_target_namespace_without_printing_values(self) -> None:
+        inventory = {
+            "items": [
+                {
+                    "namespace": "immich",
+                    "legacy_name": "legacy",
+                    "generated_name": "generated",
+                    "keys": ["password"],
+                    "type": "Opaque",
+                }
+            ]
+        }
+        secret = self.secret({"password": b"secret-sentinel"})
+        ready = {"status": {"conditions": [{"type": "Ready", "status": "True"}]}}
+        output = io.StringIO()
+        with mock.patch.object(
+            self.module, "run_json", side_effect=[ready, secret, secret]
+        ) as run_json, contextlib.redirect_stdout(output):
+            self.module.validate_live(
+                Path("/tmp/dev.config"), inventory, {"immich": "immich-feature"}
+            )
+        self.assertTrue(
+            all("immich-feature" in call.args[0] for call in run_json.call_args_list)
+        )
+        self.assertNotIn("secret-sentinel", output.getvalue())
+        self.assertIn("Secret parity passed: 1/1", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/tools/onepassword/validate_secret_parity.py
+++ b/tools/onepassword/validate_secret_parity.py
@@ -6,6 +6,7 @@ import base64
 import binascii
 import hmac
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,9 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from render_production_items import DEFAULT_INVENTORY, load_inventory
+
+
+NAMESPACE_PATTERN = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
 
 
 def decode_data(secret: dict[str, Any]) -> dict[str, bytes]:
@@ -76,18 +80,40 @@ def is_ready(item: dict[str, Any]) -> bool:
     )
 
 
-def validate_live(kubeconfig: Path, inventory: dict[str, Any]) -> None:
+def parse_namespace_overrides(values: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for value in values:
+        if value.count("=") != 1:
+            raise ValueError("namespace override must be SOURCE=TARGET")
+        source, target = value.split("=", 1)
+        if (
+            not NAMESPACE_PATTERN.fullmatch(source)
+            or not NAMESPACE_PATTERN.fullmatch(target)
+            or source in overrides
+        ):
+            raise ValueError("namespace override is invalid or duplicated")
+        overrides[source] = target
+    return overrides
+
+
+def validate_live(
+    kubeconfig: Path,
+    inventory: dict[str, Any],
+    namespace_overrides: dict[str, str] | None = None,
+) -> None:
+    namespace_overrides = namespace_overrides or {}
     passed = 0
     for item in inventory["items"]:
-        base = ["kubectl", "--kubeconfig", str(kubeconfig), "-n", item["namespace"], "get"]
+        namespace = namespace_overrides.get(item["namespace"], item["namespace"])
+        base = ["kubectl", "--kubeconfig", str(kubeconfig), "-n", namespace, "get"]
         opi = run_json(base + ["onepassworditem", item["generated_name"], "-o", "json"])
         if not is_ready(opi):
-            raise ValueError(f"OnePasswordItem is not Ready for {item['namespace']}/{item['generated_name']}")
+            raise ValueError(f"OnePasswordItem is not Ready for {namespace}/{item['generated_name']}")
         legacy = run_json(base + ["secret", item["legacy_name"], "-o", "json"])
         generated = run_json(base + ["secret", item["generated_name"], "-o", "json"])
         compare_pair(legacy, generated, set(item["keys"]), item["type"])
         passed += 1
-        print(f"PASS {item['namespace']}/{item['legacy_name']} -> {item['generated_name']}")
+        print(f"PASS {namespace}/{item['legacy_name']} -> {item['generated_name']}")
     print(f"Secret parity passed: {passed}/{len(inventory['items'])}")
 
 
@@ -95,6 +121,13 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Compare legacy and 1Password-generated Kubernetes Secrets without displaying data")
     parser.add_argument("--kubeconfig", type=Path, required=True)
     parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument(
+        "--namespace-override",
+        action="append",
+        default=[],
+        metavar="SOURCE=TARGET",
+        help="Map an inventory namespace to its live namespace; repeat as needed",
+    )
     return parser.parse_args()
 
 
@@ -102,7 +135,8 @@ def main() -> int:
     args = parse_args()
     try:
         inventory = load_inventory(args.inventory)
-        validate_live(args.kubeconfig, inventory)
+        overrides = parse_namespace_overrides(args.namespace_override)
+        validate_live(args.kubeconfig, inventory, overrides)
     except (OSError, ValueError, RuntimeError) as error:
         print(f"Secret parity failed: {error}", file=sys.stderr)
         return 1


### PR DESCRIPTION
## Summary

- add three ID-only development `OnePasswordItem` resources
- isolate development cert-manager and certificate overlays from production
- switch the Immich branch profile to generated 1Password Secrets
- add no-output parity, disposable certificate, and reversible Cilium outage-retention validators

## Why

This is phase 4 of the SOPS-to-1Password migration. It proves development consumers can use generated Secrets while retaining the existing SOPS resources for per-reference rollback. Production consumers are unchanged.

## Validation

- development vault metadata validation: 3/3 exact item schemas
- ID-only safety scan: 3/3 resources
- no-output live Secret parity: 3/3
- disposable Let's Encrypt staging Certificate: Ready, then cleaned up
- Immich branch exact `/api/server/ping`, workload, database, storage, service, and route checks: passed
- simulated vault outage: operator became unavailable while the generated Secret and consumer remained unchanged; operator/item recovery passed
- OnePassword tooling tests: 13 passed
- development verifier tests: 12 passed
- Codex harness: 81 passed
- production, development, and Immich branch Kustomize renders: passed
- kubeconform 0.7.0: 134 resources, 0 invalid, 0 errors
- direct-auth chart and production-foundation policies: passed
- generated architecture check and full pre-commit: passed
- post-test cleanup: Flux restored to `main`; temporary certificate, outage, and Immich branch resources removed
- production foundation remained healthy: 17/17 `OnePasswordItem` resources Ready

## Development limitation

Development does not deploy Authentik. The migrated Immich configuration preserves the existing rendered OIDC URLs for byte parity, but OIDC login is unavailable and is not claimed as a development acceptance path. Production OIDC validation remains part of the later production cutover phase.
