### PR TITLE
fix: preserve Grafana dashboard datasource variables

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/onepassword-rate-limit-fix"}
+{"feature_directory":"specs/fix-alert-reconciliation"}

--- a/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
+++ b/kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json
@@ -13,7 +13,7 @@
       {
         "datasource": {
           "type": "loki",
-          "uid": "${DS_LOKI}"
+          "uid": "$${DS_LOKI}"
         },
         "enable": false,
         "expr": "{namespace=\"flux-system\"} |~ \"error|Error|ERROR\"",
@@ -49,7 +49,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resources that are currently suspended and will NOT reconcile automatically",
       "fieldConfig": {
@@ -100,7 +100,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",suspended=\"true\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
@@ -112,7 +112,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resources currently failing reconciliation",
       "fieldConfig": {
@@ -163,7 +163,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
@@ -175,7 +175,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resources whose p95 reconcile duration over 30 minutes exceeds 60 seconds, using gotk_reconcile_duration_seconds buckets.",
       "fieldConfig": {
@@ -230,7 +230,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(histogram_quantile(0.95, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[30m])) by (le, exported_namespace, name, kind)) > 60) OR vector(0)",
           "refId": "A"
@@ -242,7 +242,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resources waiting on dependencies (Unknown state)",
       "fieldConfig": {
@@ -293,7 +293,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "refId": "A"
@@ -305,7 +305,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Reconciliation rate (reconciliations per second, last 5 minutes)",
       "fieldConfig": {
@@ -360,7 +360,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "sum(rate(gotk_reconcile_duration_seconds_count{job=\"prometheus.scrape.pods\"}[5m])) OR on() vector(0)",
           "refId": "A"
@@ -372,7 +372,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Total managed Flux resources",
       "fieldConfig": {
@@ -419,7 +419,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"Kustomization|HelmRelease\",job=\"prometheus.scrape.service\"})",
           "refId": "A"
@@ -444,7 +444,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resource health status over time (ready vs failing resources)",
       "fieldConfig": {
@@ -569,7 +569,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"True\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Ready",
@@ -578,7 +578,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"False\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Failing",
@@ -587,7 +587,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count(gotk_resource_info{exported_namespace=~\"$namespace\",ready=\"Unknown\",job=\"prometheus.scrape.service\"}) OR vector(0)",
           "legendFormat": "Unknown",
@@ -600,7 +600,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Reconciliation duration percentiles",
       "fieldConfig": {
@@ -680,7 +680,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.50, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[5m])) by (le)) OR on() vector(0)",
           "legendFormat": "p50",
@@ -689,7 +689,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.90, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[5m])) by (le)) OR on() vector(0)",
           "legendFormat": "p90",
@@ -698,7 +698,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.95, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[5m])) by (le)) OR on() vector(0)",
           "legendFormat": "p95",
@@ -707,7 +707,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.99, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.pods\"}[5m])) by (le)) OR on() vector(0)",
           "legendFormat": "p99",
@@ -733,7 +733,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Detailed list of all resources with their current status",
       "fieldConfig": {
@@ -903,7 +903,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "gotk_resource_info{exported_namespace=~\"$namespace\", customresource_kind=~\"$resource_type\"}",
           "format": "table",
@@ -955,7 +955,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resource count by type",
       "fieldConfig": {
@@ -1012,7 +1012,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count by (customresource_kind) (gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.service\"})",
           "format": "time_series",
@@ -1026,7 +1026,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Resource count by namespace",
       "fieldConfig": {
@@ -1104,7 +1104,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "count by (exported_namespace) (gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.service\"})",
           "legendFormat": "{{exported_namespace}}",
@@ -1117,7 +1117,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "$${DS_PROMETHEUS}"
       },
       "description": "Reconciliation duration by resource",
       "fieldConfig": {
@@ -1196,7 +1196,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "$${DS_PROMETHEUS}"
           },
           "expr": "histogram_quantile(0.95, sum(rate(gotk_reconcile_duration_seconds_bucket{exported_namespace=~\"$namespace\",name=~\"$resource_name\",job=\"prometheus.scrape.pods\"}[5m])) by (le, name, exported_namespace)) OR on() vector(0)",
           "legendFormat": "{{exported_namespace}}/{{name}}",
@@ -1222,7 +1222,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "$${DS_LOKI}"
       },
       "description": "Recent logs from Flux controllers (errors highlighted)",
       "gridPos": {
@@ -1247,7 +1247,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "$${DS_LOKI}"
           },
           "expr": "{namespace=\"flux-system\", app=~\"source-controller|kustomize-controller|helm-controller|notification-controller\"} |~ \"$log_filter\"",
           "refId": "A"
@@ -1311,7 +1311,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$${DS_PROMETHEUS}"
         },
         "definition": "label_values(gotk_resource_info{job=\"prometheus.scrape.service\"}, exported_namespace)",
         "hide": 0,
@@ -1339,7 +1339,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$${DS_PROMETHEUS}"
         },
         "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",job=\"prometheus.scrape.service\"}, customresource_kind)",
         "hide": 0,
@@ -1367,7 +1367,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "$${DS_PROMETHEUS}"
         },
         "definition": "label_values(gotk_resource_info{exported_namespace=~\"$namespace\",customresource_kind=~\"$resource_type\",job=\"prometheus.scrape.service\"}, name)",
         "hide": 0,

--- a/specs/fix-alert-reconciliation/checklists/requirements.md
+++ b/specs/fix-alert-reconciliation/checklists/requirements.md
@@ -1,0 +1,6 @@
+# Requirements Checklist
+
+- [x] Live root cause is recorded.
+- [x] Scope avoids alert suppression and secret changes.
+- [x] Runtime dashboard value is preserved.
+- [x] Production verification is required.

--- a/specs/fix-alert-reconciliation/evidence.md
+++ b/specs/fix-alert-reconciliation/evidence.md
@@ -1,0 +1,16 @@
+# Evidence: Fix Alert Reconciliation
+
+## Live Diagnosis
+
+- Production Grafana Kustomization failed strict post-build substitution because `ConfigMap/flux-dashboard` contains the Grafana runtime placeholder `${DS_LOKI}`.
+- The failure made `onepassword-items` and several dashboard/app Kustomizations report dependency failures, which fired Flux alerts.
+- Production 1Password synchronization is healthy: 17/17 `OnePasswordItem` resources are `Ready=True` and the live operator polling interval is `3600` seconds.
+- Private Arr source has a separate unescaped runtime shell variable failure; remediation is pull request 43 in `petebeegle/homelab-private`.
+
+## Validation
+
+- `jq empty kubernetes/infra/monitoring/grafana/dashboards/flux-dashboard.json`: PASS.
+- `kubectl kustomize kubernetes/infra/monitoring/grafana` followed by strict Flux substitution with the production `cluster_domain`: PASS; rendered dashboard retains 3 `${DS_LOKI}` and 26 `${DS_PROMETHEUS}` runtime placeholders.
+- `python3 tools/architecture/render.py --check`: PASS.
+- `git diff --check`: PASS.
+- The configured `check-json` pre-commit hook is unavailable; `yamllint` and `k8svalidate` correctly skipped the JSON file.

--- a/specs/fix-alert-reconciliation/plan.md
+++ b/specs/fix-alert-reconciliation/plan.md
@@ -1,0 +1,26 @@
+# Implementation Plan: Fix Alert Reconciliation
+
+**Branch**: `codex/fix-alert-reconciliation` | **Risk Tier**: high
+
+## Technical Context
+
+**Primary Areas**: Flux post-build substitution, Grafana dashboard JSON.
+
+**Smoke Strategy**: strict local production render, then post-merge production Flux and alert-state verification.
+
+**Exceptions**: Development does not operate this production Grafana instance; production verification is required after merge.
+
+## Constitution Check
+
+- [x] Desired state is changed only in Git.
+- [x] No Secret value or live configuration is edited.
+- [x] Alert semantics remain unchanged.
+- [x] The separate private-source failure is isolated in PR 43.
+
+## Steps
+
+1. Escape only the three Grafana dashboard datasource placeholders.
+2. Render the Grafana Kustomization with production substitutions and strict envsubst.
+3. Run JSON/YAML and generated-architecture checks.
+4. Commit, push, and open a PR.
+5. After merge, verify Flux, private-source dependencies, and active alert state.

--- a/specs/fix-alert-reconciliation/spec.md
+++ b/specs/fix-alert-reconciliation/spec.md
@@ -1,0 +1,46 @@
+# Feature Specification: Fix Alert Reconciliation
+
+**Feature Branch**: `codex/fix-alert-reconciliation`
+**Created**: 2026-08-22
+**Status**: Approved for incident correction
+**Risk Tier**: high
+
+## Human Gate Status
+
+**Intent Brief**: Stop recurring Grafana alerts caused by failed Flux reconciliation without silencing real alerts or changing credentials.
+
+**Clarify Status**: Skipped; live Flux status identifies the exact missing substitution value.
+
+**Spec Gate**: Approved by the user's direct request to resolve continuing alerts.
+
+## Summary
+
+Prevent Flux from interpreting the Grafana dashboard's runtime datasource placeholder as a cluster substitution. The existing Grafana datasource reference must reach Grafana unchanged.
+
+## Scope
+
+### In Scope
+
+- Escape the Grafana dashboard runtime datasource placeholder from Flux substitution.
+- Verify the rendered dashboard retains the runtime placeholder and production Grafana reconciliation can recover.
+
+### Out Of Scope
+
+- Changing alert rules, notification policy, datasource configuration, secrets, or capacity thresholds.
+- The separate private repository Arr fix, tracked by `homelab-private` pull request 43.
+
+## Requirements
+
+- **FR-001**: Flux strict post-build substitution MUST not require a `DS_LOKI` cluster variable.
+- **FR-002**: The dashboard MUST retain its Grafana runtime `DS_LOKI` datasource reference after rendering.
+- **FR-003**: No alert expression, routing policy, Secret, or consumer reference may change.
+
+## Success Criteria
+
+- **SC-001**: Strict production rendering succeeds without a `DS_LOKI` substitution value.
+- **SC-002**: Production `Kustomization/flux-system/grafana` reaches `Ready=True` after the merged revision is applied.
+- **SC-003**: The Flux failing and readiness-unknown alerts resolve after the dependent Kustomizations recover.
+
+## Assumptions
+
+- `$${DS_LOKI}` is Flux's literal-dollar escape and renders as Grafana's `${DS_LOKI}` placeholder.

--- a/specs/fix-alert-reconciliation/tasks.md
+++ b/specs/fix-alert-reconciliation/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Fix Alert Reconciliation
+
+- [x] T001 Capture live Flux build failure and confirm `DS_LOKI` is a dashboard runtime variable.
+- [x] T002 Escape the three dashboard placeholders.
+- [x] T003 Run focused rendering and repository validation.
+- [ ] T004 Commit, push, and open a pull request.
+- [ ] T005 Verify the merged revision is fetched and applied by Flux.
+- [ ] T006 Verify the Flux alerts resolve; record any remaining genuine alerts.


### PR DESCRIPTION
Fixes the production Grafana Flux Kustomization failure caused by strict post-build substitution interpreting Grafana's runtime `DS_LOKI` and `DS_PROMETHEUS` placeholders as missing cluster variables.

Validation: JSON parse; production Grafana kustomization render plus strict Flux substitution; generated architecture check; pre-commit.

Related private-source Arr runtime-variable fix: petebeegle/homelab-private#43.